### PR TITLE
fix(collector): keep existing device type

### DIFF
--- a/collector/pkg/detect/detect.go
+++ b/collector/pkg/detect/detect.go
@@ -84,7 +84,6 @@ func (d *Detect) SmartCtlInfo(device *models.Device) error {
 	device.RotationSpeed = availableDeviceInfo.RotationRate
 	device.Capacity = availableDeviceInfo.Capacity()
 	device.FormFactor = availableDeviceInfo.FormFactor.Name
-	device.DeviceType = availableDeviceInfo.Device.Type
 	device.DeviceProtocol = availableDeviceInfo.Device.Protocol
 	if len(availableDeviceInfo.Vendor) > 0 {
 		device.Manufacturer = availableDeviceInfo.Vendor


### PR DESCRIPTION
## Summary

Prevents device type from being overwritten during SMART info collection. This preserves user-configured device types for drives that require specific type settings (e.g., USB bridges, RAID controllers).

## Origin

- **Upstream PR:** https://github.com/AnalogJ/scrutiny/pull/803
- **Original author:** @thomashilzendegen

## Changes

- Removes the line that overwrites `device.DeviceType` in `SmartCtlInfo()`
- Preserves user-configured device types from `collector.yaml`

## Test Plan

- [ ] Verify drives with custom device types retain their configuration after collector runs
- [ ] Verify normal drives still work correctly