### PR TITLE
fix(notify): try to unmarshal notify.urls as JSON array

### DIFF
--- a/webapp/backend/pkg/notify/notify.go
+++ b/webapp/backend/pkg/notify/notify.go
@@ -234,6 +234,13 @@ func (n *Notify) Send() error {
 
 	//retrieve list of notification endpoints from config file
 	configUrls := n.Config.GetStringSlice("notify.urls")
+	configString := n.Config.GetString("notify.urls")
+	var jsonConfig []string
+	err := json.Unmarshal([]byte(configString), &jsonConfig)
+	if err == nil {
+		configUrls = jsonConfig
+	}
+
 	n.Logger.Debugf("Configured notification services: %v", configUrls)
 
 	if len(configUrls) == 0 {


### PR DESCRIPTION
## Summary

When `notify.urls` is configured as a JSON array in the config file, Viper's `GetStringSlice` may not parse it correctly. This fix attempts to unmarshal the raw string as JSON first, falling back to the original behavior if that fails.

## Origin

- **Upstream PR:** https://github.com/AnalogJ/scrutiny/pull/750
- **Original author:** @remi-espie

## Changes

- Adds JSON unmarshal attempt for `notify.urls` configuration
- Falls back to original `GetStringSlice` if JSON parsing fails
- Enables users to configure notification URLs as JSON arrays

## Test Plan

- [ ] Verify notifications work with YAML list format
- [ ] Verify notifications work with JSON array format
- [ ] Verify notifications work with single URL string