### PR TITLE
fix(thresholds): add observed threshold for attribute 188 with value 0

### DIFF
--- a/webapp/backend/pkg/thresholds/ata_attribute_metadata.go
+++ b/webapp/backend/pkg/thresholds/ata_attribute_metadata.go
@@ -693,6 +693,12 @@ var AtaMetadata = map[int]AtaAttributeMetadata{
 		},
 		ObservedThresholds: []ObservedThreshold{
 			{
+				Low:               0,
+				High:              0,
+				AnnualFailureRate: 0.024893587674442153,
+				ErrorInterval:     []float64{0.020857343769186413, 0.0294830350167543},
+			},
+			{
 				Low: 0,
 				// This is set arbitrarily to avoid notifications caused by low
 				// historical numbers of command timeouts (e.g. caused by a bad cable)


### PR DESCRIPTION
## Summary

Adds an observed threshold entry for ATA attribute 188 (Command_Timeout) when the value is exactly 0. This fixes incorrect failure rate calculations for drives with zero command timeouts, particularly affecting Seagate drives.

## Origin

- **Upstream PR:** https://github.com/AnalogJ/scrutiny/pull/551
- **Original author:** @aivus

## Changes

- Adds threshold entry for attribute 188 with Low=0, High=0
- Includes observed annual failure rate data for this threshold range

## Related Issues

- Partially addresses #29 (Seagate Command Timeout showing incorrect values)

## Test Plan

- [ ] Verify attribute 188 displays correctly when value is 0
- [ ] Verify Seagate drives with 0 command timeouts show correct status