### PR TITLE
feat: enhance Seagate drive timeout handling in SMART attribute metadata

### DIFF
--- a/webapp/backend/pkg/thresholds/ata_attribute_metadata.go
+++ b/webapp/backend/pkg/thresholds/ata_attribute_metadata.go
@@ -689,6 +689,18 @@ var AtaMetadata = map[int]AtaAttributeMetadata{
 					return int64(int_pieces[2])
 				}
 			}
+			// Seagate drives use a packed 48-bit format with three 16-bit fields:
+			// Bytes [1-0]: Total command timeout count
+			// Bytes [3-2]: Commands with >5s completion time
+			// Bytes [5-4]: Commands with >7.5s completion time
+			// Reference: https://superuser.com/questions/1747844/interpreting-seagate-smart-value-188-command-timeout-data-format
+			// Reference 2: https://t1.daumcdn.net/brunch/service/user/axm/file/zRYOdwPu3OMoKYmBOby1fEEQEbU.pdf
+			if rawValue > 0xFFFF {
+				// Extract total timeout count from lower 16 bits (bytes 0-1)
+				// This represents all command timeouts regardless of duration
+				total_timeouts := rawValue & 0xFFFF
+				return total_timeouts
+			}
 			return rawValue
 		},
 		ObservedThresholds: []ObservedThreshold{


### PR DESCRIPTION
## Summary

Fixes misinterpretation of Seagate SMART Attribute 188 (Command Timeout) raw values. Seagate drives use a packed 48-bit format containing three separate 16-bit timeout counters, but Scrutiny was treating this as a single large integer, resulting in incorrect display values (e.g., showing 25770197007 instead of 1).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues
[fix: Seagate Command Timeout showing incorrect values](https://github.com/Starosdev/scrutiny/issues/29)

## Changes Made

- Added packed 48-bit value detection for Attribute 188 (checks if `rawValue > 0xFFFF`)
- Implemented bitwise extraction to decode Seagate's three-field format:
  - Bytes [1-0]: Total command timeout count
  - Bytes [3-2]: Commands with >5s completion time
  - Bytes [5-4]: Commands with >7.5s completion time
- Returns the total timeout count (lower 16 bits) to capture all timeouts regardless of duration
- Added inline documentation with references to Seagate SMART specification

## Testing

- [x] I have tested this locally
  - Tested on Seagate drives showing the packed format issue
  - Verified correct extraction of timeout count from raw values
  - Confirmed web UI now displays correct values (e.g., 1 instead of 25770197007)
- [ ] I have added/updated tests that prove my fix/feature works
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary (particularly complex areas)
- [x] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [x] No console.log, debug statements, or commented-out code

## Screenshots (if applicable)

**Before:** Attribute 188 showing `25770197007` (incorrect packed value)
<img width="1063" height="241" alt="image" src="https://github.com/user-attachments/assets/5fd7dbe0-9703-48d3-b748-2113bb5fd5a6" />


**After:** Attribute 188 showing `1` (correct total timeout count)
<img width="1128" height="385" alt="Screenshot 2026-01-03 at 5 36 35 AM" src="https://github.com/user-attachments/assets/f90a0574-ab0e-41f0-a786-152f20fd06fc" />

## Additional Notes

This fix only affects Seagate drives that report packed 48-bit values (detected when `rawValue > 0xFFFF`). Other drives using string format or simple integer values remain unaffected by existing fallback logic.

The implementation prioritizes returning the **total timeout count** rather than only the most severe (>7.5s) timeouts, ensuring any command timeout is properly surfaced for health monitoring.

**References:**
- https://superuser.com/questions/1747844/interpreting-seagate-smart-value-188-command-timeout-data-format
- https://t1.daumcdn.net/brunch/service/user/axm/file/zRYOdwPu3OMoKYmBOby1fEEQEbU.pdf (Seagate SMART Attribute Specification, Section 3.11)