### PR TITLE
feat(ui): Add 'day' as option for temperature graph range

### DIFF
--- a/webapp/frontend/src/app/modules/dashboard/dashboard.component.html
+++ b/webapp/frontend/src/app/modules/dashboard/dashboard.component.html
@@ -96,6 +96,7 @@
                                     <button (click)="changeSummaryTempDuration('year')" mat-menu-item>year</button>
                                     <button (click)="changeSummaryTempDuration('month')" mat-menu-item>month</button>
                                     <button (click)="changeSummaryTempDuration('week')" mat-menu-item>week</button>
+                                    <button (click)="changeSummaryTempDuration('day')" mat-menu-item>day</button>
                                 </mat-menu>
                             </div>
                         </div>

--- a/webapp/frontend/src/app/modules/dashboard/dashboard.component.ts
+++ b/webapp/frontend/src/app/modules/dashboard/dashboard.component.ts
@@ -269,11 +269,11 @@ export class DashboardComponent implements OnInit, AfterViewInit, OnDestroy
     }
 
     /*
-
+    DURATION_KEY_DAY    = "day"
     DURATION_KEY_WEEK    = "week"
-	DURATION_KEY_MONTH   = "month"
-	DURATION_KEY_YEAR    = "year"
-	DURATION_KEY_FOREVER = "forever"
+    DURATION_KEY_MONTH   = "month"
+    DURATION_KEY_YEAR    = "year"
+    DURATION_KEY_FOREVER = "forever"
      */
 
     changeSummaryTempDuration(durationKey: string): void {


### PR DESCRIPTION
## Summary

Adds "day" as a range option in the temperature graph for more granular viewing.

## Origin

Cherry-picked from upstream PR: https://github.com/AnalogJ/scrutiny/pull/823
Original author: @CircuitCoder

## Changes

- Adds daily view option to temperature history graph