### PR TITLE
feat(zfs): add ZFS pool monitoring support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -123,3 +123,4 @@ jobs:
           path: |
             scrutiny-web-*
             scrutiny-collector-metrics-*
+            scrutiny-collector-zfs-*

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -99,6 +99,7 @@ jobs:
           path: |
             scrutiny-web-*
             scrutiny-collector-metrics-*
+            scrutiny-collector-zfs-*
 
   upload-assets:
     name: Upload Release Assets

--- a/collector/cmd/collector-zfs/collector-zfs.go
+++ b/collector/cmd/collector-zfs/collector-zfs.go
@@ -1,0 +1,224 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"strings"
+	"time"
+
+	utils "github.com/analogj/go-util/utils"
+	"github.com/analogj/scrutiny/collector/pkg/config"
+	"github.com/analogj/scrutiny/collector/pkg/errors"
+	"github.com/analogj/scrutiny/collector/pkg/zfs"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/version"
+	"github.com/fatih/color"
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli/v2"
+)
+
+var goos string
+var goarch string
+
+func main() {
+	config, err := config.Create()
+	if err != nil {
+		fmt.Printf("FATAL: %+v\n", err)
+		os.Exit(1)
+	}
+
+	// Use separate config file for ZFS collector
+	configFilePath := "/opt/scrutiny/config/collector-zfs.yaml"
+	configFilePathAlternative := "/opt/scrutiny/config/collector-zfs.yml"
+	// Fall back to main collector config if ZFS-specific config doesn't exist
+	configFilePathFallback := "/opt/scrutiny/config/collector.yaml"
+	configFilePathFallbackAlt := "/opt/scrutiny/config/collector.yml"
+
+	if !utils.FileExists(configFilePath) && utils.FileExists(configFilePathAlternative) {
+		configFilePath = configFilePathAlternative
+	} else if !utils.FileExists(configFilePath) && !utils.FileExists(configFilePathAlternative) {
+		if utils.FileExists(configFilePathFallback) {
+			configFilePath = configFilePathFallback
+		} else if utils.FileExists(configFilePathFallbackAlt) {
+			configFilePath = configFilePathFallbackAlt
+		}
+	}
+
+	// Create a bootstrap logger for config loading
+	bootstrapLogger := logrus.WithFields(logrus.Fields{"type": "zfs"})
+	bootstrapLogger.Logger.SetLevel(logrus.InfoLevel)
+
+	// Load the config file
+	err = config.ReadConfig(configFilePath, bootstrapLogger)
+	if _, ok := err.(errors.ConfigFileMissingError); ok {
+		// Ignore "could not find config file"
+	} else if err != nil {
+		os.Exit(1)
+	}
+
+	cli.CommandHelpTemplate = `NAME:
+   {{.HelpName}} - {{.Usage}}
+USAGE:
+   {{if .UsageText}}{{.UsageText}}{{else}}{{.HelpName}} {{if .ArgsUsage}}{{.ArgsUsage}}{{else}}[arguments...]{{end}}{{end}}{{if .Category}}
+CATEGORY:
+   {{.Category}}{{end}}{{if .Description}}
+DESCRIPTION:
+   {{.Description}}{{end}}{{if .VisibleFlags}}
+OPTIONS:
+   {{range .VisibleFlags}}{{.}}
+   {{end}}{{end}}
+`
+
+	app := &cli.App{
+		Name:     "scrutiny-collector-zfs",
+		Usage:    "ZFS pool data collector for scrutiny",
+		Version:  version.VERSION,
+		Compiled: time.Now(),
+		Authors: []*cli.Author{
+			{
+				Name:  "Scrutiny Contributors",
+				Email: "https://github.com/Starosdev/scrutiny",
+			},
+		},
+		Before: func(c *cli.Context) error {
+			collectorZfs := "Starosdev/scrutiny/zfs"
+
+			var versionInfo string
+			if len(goos) > 0 && len(goarch) > 0 {
+				versionInfo = fmt.Sprintf("%s.%s-%s", goos, goarch, version.VERSION)
+			} else {
+				versionInfo = fmt.Sprintf("dev-%s", version.VERSION)
+			}
+
+			subtitle := collectorZfs + utils.LeftPad2Len(versionInfo, " ", 65-len(collectorZfs))
+
+			color.New(color.FgGreen).Fprintf(c.App.Writer, fmt.Sprintf(utils.StripIndent(
+				`
+			 ___   ___  ____  __  __  ____  ____  _  _  _  _
+			/ __) / __)(  _ \(  )(  )(_  _)(_  _)( \( )( \/ )
+			\__ \( (__  )   / )(__)(   )(   _)(_  )  (  \  /
+			(___/ \___)(_)\_)(______) (__) (____)(_)\_) (__)
+			%s
+
+			`), subtitle))
+
+			return nil
+		},
+
+		Commands: []*cli.Command{
+			{
+				Name:  "run",
+				Usage: "Run the scrutiny ZFS pool collector",
+				Action: func(c *cli.Context) error {
+					if c.IsSet("config") {
+						err = config.ReadConfig(c.String("config"), bootstrapLogger)
+						if err != nil {
+							fmt.Printf("Could not find config file at specified path: %s", c.String("config"))
+							return err
+						}
+					}
+
+					// Override config with flags if set
+					if c.IsSet("host-id") {
+						config.Set("host.id", c.String("host-id"))
+					}
+
+					if c.Bool("debug") {
+						config.Set("log.level", "DEBUG")
+					}
+
+					if c.IsSet("log-file") {
+						config.Set("log.file", c.String("log-file"))
+					}
+
+					if c.IsSet("api-endpoint") {
+						apiEndpoint := strings.TrimSuffix(c.String("api-endpoint"), "/") + "/"
+						config.Set("api.endpoint", apiEndpoint)
+					}
+
+					collectorLogger, logFile, err := CreateLogger(config)
+					if logFile != nil {
+						defer logFile.Close()
+					}
+					if err != nil {
+						return err
+					}
+
+					settingsData, err := json.MarshalIndent(config.AllSettings(), "", "\t")
+					collectorLogger.Debug(string(settingsData), err)
+
+					zfsCollector, err := zfs.CreateCollector(
+						config,
+						collectorLogger,
+						config.GetString("api.endpoint"),
+					)
+					if err != nil {
+						return err
+					}
+
+					return zfsCollector.Run()
+				},
+
+				Flags: []cli.Flag{
+					&cli.StringFlag{
+						Name:  "config",
+						Usage: "Specify the path to the config file",
+					},
+					&cli.StringFlag{
+						Name:    "api-endpoint",
+						Usage:   "The api server endpoint",
+						EnvVars: []string{"COLLECTOR_ZFS_API_ENDPOINT", "COLLECTOR_API_ENDPOINT"},
+					},
+					&cli.StringFlag{
+						Name:    "log-file",
+						Usage:   "Path to file for logging. Leave empty to use STDOUT",
+						EnvVars: []string{"COLLECTOR_ZFS_LOG_FILE", "COLLECTOR_LOG_FILE"},
+					},
+					&cli.BoolFlag{
+						Name:    "debug",
+						Usage:   "Enable debug logging",
+						EnvVars: []string{"COLLECTOR_ZFS_DEBUG", "COLLECTOR_DEBUG", "DEBUG"},
+					},
+					&cli.StringFlag{
+						Name:    "host-id",
+						Usage:   "Host identifier/label, used for grouping pools",
+						Value:   "",
+						EnvVars: []string{"COLLECTOR_ZFS_HOST_ID", "COLLECTOR_HOST_ID"},
+					},
+				},
+			},
+		},
+	}
+
+	err = app.Run(os.Args)
+	if err != nil {
+		log.Fatal(color.HiRedString("ERROR: %v", err))
+	}
+}
+
+// CreateLogger creates a logger for the ZFS collector
+func CreateLogger(appConfig config.Interface) (*logrus.Entry, *os.File, error) {
+	logger := logrus.WithFields(logrus.Fields{
+		"type": "zfs",
+	})
+
+	if level, err := logrus.ParseLevel(appConfig.GetString("log.level")); err == nil {
+		logger.Logger.SetLevel(level)
+	} else {
+		logger.Logger.SetLevel(logrus.InfoLevel)
+	}
+
+	var logFile *os.File
+	var err error
+	if appConfig.IsSet("log.file") && len(appConfig.GetString("log.file")) > 0 {
+		logFile, err = os.OpenFile(appConfig.GetString("log.file"), os.O_CREATE|os.O_WRONLY, 0644)
+		if err != nil {
+			logger.Logger.Errorf("Failed to open log file %s for output: %s", appConfig.GetString("log.file"), err)
+			return nil, logFile, err
+		}
+		logger.Logger.SetOutput(io.MultiWriter(os.Stderr, logFile))
+	}
+	return logger, logFile, nil
+}

--- a/collector/pkg/zfs/collector.go
+++ b/collector/pkg/zfs/collector.go
@@ -1,0 +1,162 @@
+package zfs
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/analogj/scrutiny/collector/pkg/config"
+	"github.com/analogj/scrutiny/collector/pkg/errors"
+	"github.com/analogj/scrutiny/collector/pkg/zfs/detect"
+	"github.com/analogj/scrutiny/collector/pkg/zfs/models"
+	"github.com/samber/lo"
+	"github.com/sirupsen/logrus"
+)
+
+// Collector handles ZFS pool collection
+type Collector struct {
+	config      config.Interface
+	logger      *logrus.Entry
+	apiEndpoint *url.URL
+	httpClient  *http.Client
+}
+
+// CreateCollector creates a new ZFS collector
+func CreateCollector(appConfig config.Interface, logger *logrus.Entry, apiEndpoint string) (*Collector, error) {
+	apiEndpointUrl, err := url.Parse(apiEndpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	timeout := 60
+	if appConfig != nil && appConfig.IsSet("api.timeout") {
+		timeout = appConfig.GetAPITimeout()
+	}
+
+	collector := &Collector{
+		config:      appConfig,
+		logger:      logger,
+		apiEndpoint: apiEndpointUrl,
+		httpClient: &http.Client{
+			Timeout: time.Duration(timeout) * time.Second,
+		},
+	}
+
+	return collector, nil
+}
+
+// Run executes the ZFS collection
+func (c *Collector) Run() error {
+	c.logger.Infoln("Starting ZFS pool collection")
+
+	// Detect pools
+	detector := detect.Detect{
+		Logger: c.logger,
+		Config: c.config,
+	}
+
+	pools, err := detector.Start()
+	if err != nil {
+		return err
+	}
+
+	if len(pools) == 0 {
+		c.logger.Infoln("No ZFS pools found")
+		return nil
+	}
+
+	c.logger.Infof("Found %d ZFS pool(s)", len(pools))
+
+	// Filter pools with empty GUID
+	validPools := lo.Filter[models.ZFSPool](pools, func(pool models.ZFSPool, _ int) bool {
+		return len(pool.GUID) > 0
+	})
+
+	// Register pools with API
+	poolWrapper, err := c.RegisterPools(validPools)
+	if err != nil {
+		return err
+	}
+
+	if !poolWrapper.Success {
+		c.logger.Errorln("An error occurred while registering pools")
+		return errors.ApiServerCommunicationError("An error occurred while registering pools")
+	}
+
+	// Upload metrics for each registered pool
+	for _, pool := range poolWrapper.Data {
+		if err := c.UploadMetrics(pool); err != nil {
+			c.logger.Errorf("Failed to upload metrics for pool %s: %v", pool.Name, err)
+			// Continue with other pools
+		}
+	}
+
+	c.logger.Infoln("ZFS collection completed")
+	return nil
+}
+
+// RegisterPools registers detected pools with the API
+func (c *Collector) RegisterPools(pools []models.ZFSPool) (*models.ZFSPoolWrapper, error) {
+	c.logger.Infoln("Sending detected pools to API for registration")
+
+	apiEndpoint, _ := url.Parse(c.apiEndpoint.String())
+	apiEndpoint, _ = apiEndpoint.Parse("api/zfs/pools/register")
+
+	wrapper := models.ZFSPoolWrapper{
+		Data: pools,
+	}
+
+	jsonData, err := json.Marshal(wrapper)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal pools: %w", err)
+	}
+
+	c.logger.Debugf("Registering pools: %s", string(jsonData))
+
+	resp, err := c.httpClient.Post(apiEndpoint.String(), "application/json", bytes.NewBuffer(jsonData))
+	if err != nil {
+		c.logger.Errorf("Failed to register pools: %v", err)
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var responseWrapper models.ZFSPoolWrapper
+	if err := json.NewDecoder(resp.Body).Decode(&responseWrapper); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return &responseWrapper, nil
+}
+
+// UploadMetrics uploads metrics for a specific pool
+func (c *Collector) UploadMetrics(pool models.ZFSPool) error {
+	c.logger.Infof("Uploading metrics for pool %s (%s)", pool.Name, pool.GUID)
+
+	apiEndpoint, _ := url.Parse(c.apiEndpoint.String())
+	apiEndpoint, _ = apiEndpoint.Parse(fmt.Sprintf("api/zfs/pool/%s/metrics", strings.ToLower(pool.GUID)))
+
+	jsonData, err := json.Marshal(pool)
+	if err != nil {
+		return fmt.Errorf("failed to marshal pool metrics: %w", err)
+	}
+
+	c.logger.Debugf("Uploading pool metrics: %s", string(jsonData))
+
+	resp, err := c.httpClient.Post(apiEndpoint.String(), "application/json", bytes.NewBuffer(jsonData))
+	if err != nil {
+		c.logger.Errorf("Failed to upload metrics for pool %s: %v", pool.Name, err)
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("API returned status %d", resp.StatusCode)
+	}
+
+	c.logger.Infof("Successfully uploaded metrics for pool %s", pool.Name)
+	return nil
+}

--- a/collector/pkg/zfs/detect/detect.go
+++ b/collector/pkg/zfs/detect/detect.go
@@ -1,0 +1,357 @@
+package detect
+
+import (
+	"bufio"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/analogj/scrutiny/collector/pkg/config"
+	"github.com/analogj/scrutiny/collector/pkg/zfs/models"
+	"github.com/sirupsen/logrus"
+)
+
+// Detect handles ZFS pool detection
+type Detect struct {
+	Logger *logrus.Entry
+	Config config.Interface
+}
+
+// Start detects all ZFS pools on the system
+func (d *Detect) Start() ([]models.ZFSPool, error) {
+	// Check if zpool command exists
+	zpoolPath, err := exec.LookPath("zpool")
+	if err != nil {
+		d.Logger.Warnf("zpool command not found: %v", err)
+		return nil, fmt.Errorf("zpool command not found: %w", err)
+	}
+	d.Logger.Debugf("Found zpool at: %s", zpoolPath)
+
+	// List all pools with basic properties
+	pools, err := d.listPools()
+	if err != nil {
+		return nil, err
+	}
+
+	// Get detailed status for each pool (vdevs, scrub, errors)
+	for i := range pools {
+		if err := d.getPoolStatus(&pools[i]); err != nil {
+			d.Logger.Warnf("Failed to get status for pool %s: %v", pools[i].Name, err)
+		}
+	}
+
+	return pools, nil
+}
+
+// listPools lists all ZFS pools with their properties
+func (d *Detect) listPools() ([]models.ZFSPool, error) {
+	// zpool list -H -p -o name,guid,size,alloc,free,frag,cap,health,ashift
+	cmd := exec.Command("zpool", "list", "-H", "-p", "-o",
+		"name,guid,size,alloc,free,frag,cap,health,ashift")
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list pools: %w", err)
+	}
+
+	var pools []models.ZFSPool
+	scanner := bufio.NewScanner(strings.NewReader(string(output)))
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			continue
+		}
+
+		fields := strings.Split(line, "\t")
+		if len(fields) < 9 {
+			d.Logger.Warnf("Unexpected zpool list output: %s", line)
+			continue
+		}
+
+		size, _ := strconv.ParseInt(fields[2], 10, 64)
+		alloc, _ := strconv.ParseInt(fields[3], 10, 64)
+		free, _ := strconv.ParseInt(fields[4], 10, 64)
+		frag, _ := strconv.Atoi(fields[5])
+		cap, _ := strconv.Atoi(fields[6])
+		ashift, _ := strconv.Atoi(fields[8])
+
+		pool := models.ZFSPool{
+			Name:            fields[0],
+			GUID:            fields[1],
+			Size:            size,
+			Allocated:       alloc,
+			Free:            free,
+			Fragmentation:   frag,
+			CapacityPercent: float64(cap),
+			Health:          fields[7],
+			Status:          models.ZFSPoolStatus(fields[7]),
+			Ashift:          ashift,
+			ScrubState:      models.ZFSScrubStateNone,
+		}
+
+		// Set HostID if configured
+		if d.Config != nil && d.Config.IsSet("host.id") {
+			pool.HostID = d.Config.GetString("host.id")
+		}
+
+		pools = append(pools, pool)
+	}
+
+	return pools, nil
+}
+
+// getPoolStatus gets detailed status for a pool including vdevs and scrub
+func (d *Detect) getPoolStatus(pool *models.ZFSPool) error {
+	// zpool status -p <poolname>
+	cmd := exec.Command("zpool", "status", "-p", pool.Name)
+	output, err := cmd.Output()
+	if err != nil {
+		return fmt.Errorf("failed to get pool status: %w", err)
+	}
+
+	statusStr := string(output)
+
+	// Parse vdev tree
+	pool.Vdevs = d.parseVdevTree(statusStr, pool.Name)
+
+	// Calculate total errors from vdevs
+	d.calculateTotalErrors(pool)
+
+	// Parse scrub status
+	d.parseScrubStatus(pool, statusStr)
+
+	return nil
+}
+
+// parseVdevTree parses the vdev configuration from zpool status output
+func (d *Detect) parseVdevTree(output string, poolName string) []models.ZFSVdev {
+	var vdevs []models.ZFSVdev
+	var currentParent *models.ZFSVdev
+	var inConfig bool
+	var baseIndent int
+
+	// Pattern to match vdev lines with status and errors
+	// Example: "  mirror-0  ONLINE       0     0     0"
+	vdevPattern := regexp.MustCompile(`^(\s*)(\S+)\s+(ONLINE|DEGRADED|FAULTED|OFFLINE|REMOVED|UNAVAIL|AVAIL|INUSE)\s+(\d+)\s+(\d+)\s+(\d+)`)
+
+	scanner := bufio.NewScanner(strings.NewReader(output))
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		// Look for config section
+		if strings.Contains(line, "config:") {
+			inConfig = true
+			continue
+		}
+
+		// Skip header lines
+		if strings.Contains(line, "NAME") && strings.Contains(line, "STATE") {
+			continue
+		}
+
+		// End of config section
+		if inConfig && (strings.Contains(line, "errors:") || strings.Contains(line, "scan:")) {
+			break
+		}
+
+		if !inConfig {
+			continue
+		}
+
+		matches := vdevPattern.FindStringSubmatch(line)
+		if matches == nil {
+			continue
+		}
+
+		indent := len(matches[1])
+		name := matches[2]
+		status := matches[3]
+		readErr, _ := strconv.ParseInt(matches[4], 10, 64)
+		writeErr, _ := strconv.ParseInt(matches[5], 10, 64)
+		ckErr, _ := strconv.ParseInt(matches[6], 10, 64)
+
+		// Skip the pool name line itself
+		if name == poolName {
+			baseIndent = indent
+			continue
+		}
+
+		vdev := models.ZFSVdev{
+			Name:           name,
+			Status:         models.ZFSPoolStatus(status),
+			ReadErrors:     readErr,
+			WriteErrors:    writeErr,
+			ChecksumErrors: ckErr,
+			Type:           d.detectVdevType(name),
+		}
+
+		// Detect if this is a device path
+		if strings.HasPrefix(name, "/dev/") || strings.Contains(name, "sd") ||
+			strings.Contains(name, "nvme") || strings.Contains(name, "ada") ||
+			strings.Contains(name, "da") || strings.Contains(name, "disk") {
+			vdev.Type = models.ZFSVdevTypeDisk
+			vdev.Path = d.resolveDevicePath(name)
+		}
+
+		// Determine hierarchy based on indentation
+		if indent == baseIndent+2 {
+			// Top-level vdev (mirror, raidz, disk directly under pool)
+			vdevs = append(vdevs, vdev)
+			currentParent = &vdevs[len(vdevs)-1]
+		} else if indent > baseIndent+2 && currentParent != nil {
+			// Child of current parent
+			currentParent.Children = append(currentParent.Children, vdev)
+		}
+	}
+
+	return vdevs
+}
+
+// detectVdevType determines the vdev type from its name
+func (d *Detect) detectVdevType(name string) models.ZFSVdevType {
+	nameLower := strings.ToLower(name)
+
+	switch {
+	case strings.HasPrefix(nameLower, "mirror"):
+		return models.ZFSVdevTypeMirror
+	case strings.HasPrefix(nameLower, "raidz3"):
+		return models.ZFSVdevTypeRaidz3
+	case strings.HasPrefix(nameLower, "raidz2"):
+		return models.ZFSVdevTypeRaidz2
+	case strings.HasPrefix(nameLower, "raidz1"), strings.HasPrefix(nameLower, "raidz"):
+		return models.ZFSVdevTypeRaidz1
+	case strings.HasPrefix(nameLower, "draid3"):
+		return models.ZFSVdevTypeDraid3
+	case strings.HasPrefix(nameLower, "draid2"):
+		return models.ZFSVdevTypeDraid2
+	case strings.HasPrefix(nameLower, "draid1"), strings.HasPrefix(nameLower, "draid"):
+		return models.ZFSVdevTypeDraid1
+	case nameLower == "spare" || nameLower == "spares":
+		return models.ZFSVdevTypeSpare
+	case nameLower == "log" || nameLower == "logs":
+		return models.ZFSVdevTypeLog
+	case nameLower == "cache":
+		return models.ZFSVdevTypeCache
+	case nameLower == "special":
+		return models.ZFSVdevTypeSpecial
+	case nameLower == "dedup":
+		return models.ZFSVdevTypeDedup
+	default:
+		return models.ZFSVdevTypeDisk
+	}
+}
+
+// resolveDevicePath resolves a device name to its full path
+func (d *Detect) resolveDevicePath(name string) string {
+	if strings.HasPrefix(name, "/dev/") {
+		return name
+	}
+	// Common Linux device names
+	if strings.HasPrefix(name, "sd") || strings.HasPrefix(name, "nvme") ||
+		strings.HasPrefix(name, "hd") || strings.HasPrefix(name, "vd") {
+		return "/dev/" + name
+	}
+	// FreeBSD device names
+	if strings.HasPrefix(name, "ada") || strings.HasPrefix(name, "da") ||
+		strings.HasPrefix(name, "nda") {
+		return "/dev/" + name
+	}
+	return name
+}
+
+// calculateTotalErrors calculates total errors from all vdevs
+func (d *Detect) calculateTotalErrors(pool *models.ZFSPool) {
+	pool.TotalReadErrors = 0
+	pool.TotalWriteErrors = 0
+	pool.TotalChecksumErrors = 0
+
+	var addErrors func(vdevs []models.ZFSVdev)
+	addErrors = func(vdevs []models.ZFSVdev) {
+		for _, vdev := range vdevs {
+			pool.TotalReadErrors += vdev.ReadErrors
+			pool.TotalWriteErrors += vdev.WriteErrors
+			pool.TotalChecksumErrors += vdev.ChecksumErrors
+			if len(vdev.Children) > 0 {
+				addErrors(vdev.Children)
+			}
+		}
+	}
+
+	addErrors(pool.Vdevs)
+}
+
+// parseScrubStatus parses scrub information from zpool status output
+func (d *Detect) parseScrubStatus(pool *models.ZFSPool, output string) {
+	// Look for scan: line
+	// Examples:
+	// scan: scrub repaired 0B in 00:10:30 with 0 errors on Sun Jan  5 00:34:31 2026
+	// scan: scrub in progress since Sun Jan  5 00:24:01 2026
+	// scan: scrub canceled on Sun Jan  5 00:30:00 2026
+	// scan: none requested
+
+	scrubInProgress := regexp.MustCompile(`scan:\s+scrub in progress since (.+)`)
+	scrubFinished := regexp.MustCompile(`scan:\s+scrub repaired \S+ in (\S+) with (\d+) errors on (.+)`)
+	scrubCanceled := regexp.MustCompile(`scan:\s+scrub canceled on (.+)`)
+	scrubProgress := regexp.MustCompile(`(\d+(?:\.\d+)?)\s*%\s+done`)
+
+	scanner := bufio.NewScanner(strings.NewReader(output))
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		if matches := scrubInProgress.FindStringSubmatch(line); matches != nil {
+			pool.ScrubState = models.ZFSScrubStateScanning
+			if t, err := d.parseZFSDate(matches[1]); err == nil {
+				pool.ScrubStartTime = &t
+			}
+			continue
+		}
+
+		if matches := scrubFinished.FindStringSubmatch(line); matches != nil {
+			pool.ScrubState = models.ZFSScrubStateFinished
+			pool.ScrubErrorsCount, _ = strconv.ParseInt(matches[2], 10, 64)
+			if t, err := d.parseZFSDate(matches[3]); err == nil {
+				pool.ScrubEndTime = &t
+			}
+			pool.ScrubPercentComplete = 100.0
+			continue
+		}
+
+		if matches := scrubCanceled.FindStringSubmatch(line); matches != nil {
+			pool.ScrubState = models.ZFSScrubStateCanceled
+			if t, err := d.parseZFSDate(matches[1]); err == nil {
+				pool.ScrubEndTime = &t
+			}
+			continue
+		}
+
+		// Parse progress percentage if scrubbing
+		if pool.ScrubState == models.ZFSScrubStateScanning {
+			if matches := scrubProgress.FindStringSubmatch(line); matches != nil {
+				pool.ScrubPercentComplete, _ = strconv.ParseFloat(matches[1], 64)
+			}
+		}
+	}
+}
+
+// parseZFSDate parses a date string from ZFS output
+func (d *Detect) parseZFSDate(dateStr string) (time.Time, error) {
+	// ZFS uses format like: "Sun Jan  5 00:34:31 2026"
+	layouts := []string{
+		"Mon Jan  2 15:04:05 2006",
+		"Mon Jan 2 15:04:05 2006",
+		time.ANSIC,
+		time.UnixDate,
+	}
+
+	dateStr = strings.TrimSpace(dateStr)
+
+	for _, layout := range layouts {
+		if t, err := time.Parse(layout, dateStr); err == nil {
+			return t, nil
+		}
+	}
+
+	return time.Time{}, fmt.Errorf("unable to parse date: %s", dateStr)
+}

--- a/collector/pkg/zfs/models/pool.go
+++ b/collector/pkg/zfs/models/pool.go
@@ -1,0 +1,105 @@
+package models
+
+import (
+	"time"
+)
+
+// ZFSPoolStatus represents the health status of a ZFS pool
+type ZFSPoolStatus string
+
+const (
+	ZFSPoolStatusOnline   ZFSPoolStatus = "ONLINE"
+	ZFSPoolStatusDegraded ZFSPoolStatus = "DEGRADED"
+	ZFSPoolStatusFaulted  ZFSPoolStatus = "FAULTED"
+	ZFSPoolStatusOffline  ZFSPoolStatus = "OFFLINE"
+	ZFSPoolStatusRemoved  ZFSPoolStatus = "REMOVED"
+	ZFSPoolStatusUnavail  ZFSPoolStatus = "UNAVAIL"
+)
+
+// ZFSScrubState represents the state of a ZFS scrub operation
+type ZFSScrubState string
+
+const (
+	ZFSScrubStateNone     ZFSScrubState = "none"
+	ZFSScrubStateScanning ZFSScrubState = "scanning"
+	ZFSScrubStateFinished ZFSScrubState = "finished"
+	ZFSScrubStateCanceled ZFSScrubState = "canceled"
+)
+
+// ZFSVdevType represents the type of a ZFS vdev
+type ZFSVdevType string
+
+const (
+	ZFSVdevTypeDisk    ZFSVdevType = "disk"
+	ZFSVdevTypeFile    ZFSVdevType = "file"
+	ZFSVdevTypeMirror  ZFSVdevType = "mirror"
+	ZFSVdevTypeRaidz1  ZFSVdevType = "raidz1"
+	ZFSVdevTypeRaidz2  ZFSVdevType = "raidz2"
+	ZFSVdevTypeRaidz3  ZFSVdevType = "raidz3"
+	ZFSVdevTypeDraid1  ZFSVdevType = "draid1"
+	ZFSVdevTypeDraid2  ZFSVdevType = "draid2"
+	ZFSVdevTypeDraid3  ZFSVdevType = "draid3"
+	ZFSVdevTypeSpare   ZFSVdevType = "spare"
+	ZFSVdevTypeLog     ZFSVdevType = "log"
+	ZFSVdevTypeCache   ZFSVdevType = "cache"
+	ZFSVdevTypeSpecial ZFSVdevType = "special"
+	ZFSVdevTypeDedup   ZFSVdevType = "dedup"
+)
+
+// ZFSPoolWrapper wraps the response for ZFS pool API calls
+type ZFSPoolWrapper struct {
+	Success bool      `json:"success"`
+	Errors  []error   `json:"errors,omitempty"`
+	Data    []ZFSPool `json:"data"`
+}
+
+// ZFSPool represents a ZFS storage pool
+type ZFSPool struct {
+	GUID   string `json:"guid"`
+	Name   string `json:"name"`
+	HostID string `json:"host_id"`
+
+	Status ZFSPoolStatus `json:"status"`
+	Health string        `json:"health"`
+
+	Size            int64   `json:"size"`
+	Allocated       int64   `json:"allocated"`
+	Free            int64   `json:"free"`
+	Fragmentation   int     `json:"fragmentation"`
+	CapacityPercent float64 `json:"capacity_percent"`
+
+	Ashift int `json:"ashift"`
+
+	ScrubState           ZFSScrubState `json:"scrub_state"`
+	ScrubStartTime       *time.Time    `json:"scrub_start_time,omitempty"`
+	ScrubEndTime         *time.Time    `json:"scrub_end_time,omitempty"`
+	ScrubScannedBytes    int64         `json:"scrub_scanned_bytes"`
+	ScrubIssuedBytes     int64         `json:"scrub_issued_bytes"`
+	ScrubTotalBytes      int64         `json:"scrub_total_bytes"`
+	ScrubErrorsCount     int64         `json:"scrub_errors_count"`
+	ScrubPercentComplete float64       `json:"scrub_percent_complete"`
+
+	TotalReadErrors     int64 `json:"total_read_errors"`
+	TotalWriteErrors    int64 `json:"total_write_errors"`
+	TotalChecksumErrors int64 `json:"total_checksum_errors"`
+
+	Vdevs []ZFSVdev `json:"vdevs,omitempty"`
+}
+
+// ZFSVdev represents a virtual device in a ZFS pool
+type ZFSVdev struct {
+	Name   string        `json:"name"`
+	Type   ZFSVdevType   `json:"type"`
+	Status ZFSPoolStatus `json:"status"`
+	GUID   string        `json:"guid,omitempty"`
+	Path   string        `json:"path,omitempty"`
+
+	ReadErrors     int64 `json:"read_errors"`
+	WriteErrors    int64 `json:"write_errors"`
+	ChecksumErrors int64 `json:"checksum_errors"`
+
+	Size      int64 `json:"size,omitempty"`
+	Allocated int64 `json:"allocated,omitempty"`
+
+	Children []ZFSVdev `json:"children,omitempty"`
+}

--- a/docker/Dockerfile.collector-zfs
+++ b/docker/Dockerfile.collector-zfs
@@ -1,0 +1,31 @@
+########################################################################################################################
+# ZFS Collector Image
+########################################################################################################################
+
+
+########
+FROM golang:1.20-bookworm as backendbuild
+
+WORKDIR /go/src/github.com/analogj/scrutiny
+
+COPY . /go/src/github.com/analogj/scrutiny
+
+RUN apt-get update && apt-get install -y file && rm -rf /var/lib/apt/lists/*
+RUN make binary-clean binary-collector-zfs
+
+########
+FROM debian:bookworm-slim as runtime
+WORKDIR /opt/scrutiny
+ENV PATH="/opt/scrutiny/bin:${PATH}"
+
+RUN apt-get update && apt-get install -y cron zfsutils-linux ca-certificates tzdata && rm -rf /var/lib/apt/lists/* && update-ca-certificates
+
+COPY /docker/entrypoint-collector-zfs.sh /entrypoint-collector-zfs.sh
+COPY /rootfs/etc/cron.d/scrutiny-zfs /etc/cron.d/scrutiny-zfs
+COPY --from=backendbuild /go/src/github.com/analogj/scrutiny/scrutiny-collector-zfs /opt/scrutiny/bin/
+RUN chmod +x /opt/scrutiny/bin/scrutiny-collector-zfs && \
+    chmod +x /entrypoint-collector-zfs.sh && \
+    chmod 0644 /etc/cron.d/scrutiny-zfs && \
+    rm -f /etc/cron.daily/apt /etc/cron.daily/dpkg /etc/cron.daily/passwd
+
+CMD ["/entrypoint-collector-zfs.sh"]

--- a/docker/entrypoint-collector-zfs.sh
+++ b/docker/entrypoint-collector-zfs.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Cron runs in its own isolated environment (usually using only /etc/environment )
+# So when the container starts up, we will do a dump of the runtime environment into a .env file that we
+# will then source into the crontab file (/etc/cron.d/scrutiny-zfs)
+(set -o posix; export -p) > /env.sh
+
+# adding ability to customize the cron schedule.
+COLLECTOR_ZFS_CRON_SCHEDULE=${COLLECTOR_ZFS_CRON_SCHEDULE:-"*/15 * * * *"}
+COLLECTOR_ZFS_RUN_STARTUP=${COLLECTOR_ZFS_RUN_STARTUP:-"false"}
+COLLECTOR_ZFS_RUN_STARTUP_SLEEP=${COLLECTOR_ZFS_RUN_STARTUP_SLEEP:-"1"}
+
+# if the cron schedule has been overridden via env variable (eg docker-compose) we should make sure to strip quotes
+[[ "${COLLECTOR_ZFS_CRON_SCHEDULE}" == \"*\" || "${COLLECTOR_ZFS_CRON_SCHEDULE}" == \'*\' ]] && COLLECTOR_ZFS_CRON_SCHEDULE="${COLLECTOR_ZFS_CRON_SCHEDULE:1:-1}"
+
+# replace placeholder with correct value
+sed -i 's|{COLLECTOR_ZFS_CRON_SCHEDULE}|'"${COLLECTOR_ZFS_CRON_SCHEDULE}"'|g' /etc/cron.d/scrutiny-zfs
+
+if [[ "${COLLECTOR_ZFS_RUN_STARTUP}" == "true" ]]; then
+    sleep ${COLLECTOR_ZFS_RUN_STARTUP_SLEEP}
+    echo "starting scrutiny ZFS collector (run-once mode. subsequent calls will be triggered via cron service)"
+    /opt/scrutiny/bin/scrutiny-collector-zfs run
+fi
+
+
+# now that we have the env start cron in the foreground
+echo "starting cron"
+exec su -c "cron -f -L 15" root

--- a/example.collector-zfs.yaml
+++ b/example.collector-zfs.yaml
@@ -1,0 +1,26 @@
+# Scrutiny ZFS Collector Configuration
+# This file configures the ZFS pool collector component
+
+version: 1
+
+# Host identification
+host:
+  # Optional: Unique identifier for this host
+  # Used to group pools by host in the dashboard
+  id: ""
+
+# API settings
+api:
+  # The API endpoint for the Scrutiny web server
+  endpoint: "http://localhost:8080"
+
+  # Timeout in seconds for API requests
+  timeout: 60
+
+# Logging configuration
+log:
+  # Log level: DEBUG, INFO, WARNING, ERROR
+  level: INFO
+
+  # Optional: Path to log file (leave empty for STDOUT)
+  file: ""

--- a/rootfs/etc/cron.d/scrutiny-zfs
+++ b/rootfs/etc/cron.d/scrutiny-zfs
@@ -1,0 +1,15 @@
+MAILTO=""
+# Example of job definition:
+# .---------------- minute (0 - 59)
+# |  .------------- hour (0 - 23)
+# |  |  .---------- day of month (1 - 31)
+# |  |  |  .------- month (1 - 12) OR jan,feb,mar,apr ...
+# |  |  |  |  .---- day of week (0 - 6) (Sunday=0 or 7) OR sun,mon,tue,wed,thu,fri,sat
+# |  |  |  |  |
+# *  *  *  *  * user-name command to be executed
+
+# correctly route collector logs (STDOUT & STDERR) to Cron foreground (collectable by Docker STDOUT)
+# cron schedule to run every 15 minutes:  '*/15 * * * *'
+# System environmental variables are stripped by cron, source our dump of the docker environmental variables before each command (/env.sh)
+{COLLECTOR_ZFS_CRON_SCHEDULE} root . /env.sh; /opt/scrutiny/bin/scrutiny-collector-zfs run >/proc/1/fd/1 2>/proc/1/fd/2
+# An empty line is required at the end of this file for a valid cron file.

--- a/webapp/backend/pkg/database/interface.go
+++ b/webapp/backend/pkg/database/interface.go
@@ -35,4 +35,18 @@ type DeviceRepo interface {
 
 	LoadSettings(ctx context.Context) (*models.Settings, error)
 	SaveSettings(ctx context.Context, settings models.Settings) error
+
+	// ZFS Pool operations
+	RegisterZFSPool(ctx context.Context, pool models.ZFSPool) error
+	GetZFSPools(ctx context.Context) ([]models.ZFSPool, error)
+	GetZFSPoolDetails(ctx context.Context, guid string) (models.ZFSPool, error)
+	UpdateZFSPoolArchived(ctx context.Context, guid string, archived bool) error
+	UpdateZFSPoolMuted(ctx context.Context, guid string, muted bool) error
+	UpdateZFSPoolLabel(ctx context.Context, guid string, label string) error
+	DeleteZFSPool(ctx context.Context, guid string) error
+	GetZFSPoolsSummary(ctx context.Context) (map[string]*models.ZFSPool, error)
+
+	// ZFS Pool metrics
+	SaveZFSPoolMetrics(ctx context.Context, pool models.ZFSPool) error
+	GetZFSPoolMetricsHistory(ctx context.Context, guid string, durationKey string) ([]measurements.ZFSPoolMetrics, error)
 }

--- a/webapp/backend/pkg/database/migrations/m20260108000000/zfs.go
+++ b/webapp/backend/pkg/database/migrations/m20260108000000/zfs.go
@@ -1,0 +1,73 @@
+package m20260108000000
+
+import (
+	"time"
+)
+
+// ZFSPoolStatus represents the health status of a ZFS pool
+type ZFSPoolStatus string
+
+// ZFSScrubState represents the state of a ZFS scrub operation
+type ZFSScrubState string
+
+// ZFSVdevType represents the type of a ZFS vdev
+type ZFSVdevType string
+
+// ZFSPool represents a ZFS storage pool for migration
+type ZFSPool struct {
+	CreatedAt time.Time
+	UpdatedAt time.Time
+	DeletedAt *time.Time
+
+	GUID   string `gorm:"primary_key"`
+	Name   string
+	HostID string
+
+	Status ZFSPoolStatus
+	Health string
+
+	Size            int64
+	Allocated       int64
+	Free            int64
+	Fragmentation   int
+	CapacityPercent float64
+
+	Ashift int
+
+	ScrubState           ZFSScrubState
+	ScrubStartTime       *time.Time
+	ScrubEndTime         *time.Time
+	ScrubScannedBytes    int64
+	ScrubIssuedBytes     int64
+	ScrubTotalBytes      int64
+	ScrubErrorsCount     int64
+	ScrubPercentComplete float64
+
+	TotalReadErrors     int64
+	TotalWriteErrors    int64
+	TotalChecksumErrors int64
+
+	Label    string
+	Archived bool
+	Muted    bool
+}
+
+// ZFSVdev represents a virtual device in a ZFS pool for migration
+type ZFSVdev struct {
+	ID       uint `gorm:"primary_key;autoIncrement"`
+	PoolGUID string `gorm:"index;not null"`
+	ParentID *uint  `gorm:"index"`
+
+	Name   string
+	Type   ZFSVdevType
+	Status ZFSPoolStatus
+	GUID   string
+	Path   string
+
+	ReadErrors     int64
+	WriteErrors    int64
+	ChecksumErrors int64
+
+	Size      int64
+	Allocated int64
+}

--- a/webapp/backend/pkg/database/scrutiny_repository_migrations.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_migrations.go
@@ -15,6 +15,7 @@ import (
 	"github.com/analogj/scrutiny/webapp/backend/pkg/database/migrations/m20220716214900"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/database/migrations/m20250221084400"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/database/migrations/m20251108044508"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/database/migrations/m20260108000000"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/models"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/models/collector"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/models/measurements"
@@ -432,6 +433,16 @@ func (sr *scrutinyRepository) Migrate(ctx context.Context) error {
 				//migrate the device database.
 				// adding column (muted)
 				return tx.AutoMigrate(m20251108044508.Device{})
+			},
+		},
+		{
+			ID: "m20260108000000", // add ZFS pool and vdev tables
+			Migrate: func(tx *gorm.DB) error {
+				// Create ZFS pool and vdev tables
+				return tx.AutoMigrate(
+					&m20260108000000.ZFSPool{},
+					&m20260108000000.ZFSVdev{},
+				)
 			},
 		},
 	})

--- a/webapp/backend/pkg/database/scrutiny_repository_zfs.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_zfs.go
@@ -1,0 +1,286 @@
+package database
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/analogj/scrutiny/webapp/backend/pkg/models"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/models/measurements"
+	"gorm.io/gorm/clause"
+)
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// ZFS Pool
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// RegisterZFSPool inserts or updates a ZFS pool in the database
+func (sr *scrutinyRepository) RegisterZFSPool(ctx context.Context, pool models.ZFSPool) error {
+	// First, handle the pool itself (upsert)
+	if err := sr.gormClient.WithContext(ctx).Clauses(clause.OnConflict{
+		Columns: []clause.Column{{Name: "guid"}},
+		DoUpdates: clause.AssignmentColumns([]string{
+			"name", "host_id", "status", "health",
+			"size", "allocated", "free", "fragmentation", "capacity_percent",
+			"ashift",
+			"scrub_state", "scrub_start_time", "scrub_end_time",
+			"scrub_scanned_bytes", "scrub_issued_bytes", "scrub_total_bytes",
+			"scrub_errors_count", "scrub_percent_complete",
+			"total_read_errors", "total_write_errors", "total_checksum_errors",
+		}),
+	}).Create(&pool).Error; err != nil {
+		return err
+	}
+
+	// Handle vdevs - delete existing and recreate
+	if len(pool.Vdevs) > 0 {
+		// Delete existing vdevs for this pool
+		if err := sr.gormClient.WithContext(ctx).Where("pool_guid = ?", pool.GUID).Delete(&models.ZFSVdev{}).Error; err != nil {
+			return err
+		}
+
+		// Insert new vdevs with hierarchy
+		if err := sr.insertVdevsRecursive(ctx, pool.GUID, pool.Vdevs, nil); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// insertVdevsRecursive inserts vdevs and their children recursively
+func (sr *scrutinyRepository) insertVdevsRecursive(ctx context.Context, poolGUID string, vdevs []models.ZFSVdev, parentID *uint) error {
+	for _, vdev := range vdevs {
+		vdev.PoolGUID = poolGUID
+		vdev.ParentID = parentID
+		vdev.ID = 0 // Reset ID to let GORM auto-generate
+
+		children := vdev.Children
+		vdev.Children = nil // Don't try to insert children via association
+
+		if err := sr.gormClient.WithContext(ctx).Create(&vdev).Error; err != nil {
+			return err
+		}
+
+		// Recursively insert children
+		if len(children) > 0 {
+			if err := sr.insertVdevsRecursive(ctx, poolGUID, children, &vdev.ID); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// GetZFSPools returns all non-archived ZFS pools
+func (sr *scrutinyRepository) GetZFSPools(ctx context.Context) ([]models.ZFSPool, error) {
+	pools := []models.ZFSPool{}
+	if err := sr.gormClient.WithContext(ctx).Where("archived = ?", false).Find(&pools).Error; err != nil {
+		return nil, fmt.Errorf("could not get ZFS pools from DB: %v", err)
+	}
+	return pools, nil
+}
+
+// GetZFSPoolDetails returns a single ZFS pool with its vdev hierarchy
+func (sr *scrutinyRepository) GetZFSPoolDetails(ctx context.Context, guid string) (models.ZFSPool, error) {
+	var pool models.ZFSPool
+
+	if err := sr.gormClient.WithContext(ctx).Where("guid = ?", guid).First(&pool).Error; err != nil {
+		return models.ZFSPool{}, err
+	}
+
+	// Load top-level vdevs (those without a parent)
+	var vdevs []models.ZFSVdev
+	if err := sr.gormClient.WithContext(ctx).Where("pool_guid = ? AND parent_id IS NULL", guid).Find(&vdevs).Error; err != nil {
+		return pool, err
+	}
+
+	// Load children recursively for each vdev
+	for i := range vdevs {
+		if err := sr.loadVdevChildren(ctx, &vdevs[i]); err != nil {
+			return pool, err
+		}
+	}
+
+	pool.Vdevs = vdevs
+	return pool, nil
+}
+
+// loadVdevChildren recursively loads children for a vdev
+func (sr *scrutinyRepository) loadVdevChildren(ctx context.Context, vdev *models.ZFSVdev) error {
+	var children []models.ZFSVdev
+	if err := sr.gormClient.WithContext(ctx).Where("parent_id = ?", vdev.ID).Find(&children).Error; err != nil {
+		return err
+	}
+
+	for i := range children {
+		if err := sr.loadVdevChildren(ctx, &children[i]); err != nil {
+			return err
+		}
+	}
+
+	vdev.Children = children
+	return nil
+}
+
+// UpdateZFSPoolArchived updates the archived state of a ZFS pool
+func (sr *scrutinyRepository) UpdateZFSPoolArchived(ctx context.Context, guid string, archived bool) error {
+	var pool models.ZFSPool
+	if err := sr.gormClient.WithContext(ctx).Where("guid = ?", guid).First(&pool).Error; err != nil {
+		return fmt.Errorf("could not get ZFS pool from DB: %v", err)
+	}
+
+	return sr.gormClient.Model(&pool).Where("guid = ?", guid).Update("archived", archived).Error
+}
+
+// UpdateZFSPoolMuted updates the muted state of a ZFS pool
+func (sr *scrutinyRepository) UpdateZFSPoolMuted(ctx context.Context, guid string, muted bool) error {
+	var pool models.ZFSPool
+	if err := sr.gormClient.WithContext(ctx).Where("guid = ?", guid).First(&pool).Error; err != nil {
+		return fmt.Errorf("could not get ZFS pool from DB: %v", err)
+	}
+
+	return sr.gormClient.Model(&pool).Where("guid = ?", guid).Update("muted", muted).Error
+}
+
+// UpdateZFSPoolLabel updates the label of a ZFS pool
+func (sr *scrutinyRepository) UpdateZFSPoolLabel(ctx context.Context, guid string, label string) error {
+	var pool models.ZFSPool
+	if err := sr.gormClient.WithContext(ctx).Where("guid = ?", guid).First(&pool).Error; err != nil {
+		return fmt.Errorf("could not get ZFS pool from DB: %v", err)
+	}
+
+	return sr.gormClient.Model(&pool).Where("guid = ?", guid).Update("label", label).Error
+}
+
+// DeleteZFSPool deletes a ZFS pool and its associated data
+func (sr *scrutinyRepository) DeleteZFSPool(ctx context.Context, guid string) error {
+	// Delete vdevs first (foreign key constraint)
+	if err := sr.gormClient.WithContext(ctx).Where("pool_guid = ?", guid).Delete(&models.ZFSVdev{}).Error; err != nil {
+		return err
+	}
+
+	// Delete the pool
+	if err := sr.gormClient.WithContext(ctx).Where("guid = ?", guid).Delete(&models.ZFSPool{}).Error; err != nil {
+		return err
+	}
+
+	// Delete data from InfluxDB
+	buckets := []string{
+		sr.appConfig.GetString("web.influxdb.bucket"),
+		fmt.Sprintf("%s_weekly", sr.appConfig.GetString("web.influxdb.bucket")),
+		fmt.Sprintf("%s_monthly", sr.appConfig.GetString("web.influxdb.bucket")),
+		fmt.Sprintf("%s_yearly", sr.appConfig.GetString("web.influxdb.bucket")),
+	}
+
+	for _, bucket := range buckets {
+		sr.logger.Infof("Deleting ZFS pool data for %s in bucket: %s", guid, bucket)
+		if err := sr.influxClient.DeleteAPI().DeleteWithName(
+			ctx,
+			sr.appConfig.GetString("web.influxdb.org"),
+			bucket,
+			time.Now().AddDate(-10, 0, 0),
+			time.Now(),
+			fmt.Sprintf(`pool_guid="%s"`, guid),
+		); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// GetZFSPoolsSummary returns a summary of all non-archived ZFS pools
+func (sr *scrutinyRepository) GetZFSPoolsSummary(ctx context.Context) (map[string]*models.ZFSPool, error) {
+	pools, err := sr.GetZFSPools(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	summary := make(map[string]*models.ZFSPool)
+	for i := range pools {
+		summary[pools[i].GUID] = &pools[i]
+	}
+
+	return summary, nil
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// ZFS Pool Metrics (InfluxDB)
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// SaveZFSPoolMetrics saves ZFS pool metrics to InfluxDB
+func (sr *scrutinyRepository) SaveZFSPoolMetrics(ctx context.Context, pool models.ZFSPool) error {
+	// Create metrics from pool data
+	metrics := measurements.ZFSPoolMetrics{
+		Date:            time.Now(),
+		PoolGUID:        pool.GUID,
+		PoolName:        pool.Name,
+		Size:            pool.Size,
+		Allocated:       pool.Allocated,
+		Free:            pool.Free,
+		CapacityPercent: pool.CapacityPercent,
+		Fragmentation:   pool.Fragmentation,
+		Status:          string(pool.Status),
+		ReadErrors:      pool.TotalReadErrors,
+		WriteErrors:     pool.TotalWriteErrors,
+		ChecksumErrors:  pool.TotalChecksumErrors,
+		ScrubState:      string(pool.ScrubState),
+		ScrubPercent:    pool.ScrubPercentComplete,
+		ScrubErrors:     pool.ScrubErrorsCount,
+	}
+
+	tags, fields := metrics.Flatten()
+
+	// Save to daily bucket
+	return sr.saveDatapoint(
+		sr.influxWriteApi,
+		"zfs_pool",
+		tags,
+		fields,
+		metrics.Date,
+		ctx,
+	)
+}
+
+// GetZFSPoolMetricsHistory retrieves historical metrics for a ZFS pool
+func (sr *scrutinyRepository) GetZFSPoolMetricsHistory(ctx context.Context, guid string, durationKey string) ([]measurements.ZFSPoolMetrics, error) {
+	// Map duration key to actual duration and bucket
+	bucketName := sr.lookupBucketName(durationKey)
+	duration := sr.lookupDuration(durationKey)
+
+	queryStr := fmt.Sprintf(`
+		from(bucket: "%s")
+		|> range(start: %s, stop: %s)
+		|> filter(fn: (r) => r["_measurement"] == "zfs_pool")
+		|> filter(fn: (r) => r["pool_guid"] == "%s")
+		|> aggregateWindow(every: 1h, fn: last, createEmpty: false)
+		|> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")
+		|> sort(columns: ["_time"], desc: false)
+	`, bucketName, duration[0], duration[1], guid)
+
+	result, err := sr.influxQueryApi.Query(ctx, queryStr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query ZFS pool metrics: %v", err)
+	}
+
+	var metricsHistory []measurements.ZFSPoolMetrics
+	for result.Next() {
+		record := result.Record()
+		values := record.Values()
+
+		metrics, err := measurements.NewZFSPoolMetricsFromInfluxDB(values)
+		if err != nil {
+			sr.logger.Warnf("Failed to parse ZFS pool metrics: %v", err)
+			continue
+		}
+
+		metricsHistory = append(metricsHistory, *metrics)
+	}
+
+	if result.Err() != nil {
+		return nil, fmt.Errorf("query error: %v", result.Err())
+	}
+
+	return metricsHistory, nil
+}

--- a/webapp/backend/pkg/models/measurements/zfs_pool_metrics.go
+++ b/webapp/backend/pkg/models/measurements/zfs_pool_metrics.go
@@ -1,0 +1,112 @@
+package measurements
+
+import (
+	"time"
+)
+
+// ZFSPoolMetrics represents time-series metrics for a ZFS pool stored in InfluxDB
+type ZFSPoolMetrics struct {
+	Date     time.Time `json:"date"`
+	PoolGUID string    `json:"pool_guid"` // tag
+	PoolName string    `json:"pool_name"` // tag
+
+	// Capacity metrics (fields)
+	Size            int64   `json:"size"`
+	Allocated       int64   `json:"allocated"`
+	Free            int64   `json:"free"`
+	CapacityPercent float64 `json:"capacity_percent"`
+	Fragmentation   int     `json:"fragmentation"`
+
+	// Health status (field - stored as string)
+	Status string `json:"status"`
+
+	// Error counts (fields)
+	ReadErrors     int64 `json:"read_errors"`
+	WriteErrors    int64 `json:"write_errors"`
+	ChecksumErrors int64 `json:"checksum_errors"`
+
+	// Scrub metrics (fields)
+	ScrubState   string  `json:"scrub_state"`
+	ScrubPercent float64 `json:"scrub_percent"`
+	ScrubErrors  int64   `json:"scrub_errors"`
+}
+
+// Flatten converts the ZFSPoolMetrics struct to tags and fields for InfluxDB
+func (m *ZFSPoolMetrics) Flatten() (tags map[string]string, fields map[string]interface{}) {
+	tags = map[string]string{
+		"pool_guid": m.PoolGUID,
+		"pool_name": m.PoolName,
+	}
+
+	fields = map[string]interface{}{
+		"size":             m.Size,
+		"allocated":        m.Allocated,
+		"free":             m.Free,
+		"capacity_percent": m.CapacityPercent,
+		"fragmentation":    m.Fragmentation,
+		"status":           m.Status,
+		"read_errors":      m.ReadErrors,
+		"write_errors":     m.WriteErrors,
+		"checksum_errors":  m.ChecksumErrors,
+		"scrub_state":      m.ScrubState,
+		"scrub_percent":    m.ScrubPercent,
+		"scrub_errors":     m.ScrubErrors,
+	}
+
+	return tags, fields
+}
+
+// NewZFSPoolMetricsFromInfluxDB creates a ZFSPoolMetrics from InfluxDB query result
+func NewZFSPoolMetricsFromInfluxDB(attrs map[string]interface{}) (*ZFSPoolMetrics, error) {
+	m := ZFSPoolMetrics{
+		Date:     attrs["_time"].(time.Time),
+		PoolGUID: attrs["pool_guid"].(string),
+		PoolName: attrs["pool_name"].(string),
+	}
+
+	// Parse optional fields
+	if val, ok := attrs["size"]; ok && val != nil {
+		m.Size = val.(int64)
+	}
+	if val, ok := attrs["allocated"]; ok && val != nil {
+		m.Allocated = val.(int64)
+	}
+	if val, ok := attrs["free"]; ok && val != nil {
+		m.Free = val.(int64)
+	}
+	if val, ok := attrs["capacity_percent"]; ok && val != nil {
+		m.CapacityPercent = val.(float64)
+	}
+	if val, ok := attrs["fragmentation"]; ok && val != nil {
+		m.Fragmentation = int(val.(int64))
+	}
+	if val, ok := attrs["status"]; ok && val != nil {
+		m.Status = val.(string)
+	}
+	if val, ok := attrs["read_errors"]; ok && val != nil {
+		m.ReadErrors = val.(int64)
+	}
+	if val, ok := attrs["write_errors"]; ok && val != nil {
+		m.WriteErrors = val.(int64)
+	}
+	if val, ok := attrs["checksum_errors"]; ok && val != nil {
+		m.ChecksumErrors = val.(int64)
+	}
+	if val, ok := attrs["scrub_state"]; ok && val != nil {
+		m.ScrubState = val.(string)
+	}
+	if val, ok := attrs["scrub_percent"]; ok && val != nil {
+		m.ScrubPercent = val.(float64)
+	}
+	if val, ok := attrs["scrub_errors"]; ok && val != nil {
+		m.ScrubErrors = val.(int64)
+	}
+
+	return &m, nil
+}
+
+// ZFSPoolCapacityHistory represents a simplified capacity data point for charts
+type ZFSPoolCapacityHistory struct {
+	Date            time.Time `json:"date"`
+	CapacityPercent float64   `json:"capacity_percent"`
+}

--- a/webapp/backend/pkg/models/zfs_pool.go
+++ b/webapp/backend/pkg/models/zfs_pool.go
@@ -1,0 +1,111 @@
+package models
+
+import (
+	"time"
+)
+
+// ZFSPoolStatus represents the health status of a ZFS pool
+type ZFSPoolStatus string
+
+const (
+	ZFSPoolStatusOnline   ZFSPoolStatus = "ONLINE"
+	ZFSPoolStatusDegraded ZFSPoolStatus = "DEGRADED"
+	ZFSPoolStatusFaulted  ZFSPoolStatus = "FAULTED"
+	ZFSPoolStatusOffline  ZFSPoolStatus = "OFFLINE"
+	ZFSPoolStatusRemoved  ZFSPoolStatus = "REMOVED"
+	ZFSPoolStatusUnavail  ZFSPoolStatus = "UNAVAIL"
+)
+
+// ZFSScrubState represents the state of a ZFS scrub operation
+type ZFSScrubState string
+
+const (
+	ZFSScrubStateNone     ZFSScrubState = "none"
+	ZFSScrubStateScanning ZFSScrubState = "scanning"
+	ZFSScrubStateFinished ZFSScrubState = "finished"
+	ZFSScrubStateCanceled ZFSScrubState = "canceled"
+)
+
+// ZFSPoolWrapper wraps the response for ZFS pool API calls
+type ZFSPoolWrapper struct {
+	Success bool      `json:"success"`
+	Errors  []error   `json:"errors,omitempty"`
+	Data    []ZFSPool `json:"data"`
+}
+
+// ZFSPool represents a ZFS storage pool
+type ZFSPool struct {
+	// GORM attributes
+	CreatedAt time.Time  `json:"created_at"`
+	UpdatedAt time.Time  `json:"updated_at"`
+	DeletedAt *time.Time `json:"deleted_at,omitempty"`
+
+	// Pool identifier (GUID) - primary key
+	GUID   string `json:"guid" gorm:"primary_key"`
+	Name   string `json:"name"`
+	HostID string `json:"host_id"`
+
+	// Pool status
+	Status ZFSPoolStatus `json:"status"`
+	Health string        `json:"health"`
+
+	// Capacity metrics (in bytes)
+	Size            int64   `json:"size"`
+	Allocated       int64   `json:"allocated"`
+	Free            int64   `json:"free"`
+	Fragmentation   int     `json:"fragmentation"`
+	CapacityPercent float64 `json:"capacity_percent"`
+
+	// Pool configuration
+	Ashift int `json:"ashift"`
+
+	// Scrub status (stored as JSON in SQLite)
+	ScrubState          ZFSScrubState `json:"scrub_state"`
+	ScrubStartTime      *time.Time    `json:"scrub_start_time,omitempty"`
+	ScrubEndTime        *time.Time    `json:"scrub_end_time,omitempty"`
+	ScrubScannedBytes   int64         `json:"scrub_scanned_bytes"`
+	ScrubIssuedBytes    int64         `json:"scrub_issued_bytes"`
+	ScrubTotalBytes     int64         `json:"scrub_total_bytes"`
+	ScrubErrorsCount    int64         `json:"scrub_errors_count"`
+	ScrubPercentComplete float64      `json:"scrub_percent_complete"`
+
+	// Aggregate error counts (sum of all vdevs)
+	TotalReadErrors     int64 `json:"total_read_errors"`
+	TotalWriteErrors    int64 `json:"total_write_errors"`
+	TotalChecksumErrors int64 `json:"total_checksum_errors"`
+
+	// User provided metadata
+	Label string `json:"label,omitempty"`
+
+	// Pool management flags
+	Archived bool `json:"archived"`
+	Muted    bool `json:"muted"`
+
+	// Vdevs associated with this pool (loaded via preload, not stored in this table)
+	Vdevs []ZFSVdev `json:"vdevs,omitempty" gorm:"foreignKey:PoolGUID;references:GUID"`
+}
+
+// IsHealthy returns true if the pool status is ONLINE
+func (p *ZFSPool) IsHealthy() bool {
+	return p.Status == ZFSPoolStatusOnline
+}
+
+// IsDegraded returns true if the pool status is DEGRADED
+func (p *ZFSPool) IsDegraded() bool {
+	return p.Status == ZFSPoolStatusDegraded
+}
+
+// IsFaulted returns true if the pool status is FAULTED
+func (p *ZFSPool) IsFaulted() bool {
+	return p.Status == ZFSPoolStatusFaulted
+}
+
+// HasErrors returns true if the pool has any read, write, or checksum errors
+func (p *ZFSPool) HasErrors() bool {
+	return p.TotalReadErrors > 0 || p.TotalWriteErrors > 0 || p.TotalChecksumErrors > 0
+}
+
+// IsScrubbing returns true if a scrub is currently in progress
+func (p *ZFSPool) IsScrubbing() bool {
+	return p.ScrubState == ZFSScrubStateScanning
+}

--- a/webapp/backend/pkg/models/zfs_vdev.go
+++ b/webapp/backend/pkg/models/zfs_vdev.go
@@ -1,0 +1,89 @@
+package models
+
+// ZFSVdevType represents the type of a ZFS vdev
+type ZFSVdevType string
+
+const (
+	ZFSVdevTypeDisk    ZFSVdevType = "disk"
+	ZFSVdevTypeFile    ZFSVdevType = "file"
+	ZFSVdevTypeMirror  ZFSVdevType = "mirror"
+	ZFSVdevTypeRaidz1  ZFSVdevType = "raidz1"
+	ZFSVdevTypeRaidz2  ZFSVdevType = "raidz2"
+	ZFSVdevTypeRaidz3  ZFSVdevType = "raidz3"
+	ZFSVdevTypeDraid1  ZFSVdevType = "draid1"
+	ZFSVdevTypeDraid2  ZFSVdevType = "draid2"
+	ZFSVdevTypeDraid3  ZFSVdevType = "draid3"
+	ZFSVdevTypeSpare   ZFSVdevType = "spare"
+	ZFSVdevTypeLog     ZFSVdevType = "log"
+	ZFSVdevTypeCache   ZFSVdevType = "cache"
+	ZFSVdevTypeSpecial ZFSVdevType = "special"
+	ZFSVdevTypeDedup   ZFSVdevType = "dedup"
+	ZFSVdevTypeRoot    ZFSVdevType = "root" // Virtual root node for the pool
+)
+
+// ZFSVdev represents a virtual device in a ZFS pool
+type ZFSVdev struct {
+	// Primary key
+	ID uint `json:"id" gorm:"primary_key;autoIncrement"`
+
+	// Foreign key to pool
+	PoolGUID string `json:"pool_guid" gorm:"index;not null"`
+
+	// Vdev hierarchy - ParentID is null for top-level vdevs
+	ParentID *uint `json:"parent_id,omitempty" gorm:"index"`
+
+	// Vdev properties
+	Name   string        `json:"name"`
+	Type   ZFSVdevType   `json:"type"`
+	Status ZFSPoolStatus `json:"status"`
+	GUID   string        `json:"guid,omitempty"`
+	Path   string        `json:"path,omitempty"` // Device path for leaf vdevs (e.g., /dev/sda)
+
+	// Error counters
+	ReadErrors     int64 `json:"read_errors"`
+	WriteErrors    int64 `json:"write_errors"`
+	ChecksumErrors int64 `json:"checksum_errors"`
+
+	// Size information (for leaf vdevs)
+	Size      int64 `json:"size,omitempty"`
+	Allocated int64 `json:"allocated,omitempty"`
+
+	// Children vdevs (populated when loading hierarchy)
+	Children []ZFSVdev `json:"children,omitempty" gorm:"foreignKey:ParentID;references:ID"`
+}
+
+// IsLeaf returns true if this vdev has no children (is a disk or file)
+func (v *ZFSVdev) IsLeaf() bool {
+	return v.Type == ZFSVdevTypeDisk || v.Type == ZFSVdevTypeFile
+}
+
+// IsHealthy returns true if the vdev status is ONLINE
+func (v *ZFSVdev) IsHealthy() bool {
+	return v.Status == ZFSPoolStatusOnline
+}
+
+// HasErrors returns true if the vdev has any read, write, or checksum errors
+func (v *ZFSVdev) HasErrors() bool {
+	return v.ReadErrors > 0 || v.WriteErrors > 0 || v.ChecksumErrors > 0
+}
+
+// IsDataVdev returns true if this is a data vdev (not spare, log, cache, special, or dedup)
+func (v *ZFSVdev) IsDataVdev() bool {
+	switch v.Type {
+	case ZFSVdevTypeSpare, ZFSVdevTypeLog, ZFSVdevTypeCache, ZFSVdevTypeSpecial, ZFSVdevTypeDedup:
+		return false
+	default:
+		return true
+	}
+}
+
+// IsRedundant returns true if this vdev type provides redundancy
+func (v *ZFSVdev) IsRedundant() bool {
+	switch v.Type {
+	case ZFSVdevTypeMirror, ZFSVdevTypeRaidz1, ZFSVdevTypeRaidz2, ZFSVdevTypeRaidz3,
+		ZFSVdevTypeDraid1, ZFSVdevTypeDraid2, ZFSVdevTypeDraid3:
+		return true
+	default:
+		return false
+	}
+}

--- a/webapp/backend/pkg/web/handler/zfs_get_details.go
+++ b/webapp/backend/pkg/web/handler/zfs_get_details.go
@@ -1,0 +1,44 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/analogj/scrutiny/webapp/backend/pkg/database"
+	"github.com/gin-gonic/gin"
+	"github.com/sirupsen/logrus"
+)
+
+// GetZFSPoolDetails returns detailed information about a specific ZFS pool
+func GetZFSPoolDetails(c *gin.Context) {
+	deviceRepo := c.MustGet("DEVICE_REPOSITORY").(database.DeviceRepo)
+	logger := c.MustGet("LOGGER").(*logrus.Entry)
+
+	guid := c.Param("guid")
+
+	// Get the pool details with vdev hierarchy
+	pool, err := deviceRepo.GetZFSPoolDetails(c, guid)
+	if err != nil {
+		logger.Errorln("An error occurred while getting ZFS pool details", err)
+		c.JSON(http.StatusNotFound, gin.H{
+			"success": false,
+			"error":   "Pool not found",
+		})
+		return
+	}
+
+	// Get metrics history (default to week)
+	durationKey := c.DefaultQuery("duration_key", "week")
+	metricsHistory, err := deviceRepo.GetZFSPoolMetricsHistory(c, guid, durationKey)
+	if err != nil {
+		logger.Warnln("Could not get ZFS pool metrics history", err)
+		// Continue without metrics history
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"success": true,
+		"data": gin.H{
+			"pool":            pool,
+			"metrics_history": metricsHistory,
+		},
+	})
+}

--- a/webapp/backend/pkg/web/handler/zfs_get_summary.go
+++ b/webapp/backend/pkg/web/handler/zfs_get_summary.go
@@ -1,0 +1,29 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/analogj/scrutiny/webapp/backend/pkg/database"
+	"github.com/gin-gonic/gin"
+	"github.com/sirupsen/logrus"
+)
+
+// GetZFSPoolsSummary returns a summary of all ZFS pools for the dashboard
+func GetZFSPoolsSummary(c *gin.Context) {
+	deviceRepo := c.MustGet("DEVICE_REPOSITORY").(database.DeviceRepo)
+	logger := c.MustGet("LOGGER").(*logrus.Entry)
+
+	summary, err := deviceRepo.GetZFSPoolsSummary(c)
+	if err != nil {
+		logger.Errorln("An error occurred while getting ZFS pools summary", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"success": true,
+		"data": gin.H{
+			"pools": summary,
+		},
+	})
+}

--- a/webapp/backend/pkg/web/handler/zfs_pool_actions.go
+++ b/webapp/backend/pkg/web/handler/zfs_pool_actions.go
@@ -1,0 +1,120 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/analogj/scrutiny/webapp/backend/pkg/database"
+	"github.com/gin-gonic/gin"
+	"github.com/sirupsen/logrus"
+)
+
+// ArchiveZFSPool archives a ZFS pool (hides it from the dashboard)
+func ArchiveZFSPool(c *gin.Context) {
+	deviceRepo := c.MustGet("DEVICE_REPOSITORY").(database.DeviceRepo)
+	logger := c.MustGet("LOGGER").(*logrus.Entry)
+
+	guid := c.Param("guid")
+
+	err := deviceRepo.UpdateZFSPoolArchived(c, guid, true)
+	if err != nil {
+		logger.Errorln("An error occurred while archiving ZFS pool", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"success": true})
+}
+
+// UnarchiveZFSPool unarchives a ZFS pool (shows it on the dashboard)
+func UnarchiveZFSPool(c *gin.Context) {
+	deviceRepo := c.MustGet("DEVICE_REPOSITORY").(database.DeviceRepo)
+	logger := c.MustGet("LOGGER").(*logrus.Entry)
+
+	guid := c.Param("guid")
+
+	err := deviceRepo.UpdateZFSPoolArchived(c, guid, false)
+	if err != nil {
+		logger.Errorln("An error occurred while unarchiving ZFS pool", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"success": true})
+}
+
+// MuteZFSPool mutes notifications for a ZFS pool
+func MuteZFSPool(c *gin.Context) {
+	deviceRepo := c.MustGet("DEVICE_REPOSITORY").(database.DeviceRepo)
+	logger := c.MustGet("LOGGER").(*logrus.Entry)
+
+	guid := c.Param("guid")
+
+	err := deviceRepo.UpdateZFSPoolMuted(c, guid, true)
+	if err != nil {
+		logger.Errorln("An error occurred while muting ZFS pool", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"success": true})
+}
+
+// UnmuteZFSPool unmutes notifications for a ZFS pool
+func UnmuteZFSPool(c *gin.Context) {
+	deviceRepo := c.MustGet("DEVICE_REPOSITORY").(database.DeviceRepo)
+	logger := c.MustGet("LOGGER").(*logrus.Entry)
+
+	guid := c.Param("guid")
+
+	err := deviceRepo.UpdateZFSPoolMuted(c, guid, false)
+	if err != nil {
+		logger.Errorln("An error occurred while unmuting ZFS pool", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"success": true})
+}
+
+// UpdateZFSPoolLabel updates the custom label for a ZFS pool
+func UpdateZFSPoolLabel(c *gin.Context) {
+	deviceRepo := c.MustGet("DEVICE_REPOSITORY").(database.DeviceRepo)
+	logger := c.MustGet("LOGGER").(*logrus.Entry)
+
+	guid := c.Param("guid")
+
+	var payload struct {
+		Label string `json:"label"`
+	}
+	if err := c.BindJSON(&payload); err != nil {
+		logger.Errorln("Cannot parse label payload", err)
+		c.JSON(http.StatusBadRequest, gin.H{"success": false})
+		return
+	}
+
+	err := deviceRepo.UpdateZFSPoolLabel(c, guid, payload.Label)
+	if err != nil {
+		logger.Errorln("An error occurred while updating ZFS pool label", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"success": true})
+}
+
+// DeleteZFSPool deletes a ZFS pool from tracking
+func DeleteZFSPool(c *gin.Context) {
+	deviceRepo := c.MustGet("DEVICE_REPOSITORY").(database.DeviceRepo)
+	logger := c.MustGet("LOGGER").(*logrus.Entry)
+
+	guid := c.Param("guid")
+
+	err := deviceRepo.DeleteZFSPool(c, guid)
+	if err != nil {
+		logger.Errorln("An error occurred while deleting ZFS pool", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"success": true})
+}

--- a/webapp/backend/pkg/web/handler/zfs_register_pools.go
+++ b/webapp/backend/pkg/web/handler/zfs_register_pools.go
@@ -1,0 +1,52 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/analogj/scrutiny/webapp/backend/pkg/database"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/models"
+	"github.com/gin-gonic/gin"
+	"github.com/samber/lo"
+	"github.com/sirupsen/logrus"
+)
+
+// RegisterZFSPools registers ZFS pools detected by the collector.
+// This function is called every time the ZFS collector runs.
+func RegisterZFSPools(c *gin.Context) {
+	deviceRepo := c.MustGet("DEVICE_REPOSITORY").(database.DeviceRepo)
+	logger := c.MustGet("LOGGER").(*logrus.Entry)
+
+	var poolWrapper models.ZFSPoolWrapper
+	err := c.BindJSON(&poolWrapper)
+	if err != nil {
+		logger.Errorln("Cannot parse ZFS pools", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
+		return
+	}
+
+	// Filter any pool with empty GUID (they are invalid)
+	detectedPools := lo.Filter[models.ZFSPool](poolWrapper.Data, func(pool models.ZFSPool, _ int) bool {
+		return len(pool.GUID) > 0
+	})
+
+	errs := []error{}
+	for _, pool := range detectedPools {
+		// Insert pools into DB (and update specified columns if pool is already registered)
+		if err := deviceRepo.RegisterZFSPool(c, pool); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	if len(errs) > 0 {
+		logger.Errorln("An error occurred while registering ZFS pools", errs)
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"success": false,
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, models.ZFSPoolWrapper{
+		Success: true,
+		Data:    detectedPools,
+	})
+}

--- a/webapp/backend/pkg/web/handler/zfs_upload_metrics.go
+++ b/webapp/backend/pkg/web/handler/zfs_upload_metrics.go
@@ -1,0 +1,45 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/analogj/scrutiny/webapp/backend/pkg/database"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/models"
+	"github.com/gin-gonic/gin"
+	"github.com/sirupsen/logrus"
+)
+
+// UploadZFSPoolMetrics receives ZFS pool metrics from the collector and saves them
+func UploadZFSPoolMetrics(c *gin.Context) {
+	deviceRepo := c.MustGet("DEVICE_REPOSITORY").(database.DeviceRepo)
+	logger := c.MustGet("LOGGER").(*logrus.Entry)
+
+	guid := c.Param("guid")
+
+	var pool models.ZFSPool
+	err := c.BindJSON(&pool)
+	if err != nil {
+		logger.Errorln("Cannot parse ZFS pool metrics", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
+		return
+	}
+
+	// Ensure the GUID matches the URL parameter
+	pool.GUID = guid
+
+	// Update the pool in the database
+	if err := deviceRepo.RegisterZFSPool(c, pool); err != nil {
+		logger.Errorln("An error occurred while updating ZFS pool", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
+		return
+	}
+
+	// Save metrics to InfluxDB
+	if err := deviceRepo.SaveZFSPoolMetrics(c, pool); err != nil {
+		logger.Errorln("An error occurred while saving ZFS pool metrics", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"success": true})
+}

--- a/webapp/backend/pkg/web/server.go
+++ b/webapp/backend/pkg/web/server.go
@@ -75,6 +75,21 @@ func (ae *AppEngine) Setup(logger *logrus.Entry) *gin.Engine {
 
 			api.GET("/settings", handler.GetSettings)   //used to get settings
 			api.POST("/settings", handler.SaveSettings) //used to save settings
+
+			// ZFS Pool API endpoints
+			zfs := api.Group("/zfs")
+			{
+				zfs.POST("/pools/register", handler.RegisterZFSPools)        //used by ZFS Collector to register pools
+				zfs.GET("/summary", handler.GetZFSPoolsSummary)              //used by ZFS Dashboard
+				zfs.POST("/pool/:guid/metrics", handler.UploadZFSPoolMetrics) //used by ZFS Collector to upload metrics
+				zfs.GET("/pool/:guid/details", handler.GetZFSPoolDetails)    //used by ZFS Pool Details view
+				zfs.POST("/pool/:guid/archive", handler.ArchiveZFSPool)      //used by UI to archive pool
+				zfs.POST("/pool/:guid/unarchive", handler.UnarchiveZFSPool)  //used by UI to unarchive pool
+				zfs.POST("/pool/:guid/mute", handler.MuteZFSPool)            //used by UI to mute pool
+				zfs.POST("/pool/:guid/unmute", handler.UnmuteZFSPool)        //used by UI to unmute pool
+				zfs.POST("/pool/:guid/label", handler.UpdateZFSPoolLabel)    //used by UI to set pool label
+				zfs.DELETE("/pool/:guid", handler.DeleteZFSPool)             //used by UI to delete pool
+			}
 		}
 	}
 

--- a/webapp/frontend/src/app/app.routing.ts
+++ b/webapp/frontend/src/app/app.routing.ts
@@ -38,7 +38,11 @@ export const appRoutes: Route[] = [
 
             // Example
             {path: 'dashboard', loadChildren: () => import('app/modules/dashboard/dashboard.module').then(m => m.DashboardModule)},
-            {path: 'device/:wwn', loadChildren: () => import('app/modules/detail/detail.module').then(m => m.DetailModule)}
+            {path: 'device/:wwn', loadChildren: () => import('app/modules/detail/detail.module').then(m => m.DetailModule)},
+
+            // ZFS Pools
+            {path: 'zfs-pools', loadChildren: () => import('app/modules/zfs-pools/zfs-pools.module').then(m => m.ZFSPoolsModule)},
+            {path: 'zfs-pool/:guid', loadChildren: () => import('app/modules/zfs-pool-detail/zfs-pool-detail.module').then(m => m.ZFSPoolDetailModule)}
 
             // 404 & Catch all
             // {path: '404-not-found', pathMatch: 'full', loadChildren: () => import('app/modules/admin/pages/errors/error-404/error-404.module').then(m => m.Error404Module)},

--- a/webapp/frontend/src/app/core/models/zfs-pool-model.ts
+++ b/webapp/frontend/src/app/core/models/zfs-pool-model.ts
@@ -1,0 +1,56 @@
+// maps to webapp/backend/pkg/models/zfs_pool.go
+export interface ZFSPoolModel {
+    guid: string;
+    name: string;
+    host_id: string;
+    label: string;
+    archived: boolean;
+    muted: boolean;
+
+    status: ZFSPoolStatus;
+    size: number;
+    allocated: number;
+    free: number;
+    fragmentation: number;
+    capacity_percent: number;
+
+    scrub_state: ZFSScrubState;
+    scrub_start: string;
+    scrub_end: string;
+    scrub_percent: number;
+    scrub_errors: number;
+
+    total_read_errors: number;
+    total_write_errors: number;
+    total_checksum_errors: number;
+
+    vdevs?: ZFSVdevModel[];
+
+    created_at: string;
+    updated_at: string;
+}
+
+export type ZFSPoolStatus = 'ONLINE' | 'DEGRADED' | 'FAULTED' | 'OFFLINE' | 'REMOVED' | 'UNAVAIL';
+export type ZFSScrubState = 'none' | 'scanning' | 'finished' | 'canceled';
+
+export interface ZFSVdevModel {
+    id: number;
+    pool_guid: string;
+    parent_id?: number;
+
+    name: string;
+    type: ZFSVdevType;
+    status: string;
+    path: string;
+
+    read_errors: number;
+    write_errors: number;
+    checksum_errors: number;
+
+    children?: ZFSVdevModel[];
+
+    created_at: string;
+    updated_at: string;
+}
+
+export type ZFSVdevType = 'disk' | 'file' | 'mirror' | 'raidz1' | 'raidz2' | 'raidz3' | 'spare' | 'log' | 'cache' | 'special' | 'dedup';

--- a/webapp/frontend/src/app/core/models/zfs-pool-summary-model.ts
+++ b/webapp/frontend/src/app/core/models/zfs-pool-summary-model.ts
@@ -1,0 +1,31 @@
+// maps to API response for ZFS pool summary
+import { ZFSPoolModel } from './zfs-pool-model';
+
+export interface ZFSPoolSummaryModel {
+    pool: ZFSPoolModel;
+}
+
+export interface ZFSPoolSummaryResponseWrapper {
+    success: boolean;
+    data: {
+        summary: { [guid: string]: ZFSPoolSummaryModel };
+    };
+}
+
+export interface ZFSPoolDetailsResponseWrapper {
+    success: boolean;
+    data: {
+        pool: ZFSPoolModel;
+        metrics_history: ZFSPoolMetricsHistoryModel[];
+    };
+}
+
+export interface ZFSPoolMetricsHistoryModel {
+    date: string;
+    size: number;
+    allocated: number;
+    free: number;
+    capacity_percent: number;
+    fragmentation: number;
+    status: string;
+}

--- a/webapp/frontend/src/app/layout/common/zfs-pool-card/zfs-pool-card.component.html
+++ b/webapp/frontend/src/app/layout/common/zfs-pool-card/zfs-pool-card.component.html
@@ -1,0 +1,192 @@
+<div
+  [ngClass]="{
+    'border-green': getPoolStatus(poolSummary.pool) == 'passed',
+    'border-red': getPoolStatus(poolSummary.pool) == 'failed',
+    'border-yellow': getPoolStatus(poolSummary.pool) == 'unknown',
+    'text-disabled': poolSummary.pool.archived
+  }"
+  class="relative flex flex-col flex-auto p-6 pr-3 pb-3 bg-card rounded border-l-4 shadow-md overflow-hidden"
+>
+  <!-- Status watermark icon -->
+  <div class="absolute bottom-0 right-0 w-24 h-24 -m-6">
+    @if (getPoolStatus(poolSummary.pool) == 'passed') {
+      <mat-icon
+        class="icon-size-96 opacity-12 text-green"
+        [svgIcon]="'heroicons_outline:check-circle'"
+      ></mat-icon>
+    }
+    @if (getPoolStatus(poolSummary.pool) == 'failed') {
+      <mat-icon
+        class="icon-size-96 opacity-12 text-red"
+        [svgIcon]="'heroicons_outline:exclamation-circle'"
+      ></mat-icon>
+    }
+    @if (getPoolStatus(poolSummary.pool) == 'unknown') {
+      <mat-icon
+        class="icon-size-96 opacity-12 text-yellow"
+        [svgIcon]="'heroicons_outline:question-mark-circle'"
+      ></mat-icon>
+    }
+  </div>
+
+  <!-- Header -->
+  <div class="flex items-center">
+    <div class="flex flex-col">
+      <a
+        [routerLink]="'/zfs-pool/' + poolSummary.pool.guid"
+        class="font-bold text-md text-secondary uppercase tracking-wider"
+      >
+        {{ getPoolTitle(poolSummary.pool) }}
+        @if (poolSummary.pool.muted) {
+          <mat-icon
+            class="muted-icon ml-1"
+            [svgIcon]="'notifications_off'"
+          ></mat-icon>
+        }
+      </a>
+
+      @if (poolSummary.pool.updated_at) {
+        <div
+          [ngClass]="classPoolLastUpdatedOn(poolSummary.pool)"
+          class="font-medium text-sm"
+        >
+          Last Updated on
+          {{ poolSummary.pool.updated_at | date:'MMMM dd, yyyy - HH:mm' }}
+        </div>
+      }
+    </div>
+
+    <!-- Actions -->
+    @if (poolSummary.pool) {
+      <div class="ml-auto flex items-center">
+        @if (poolSummary.pool.archived) {
+          <mat-icon [svgIcon]="'archive'"></mat-icon>
+        }
+
+        <button
+          mat-icon-button
+          [matMenuTriggerFor]="poolActionsMenu"
+        >
+          <mat-icon [svgIcon]="'more_vert'"></mat-icon>
+        </button>
+
+        <mat-menu #poolActionsMenu="matMenu">
+          <a
+            mat-menu-item
+            [routerLink]="'/zfs-pool/' + poolSummary.pool.guid"
+          >
+            <span class="flex items-center">
+              <mat-icon
+                class="icon-size-20 mr-3"
+                [svgIcon]="'assessment'"
+              ></mat-icon>
+              <span>View Details</span>
+            </span>
+          </a>
+
+          <a
+            mat-menu-item
+            (click)="archivePool()"
+          >
+            <span class="flex items-center">
+              <mat-icon
+                class="icon-size-20 mr-3"
+                [svgIcon]="
+                  poolSummary.pool.archived
+                    ? 'unarchive'
+                    : 'archive'
+                "
+              ></mat-icon>
+              <span>
+                {{
+                  poolSummary.pool.archived
+                    ? 'Unarchive'
+                    : 'Archive'
+                }}
+                Pool
+              </span>
+            </span>
+          </a>
+
+          <a
+            mat-menu-item
+            (click)="deletePool()"
+          >
+            <span class="flex items-center">
+              <mat-icon
+                class="icon-size-20 mr-3"
+                [svgIcon]="'delete_forever'"
+              ></mat-icon>
+              <span>Delete Pool</span>
+            </span>
+          </a>
+        </mat-menu>
+      </div>
+    }
+  </div>
+
+  <!-- Metrics -->
+  <div class="flex flex-row flex-wrap mt-4 -mx-6">
+    <!-- Status -->
+    <div class="flex flex-col mx-6 my-3 xs:w-full">
+      <div class="font-semibold text-xs text-hint uppercase tracking-wider">
+        Status
+      </div>
+      <div
+        [ngClass]="getStatusColorClass(poolSummary.pool.status)"
+        class="mt-2 font-medium text-3xl leading-none"
+      >
+        {{ poolSummary.pool.status }}
+      </div>
+    </div>
+
+    <!-- Capacity -->
+    <div class="flex flex-col mx-6 my-3 xs:w-full">
+      <div class="font-semibold text-xs text-hint uppercase tracking-wider">
+        Capacity
+      </div>
+      <div class="mt-2 font-medium text-3xl leading-none">
+        {{ poolSummary.pool.capacity_percent }}%
+      </div>
+      <div class="mt-1 h-1 w-24 bg-gray-200 rounded overflow-hidden">
+        <div
+          [ngClass]="getCapacityPercentClass(poolSummary.pool.capacity_percent)"
+          class="h-full"
+          [style.width.%]="poolSummary.pool.capacity_percent"
+        ></div>
+      </div>
+    </div>
+
+    <!-- Size -->
+    <div class="flex flex-col mx-6 my-3 xs:w-full">
+      <div class="font-semibold text-xs text-hint uppercase tracking-wider">
+        Size
+      </div>
+      <div class="mt-2 font-medium text-3xl leading-none">
+        {{ poolSummary.pool.size | fileSize:config?.file_size_si_units }}
+      </div>
+    </div>
+
+    <!-- Last Scrub -->
+    <div class="flex flex-col mx-6 my-3 xs:w-full">
+      <div class="font-semibold text-xs text-hint uppercase tracking-wider">
+        Last Scrub
+      </div>
+      <div class="mt-2 font-medium text-3xl leading-none">
+        {{ getScrubStatusText(poolSummary.pool) }}
+      </div>
+    </div>
+
+    <!-- Errors -->
+    @if (getTotalErrors(poolSummary.pool) > 0) {
+      <div class="flex flex-col mx-6 my-3 xs:w-full">
+        <div class="font-semibold text-xs text-hint uppercase tracking-wider">
+          Errors
+        </div>
+        <div class="mt-2 font-medium text-3xl leading-none text-red">
+          {{ getTotalErrors(poolSummary.pool) }}
+        </div>
+      </div>
+    }
+  </div>
+</div>

--- a/webapp/frontend/src/app/layout/common/zfs-pool-card/zfs-pool-card.component.scss
+++ b/webapp/frontend/src/app/layout/common/zfs-pool-card/zfs-pool-card.component.scss
@@ -1,0 +1,8 @@
+:host {
+    .muted-icon {
+        vertical-align: middle;
+        font-size: 16px;
+        height: 16px;
+        width: 16px;
+    }
+}

--- a/webapp/frontend/src/app/layout/common/zfs-pool-card/zfs-pool-card.component.ts
+++ b/webapp/frontend/src/app/layout/common/zfs-pool-card/zfs-pool-card.component.ts
@@ -1,0 +1,143 @@
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import moment from 'moment';
+import { Subject } from 'rxjs';
+import { MatDialog as MatDialog } from '@angular/material/dialog';
+import { ZFSPoolSummaryModel } from 'app/core/models/zfs-pool-summary-model';
+import { ZFSPoolModel, ZFSPoolStatus } from 'app/core/models/zfs-pool-model';
+import { AppConfig } from 'app/core/config/app.config';
+import { ZFSPoolsService } from 'app/modules/zfs-pools/zfs-pools.service';
+
+@Component({
+    selector: 'app-zfs-pool-card',
+    templateUrl: './zfs-pool-card.component.html',
+    styleUrls: ['./zfs-pool-card.component.scss'],
+    standalone: false
+})
+export class ZFSPoolCardComponent implements OnInit {
+
+    constructor(
+        private _zfsPoolsService: ZFSPoolsService,
+        public dialog: MatDialog,
+    ) {
+        this._unsubscribeAll = new Subject();
+    }
+
+    @Input() poolSummary: ZFSPoolSummaryModel;
+    @Input() config: AppConfig;
+    @Output() poolArchived = new EventEmitter<string>();
+    @Output() poolUnarchived = new EventEmitter<string>();
+    @Output() poolDeleted = new EventEmitter<string>();
+
+    private _unsubscribeAll: Subject<void>;
+
+    ngOnInit(): void {
+    }
+
+    // -----------------------------------------------------------------------------------------------------
+    // @ Public methods
+    // -----------------------------------------------------------------------------------------------------
+
+    getPoolStatus(pool: ZFSPoolModel): 'passed' | 'failed' | 'unknown' {
+        if (!pool) {
+            return 'unknown';
+        }
+        switch (pool.status) {
+            case 'ONLINE':
+                return 'passed';
+            case 'DEGRADED':
+            case 'FAULTED':
+                return 'failed';
+            default:
+                return 'unknown';
+        }
+    }
+
+    getStatusColorClass(status: ZFSPoolStatus): string {
+        switch (status) {
+            case 'ONLINE':
+                return 'text-green';
+            case 'DEGRADED':
+                return 'text-yellow';
+            case 'FAULTED':
+            case 'UNAVAIL':
+            case 'OFFLINE':
+            case 'REMOVED':
+                return 'text-red';
+            default:
+                return '';
+        }
+    }
+
+    classPoolLastUpdatedOn(pool: ZFSPoolModel): string {
+        const poolStatus = this.getPoolStatus(pool);
+        if (poolStatus === 'failed') {
+            return 'text-red';
+        } else if (poolStatus === 'passed') {
+            if (moment().subtract(14, 'days').isBefore(pool.updated_at)) {
+                return 'text-green';
+            } else if (moment().subtract(1, 'months').isBefore(pool.updated_at)) {
+                return 'text-yellow';
+            } else {
+                return 'text-red';
+            }
+        } else {
+            return '';
+        }
+    }
+
+    getPoolTitle(pool: ZFSPoolModel): string {
+        if (pool.label) {
+            return pool.label;
+        }
+        return pool.name;
+    }
+
+    getCapacityPercentClass(percent: number): string {
+        if (percent >= 90) {
+            return 'bg-red-500';
+        } else if (percent >= 80) {
+            return 'bg-yellow-500';
+        } else {
+            return 'bg-green-500';
+        }
+    }
+
+    getScrubStatusText(pool: ZFSPoolModel): string {
+        switch (pool.scrub_state) {
+            case 'none':
+                return 'Never';
+            case 'scanning':
+                return `In Progress (${pool.scrub_percent}%)`;
+            case 'finished':
+                return moment(pool.scrub_end).fromNow();
+            case 'canceled':
+                return 'Canceled';
+            default:
+                return 'Unknown';
+        }
+    }
+
+    archivePool(): void {
+        if (this.poolSummary.pool.archived) {
+            this._zfsPoolsService.unarchivePool(this.poolSummary.pool.guid).subscribe(() => {
+                this.poolUnarchived.emit(this.poolSummary.pool.guid);
+            });
+        } else {
+            this._zfsPoolsService.archivePool(this.poolSummary.pool.guid).subscribe(() => {
+                this.poolArchived.emit(this.poolSummary.pool.guid);
+            });
+        }
+    }
+
+    deletePool(): void {
+        if (confirm(`Are you sure you want to delete pool "${this.getPoolTitle(this.poolSummary.pool)}"?`)) {
+            this._zfsPoolsService.deletePool(this.poolSummary.pool.guid).subscribe(() => {
+                this.poolDeleted.emit(this.poolSummary.pool.guid);
+            });
+        }
+    }
+
+    getTotalErrors(pool: ZFSPoolModel): number {
+        return pool.total_read_errors + pool.total_write_errors + pool.total_checksum_errors;
+    }
+}

--- a/webapp/frontend/src/app/layout/common/zfs-pool-card/zfs-pool-card.module.ts
+++ b/webapp/frontend/src/app/layout/common/zfs-pool-card/zfs-pool-card.module.ts
@@ -1,0 +1,29 @@
+import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { CommonModule } from '@angular/common';
+import { MatButtonModule as MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatMenuModule as MatMenuModule } from '@angular/material/menu';
+import { MatTooltipModule as MatTooltipModule } from '@angular/material/tooltip';
+import { ZFSPoolCardComponent } from './zfs-pool-card.component';
+import { SharedModule } from 'app/shared/shared.module';
+
+@NgModule({
+    declarations: [
+        ZFSPoolCardComponent
+    ],
+    imports: [
+        CommonModule,
+        RouterModule,
+        MatButtonModule,
+        MatIconModule,
+        MatMenuModule,
+        MatTooltipModule,
+        SharedModule
+    ],
+    exports: [
+        ZFSPoolCardComponent
+    ]
+})
+export class ZFSPoolCardModule {
+}

--- a/webapp/frontend/src/app/layout/layouts/horizontal/material/material.component.html
+++ b/webapp/frontend/src/app/layout/layouts/horizontal/material/material.component.html
@@ -38,6 +38,14 @@
               </a>
             }
 
+            <!-- Navigation Links -->
+            @if (!isScreenSmall) {
+              <nav class="nav-links ml-8">
+                <a routerLink="/dashboard" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="nav-link">S.M.A.R.T</a>
+                <a routerLink="/zfs-pools" routerLinkActive="active" class="nav-link">ZFS Pools</a>
+              </nav>
+            }
+
             <!-- Spacer -->
             <div class="spacer"></div>
             <code>{{appVersion}}</code>

--- a/webapp/frontend/src/app/layout/layouts/horizontal/material/material.component.scss
+++ b/webapp/frontend/src/app/layout/layouts/horizontal/material/material.component.scss
@@ -99,6 +99,29 @@ material-layout {
                     }
                 }
 
+                .nav-links {
+                    display: flex;
+                    align-items: center;
+                    gap: 8px;
+
+                    .nav-link {
+                        padding: 8px 16px;
+                        border-radius: 6px;
+                        font-weight: 500;
+                        text-decoration: none;
+                        transition: background-color 0.2s ease;
+
+                        &:hover {
+                            background-color: rgba(0, 0, 0, 0.05);
+                        }
+
+                        &.active {
+                            background-color: rgba(102, 126, 234, 0.15);
+                            color: #4f5fd9;
+                        }
+                    }
+                }
+
                 .navigation-toggle-button {
                     margin-right: 8px;
                 }

--- a/webapp/frontend/src/app/modules/zfs-pool-detail/zfs-pool-detail.component.html
+++ b/webapp/frontend/src/app/modules/zfs-pool-detail/zfs-pool-detail.component.html
@@ -1,0 +1,191 @@
+@if (pool) {
+  <div class="flex flex-col flex-auto w-full p-8 xs:p-2">
+    <!-- Header -->
+    <div class="flex items-center justify-between mb-8">
+      <div class="flex items-center">
+        <button
+          mat-icon-button
+          (click)="goBack()"
+          class="mr-4">
+          <mat-icon [svgIcon]="'heroicons_outline:arrow-left'"></mat-icon>
+        </button>
+        <div>
+          <h2 class="m-0">{{ getPoolTitle() }}</h2>
+          <div class="text-secondary tracking-tight">{{ pool.name }} ({{ pool.guid }})</div>
+        </div>
+      </div>
+
+      <div class="flex items-center">
+        <button
+          mat-stroked-button
+          (click)="toggleMuted()"
+          [matTooltip]="pool.muted ? 'Unmute notifications' : 'Mute notifications'">
+          <mat-icon
+            class="icon-size-20"
+            [svgIcon]="pool.muted ? 'notifications_off' : 'notifications'">
+          </mat-icon>
+          <span class="ml-2">{{ pool.muted ? 'Unmute' : 'Mute' }}</span>
+        </button>
+      </div>
+    </div>
+
+    <!-- Pool Overview -->
+    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
+      <!-- Status Card -->
+      <treo-card class="p-6">
+        <div class="font-semibold text-xs text-hint uppercase tracking-wider mb-2">Status</div>
+        <div
+          [ngClass]="getStatusColorClass(pool.status)"
+          class="font-bold text-3xl">
+          {{ pool.status }}
+        </div>
+      </treo-card>
+
+      <!-- Capacity Card -->
+      <treo-card class="p-6">
+        <div class="font-semibold text-xs text-hint uppercase tracking-wider mb-2">Capacity</div>
+        <div class="font-bold text-3xl">{{ pool.capacity_percent }}%</div>
+        <div class="mt-2 h-2 bg-gray-200 rounded overflow-hidden">
+          <div
+            [ngClass]="{
+              'bg-green-500': pool.capacity_percent < 80,
+              'bg-yellow-500': pool.capacity_percent >= 80 && pool.capacity_percent < 90,
+              'bg-red-500': pool.capacity_percent >= 90
+            }"
+            class="h-full"
+            [style.width.%]="pool.capacity_percent">
+          </div>
+        </div>
+        <div class="text-sm text-hint mt-2">
+          {{ pool.allocated | fileSize:config?.file_size_si_units }} / {{ pool.size | fileSize:config?.file_size_si_units }}
+        </div>
+      </treo-card>
+
+      <!-- Fragmentation Card -->
+      <treo-card class="p-6">
+        <div class="font-semibold text-xs text-hint uppercase tracking-wider mb-2">Fragmentation</div>
+        <div class="font-bold text-3xl">{{ pool.fragmentation }}%</div>
+      </treo-card>
+
+      <!-- Scrub Status Card -->
+      <treo-card class="p-6">
+        <div class="font-semibold text-xs text-hint uppercase tracking-wider mb-2">Last Scrub</div>
+        @switch (pool.scrub_state) {
+          @case ('none') {
+            <div class="font-bold text-3xl text-hint">Never</div>
+          }
+          @case ('scanning') {
+            <div class="font-bold text-3xl text-yellow">In Progress</div>
+            <div class="text-sm text-hint mt-2">{{ pool.scrub_percent }}% complete</div>
+          }
+          @case ('finished') {
+            <div class="font-bold text-3xl text-green">Completed</div>
+            <div class="text-sm text-hint mt-2">{{ pool.scrub_end | date:'MMM dd, yyyy HH:mm' }}</div>
+            @if (pool.scrub_errors > 0) {
+              <div class="text-sm text-red mt-1">{{ pool.scrub_errors }} errors found</div>
+            }
+          }
+          @case ('canceled') {
+            <div class="font-bold text-3xl text-yellow">Canceled</div>
+          }
+        }
+      </treo-card>
+    </div>
+
+    <!-- Error Summary -->
+    @if (pool.total_read_errors > 0 || pool.total_write_errors > 0 || pool.total_checksum_errors > 0) {
+      <treo-card class="p-6 mb-8">
+        <div class="font-semibold text-lg text-red mb-4">Error Summary</div>
+        <div class="grid grid-cols-3 gap-4">
+          <div>
+            <div class="font-semibold text-xs text-hint uppercase tracking-wider">Read Errors</div>
+            <div class="font-bold text-2xl text-red">{{ pool.total_read_errors }}</div>
+          </div>
+          <div>
+            <div class="font-semibold text-xs text-hint uppercase tracking-wider">Write Errors</div>
+            <div class="font-bold text-2xl text-red">{{ pool.total_write_errors }}</div>
+          </div>
+          <div>
+            <div class="font-semibold text-xs text-hint uppercase tracking-wider">Checksum Errors</div>
+            <div class="font-bold text-2xl text-red">{{ pool.total_checksum_errors }}</div>
+          </div>
+        </div>
+      </treo-card>
+    }
+
+    <!-- Vdev Tree -->
+    <treo-card class="p-6 mb-8">
+      <div class="font-semibold text-lg mb-4">Virtual Device Tree</div>
+      @if (pool.vdevs && pool.vdevs.length > 0) {
+        <div class="vdev-tree">
+          @for (vdev of pool.vdevs; track vdev.id) {
+            <ng-container *ngTemplateOutlet="vdevNode; context: { vdev: vdev, depth: 0 }"></ng-container>
+          }
+        </div>
+      } @else {
+        <div class="text-hint">No vdev information available</div>
+      }
+    </treo-card>
+
+    <!-- Capacity History Chart -->
+    @if (capacityOptions) {
+      <treo-card class="p-6">
+        <div class="font-semibold text-lg mb-4">Capacity History</div>
+        <div class="h-64">
+          <apx-chart
+            class="flex-auto w-full h-full"
+            [chart]="capacityOptions.chart"
+            [colors]="capacityOptions.colors"
+            [fill]="capacityOptions.fill"
+            [series]="capacityOptions.series"
+            [stroke]="capacityOptions.stroke"
+            [tooltip]="capacityOptions.tooltip"
+            [xaxis]="capacityOptions.xaxis"
+            [yaxis]="capacityOptions.yaxis">
+          </apx-chart>
+        </div>
+      </treo-card>
+    }
+  </div>
+} @else {
+  <div class="flex items-center justify-center h-full">
+    <div class="text-hint">Loading pool details...</div>
+  </div>
+}
+
+<!-- Vdev Node Template -->
+<ng-template #vdevNode let-vdev="vdev" let-depth="depth">
+  <div
+    class="vdev-item flex items-center py-2 px-4 rounded hover:bg-hover"
+    [style.padding-left.px]="depth * 24 + 16">
+    <mat-icon
+      class="icon-size-20 mr-3"
+      [svgIcon]="getVdevIcon(vdev.type)">
+    </mat-icon>
+    <div class="flex-1">
+      <div class="flex items-center">
+        <span class="font-medium">{{ vdev.name }}</span>
+        <span class="ml-2 text-xs text-hint uppercase">({{ vdev.type }})</span>
+        <span
+          [ngClass]="getVdevStatusClass(vdev.status)"
+          class="ml-2 text-sm font-medium">
+          {{ vdev.status }}
+        </span>
+      </div>
+      @if (vdev.path) {
+        <div class="text-xs text-hint">{{ vdev.path }}</div>
+      }
+      @if (hasErrors(vdev)) {
+        <div class="text-xs text-red mt-1">
+          R: {{ vdev.read_errors }} / W: {{ vdev.write_errors }} / C: {{ vdev.checksum_errors }}
+        </div>
+      }
+    </div>
+  </div>
+
+  @if (vdev.children && vdev.children.length > 0) {
+    @for (child of vdev.children; track child.id) {
+      <ng-container *ngTemplateOutlet="vdevNode; context: { vdev: child, depth: depth + 1 }"></ng-container>
+    }
+  }
+</ng-template>

--- a/webapp/frontend/src/app/modules/zfs-pool-detail/zfs-pool-detail.component.scss
+++ b/webapp/frontend/src/app/modules/zfs-pool-detail/zfs-pool-detail.component.scss
@@ -1,0 +1,14 @@
+:host {
+    display: flex;
+    flex: 1 1 auto;
+
+    .vdev-tree {
+        .vdev-item {
+            border-left: 2px solid transparent;
+
+            &:hover {
+                border-left-color: var(--primary-color, #667eea);
+            }
+        }
+    }
+}

--- a/webapp/frontend/src/app/modules/zfs-pool-detail/zfs-pool-detail.component.ts
+++ b/webapp/frontend/src/app/modules/zfs-pool-detail/zfs-pool-detail.component.ts
@@ -1,0 +1,217 @@
+import {
+    ChangeDetectionStrategy,
+    Component,
+    OnDestroy,
+    OnInit,
+    ViewEncapsulation
+} from '@angular/core';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+import { ApexOptions } from 'ng-apexcharts';
+import { ZFSPoolDetailService } from 'app/modules/zfs-pool-detail/zfs-pool-detail.service';
+import { AppConfig } from 'app/core/config/app.config';
+import { ScrutinyConfigService } from 'app/core/config/scrutiny-config.service';
+import { Router } from '@angular/router';
+import { ZFSPoolModel, ZFSPoolStatus, ZFSVdevModel } from 'app/core/models/zfs-pool-model';
+import { ZFSPoolMetricsHistoryModel } from 'app/core/models/zfs-pool-summary-model';
+
+@Component({
+    selector: 'zfs-pool-detail',
+    templateUrl: './zfs-pool-detail.component.html',
+    styleUrls: ['./zfs-pool-detail.component.scss'],
+    encapsulation: ViewEncapsulation.None,
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    standalone: false
+})
+export class ZFSPoolDetailComponent implements OnInit, OnDestroy {
+    pool: ZFSPoolModel;
+    metricsHistory: ZFSPoolMetricsHistoryModel[];
+    capacityOptions: ApexOptions;
+    config: AppConfig;
+
+    private _unsubscribeAll: Subject<void>;
+
+    constructor(
+        private _zfsPoolDetailService: ZFSPoolDetailService,
+        private _configService: ScrutinyConfigService,
+        private router: Router,
+    ) {
+        this._unsubscribeAll = new Subject();
+    }
+
+    ngOnInit(): void {
+        // Subscribe to config changes
+        this._configService.config$
+            .pipe(takeUntil(this._unsubscribeAll))
+            .subscribe((config: AppConfig) => {
+                this.config = config;
+            });
+
+        // Get the data
+        this._zfsPoolDetailService.data$
+            .pipe(takeUntil(this._unsubscribeAll))
+            .subscribe((data) => {
+                if (data) {
+                    this.pool = data.data.pool;
+                    this.metricsHistory = data.data.metrics_history;
+                    this._prepareChartData();
+                }
+            });
+    }
+
+    ngOnDestroy(): void {
+        this._unsubscribeAll.next();
+        this._unsubscribeAll.complete();
+    }
+
+    // -----------------------------------------------------------------------------------------------------
+    // @ Private methods
+    // -----------------------------------------------------------------------------------------------------
+
+    private _prepareChartData(): void {
+        if (!this.metricsHistory || this.metricsHistory.length === 0) {
+            return;
+        }
+
+        const capacityData = this.metricsHistory.map(m => ({
+            x: new Date(m.date),
+            y: m.capacity_percent
+        }));
+
+        this.capacityOptions = {
+            chart: {
+                animations: {
+                    speed: 400,
+                    animateGradually: {
+                        enabled: false
+                    }
+                },
+                fontFamily: 'inherit',
+                foreColor: 'inherit',
+                width: '100%',
+                height: '100%',
+                type: 'area',
+                sparkline: {
+                    enabled: true
+                }
+            },
+            colors: ['#667eea'],
+            fill: {
+                colors: ['#b2bef4'],
+                opacity: 0.5,
+                type: 'gradient'
+            },
+            series: [{
+                name: 'Capacity',
+                data: capacityData
+            }],
+            stroke: {
+                curve: 'smooth',
+                width: 2
+            },
+            tooltip: {
+                theme: 'dark',
+                x: {
+                    format: 'MMM dd, yyyy HH:mm:ss'
+                },
+                y: {
+                    formatter: (value) => `${value}%`
+                }
+            },
+            xaxis: {
+                type: 'datetime',
+                labels: {
+                    datetimeUTC: false
+                }
+            },
+            yaxis: {
+                min: 0,
+                max: 100
+            }
+        };
+    }
+
+    // -----------------------------------------------------------------------------------------------------
+    // @ Public methods
+    // -----------------------------------------------------------------------------------------------------
+
+    getPoolTitle(): string {
+        if (this.pool?.label) {
+            return this.pool.label;
+        }
+        return this.pool?.name || 'Unknown Pool';
+    }
+
+    getStatusColorClass(status: ZFSPoolStatus): string {
+        switch (status) {
+            case 'ONLINE':
+                return 'text-green';
+            case 'DEGRADED':
+                return 'text-yellow';
+            case 'FAULTED':
+            case 'UNAVAIL':
+            case 'OFFLINE':
+            case 'REMOVED':
+                return 'text-red';
+            default:
+                return '';
+        }
+    }
+
+    getVdevIcon(type: string): string {
+        switch (type) {
+            case 'disk':
+            case 'file':
+                return 'heroicons_outline:server';
+            case 'mirror':
+                return 'heroicons_outline:document-duplicate';
+            case 'raidz1':
+            case 'raidz2':
+            case 'raidz3':
+                return 'heroicons_outline:database';
+            case 'spare':
+                return 'heroicons_outline:shield-check';
+            case 'log':
+                return 'heroicons_outline:document-text';
+            case 'cache':
+                return 'heroicons_outline:lightning-bolt';
+            default:
+                return 'heroicons_outline:server';
+        }
+    }
+
+    getVdevStatusClass(status: string): string {
+        switch (status) {
+            case 'ONLINE':
+                return 'text-green';
+            case 'DEGRADED':
+                return 'text-yellow';
+            case 'FAULTED':
+            case 'UNAVAIL':
+            case 'OFFLINE':
+            case 'REMOVED':
+                return 'text-red';
+            default:
+                return '';
+        }
+    }
+
+    hasErrors(vdev: ZFSVdevModel): boolean {
+        return vdev.read_errors > 0 || vdev.write_errors > 0 || vdev.checksum_errors > 0;
+    }
+
+    toggleMuted(): void {
+        const newMutedState = !this.pool.muted;
+        this._zfsPoolDetailService.setMuted(this.pool.guid, newMutedState).subscribe(() => {
+            this.pool.muted = newMutedState;
+        });
+    }
+
+    goBack(): void {
+        this.router.navigate(['/zfs-pools']);
+    }
+
+    trackByFn(index: number, item: any): any {
+        return item.id || index;
+    }
+}

--- a/webapp/frontend/src/app/modules/zfs-pool-detail/zfs-pool-detail.module.ts
+++ b/webapp/frontend/src/app/modules/zfs-pool-detail/zfs-pool-detail.module.ts
@@ -1,0 +1,37 @@
+import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { SharedModule } from 'app/shared/shared.module';
+import { ZFSPoolDetailComponent } from 'app/modules/zfs-pool-detail/zfs-pool-detail.component';
+import { zfsPoolDetailRoutes } from 'app/modules/zfs-pool-detail/zfs-pool-detail.routing';
+import { MatButtonModule as MatButtonModule } from '@angular/material/button';
+import { MatDividerModule } from '@angular/material/divider';
+import { MatIconModule } from '@angular/material/icon';
+import { MatMenuModule as MatMenuModule } from '@angular/material/menu';
+import { MatProgressBarModule as MatProgressBarModule } from '@angular/material/progress-bar';
+import { MatSortModule } from '@angular/material/sort';
+import { MatTableModule as MatTableModule } from '@angular/material/table';
+import { MatTooltipModule as MatTooltipModule } from '@angular/material/tooltip';
+import { NgApexchartsModule } from 'ng-apexcharts';
+import { TreoCardModule } from '@treo/components/card';
+
+@NgModule({
+    declarations: [
+        ZFSPoolDetailComponent
+    ],
+    imports: [
+        RouterModule.forChild(zfsPoolDetailRoutes),
+        MatButtonModule,
+        MatDividerModule,
+        MatTooltipModule,
+        MatIconModule,
+        MatMenuModule,
+        MatProgressBarModule,
+        MatSortModule,
+        MatTableModule,
+        NgApexchartsModule,
+        TreoCardModule,
+        SharedModule,
+    ]
+})
+export class ZFSPoolDetailModule {
+}

--- a/webapp/frontend/src/app/modules/zfs-pool-detail/zfs-pool-detail.resolvers.ts
+++ b/webapp/frontend/src/app/modules/zfs-pool-detail/zfs-pool-detail.resolvers.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@angular/core';
+import { ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
+import { Observable } from 'rxjs';
+import { ZFSPoolDetailService } from 'app/modules/zfs-pool-detail/zfs-pool-detail.service';
+import { ZFSPoolDetailsResponseWrapper } from 'app/core/models/zfs-pool-summary-model';
+
+@Injectable({
+    providedIn: 'root'
+})
+export class ZFSPoolDetailResolver {
+    constructor(
+        private _zfsPoolDetailService: ZFSPoolDetailService
+    ) {
+    }
+
+    resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<ZFSPoolDetailsResponseWrapper> {
+        return this._zfsPoolDetailService.getData(route.params.guid);
+    }
+}

--- a/webapp/frontend/src/app/modules/zfs-pool-detail/zfs-pool-detail.routing.ts
+++ b/webapp/frontend/src/app/modules/zfs-pool-detail/zfs-pool-detail.routing.ts
@@ -1,0 +1,13 @@
+import { Route } from '@angular/router';
+import { ZFSPoolDetailComponent } from 'app/modules/zfs-pool-detail/zfs-pool-detail.component';
+import { ZFSPoolDetailResolver } from './zfs-pool-detail.resolvers';
+
+export const zfsPoolDetailRoutes: Route[] = [
+    {
+        path: '',
+        component: ZFSPoolDetailComponent,
+        resolve: {
+            pool: ZFSPoolDetailResolver
+        }
+    }
+];

--- a/webapp/frontend/src/app/modules/zfs-pool-detail/zfs-pool-detail.service.ts
+++ b/webapp/frontend/src/app/modules/zfs-pool-detail/zfs-pool-detail.service.ts
@@ -1,0 +1,49 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { BehaviorSubject, Observable } from 'rxjs';
+import { tap } from 'rxjs/operators';
+import { getBasePath } from 'app/app.routing';
+import { ZFSPoolDetailsResponseWrapper } from 'app/core/models/zfs-pool-summary-model';
+
+@Injectable({
+    providedIn: 'root'
+})
+export class ZFSPoolDetailService {
+    // Observables
+    private _data: BehaviorSubject<ZFSPoolDetailsResponseWrapper>;
+
+    constructor(
+        private _httpClient: HttpClient
+    ) {
+        this._data = new BehaviorSubject(null);
+    }
+
+    // -----------------------------------------------------------------------------------------------------
+    // @ Accessors
+    // -----------------------------------------------------------------------------------------------------
+
+    get data$(): Observable<ZFSPoolDetailsResponseWrapper> {
+        return this._data.asObservable();
+    }
+
+    // -----------------------------------------------------------------------------------------------------
+    // @ Public methods
+    // -----------------------------------------------------------------------------------------------------
+
+    getData(guid: string): Observable<ZFSPoolDetailsResponseWrapper> {
+        return this._httpClient.get(getBasePath() + `/api/zfs/pool/${guid}/details`).pipe(
+            tap((response: ZFSPoolDetailsResponseWrapper) => {
+                this._data.next(response);
+            })
+        );
+    }
+
+    setMuted(guid: string, muted: boolean): Observable<any> {
+        const action = muted ? 'mute' : 'unmute';
+        return this._httpClient.post(getBasePath() + `/api/zfs/pool/${guid}/${action}`, {});
+    }
+
+    setLabel(guid: string, label: string): Observable<any> {
+        return this._httpClient.post(getBasePath() + `/api/zfs/pool/${guid}/label`, { label });
+    }
+}

--- a/webapp/frontend/src/app/modules/zfs-pools/zfs-pools.component.html
+++ b/webapp/frontend/src/app/modules/zfs-pools/zfs-pools.component.html
@@ -1,0 +1,99 @@
+@if (summaryData) {
+  <div>
+    <div class="flex flex-col flex-auto w-full p-8 xs:p-2">
+      <div class="flex flex-wrap w-full">
+
+        <!-- Header -->
+        <div class="flex items-center justify-between w-full my-4 px-4 xs:pr-0">
+          <div class="mr-6">
+            <h2 class="m-0">ZFS Pools</h2>
+            <div class="text-secondary tracking-tight">ZFS pool health at a glance</div>
+          </div>
+
+          <!-- Action buttons (desktop) -->
+          <div class="flex items-center">
+            <button
+              class="xs:hidden"
+              mat-stroked-button
+              [color]="showArchived ? 'primary' : null"
+              (click)="showArchived = !showArchived">
+              <mat-icon
+                class="icon-size-20"
+                [color]="showArchived ? 'primary' : null"
+                [svgIcon]="'archive'">
+              </mat-icon>
+              <span class="ml-2">Archived</span>
+            </button>
+
+            <!-- Actions menu (mobile) -->
+            <div class="hidden xs:flex">
+              <button
+                mat-icon-button
+                [matMenuTriggerFor]="actionsMenu">
+                <mat-icon [svgIcon]="'more_vert'"></mat-icon>
+              </button>
+
+              <mat-menu #actionsMenu="matMenu">
+                <button mat-menu-item (click)="showArchived = !showArchived">
+                  <mat-icon
+                    class="icon-size-20"
+                    [color]="showArchived ? 'primary' : null"
+                    [svgIcon]="'archive'">
+                  </mat-icon>
+                  <span class="ml-2">Archived</span>
+                </button>
+              </mat-menu>
+            </div>
+          </div>
+        </div>
+
+        <!-- Pool Groups by Host -->
+        @for (hostId of hostGroups | keyvalue; track hostId) {
+          <div class="flex flex-wrap w-full">
+            @if (hostId.key) {
+              <h3 class="ml-4">{{ hostId.key }}</h3>
+            }
+
+            <div class="flex flex-wrap w-full">
+              @for (poolSummary of poolSummariesForHostGroup(hostId.value); track poolSummary) {
+                @if (showArchived || !poolSummary.pool.archived) {
+                  <app-zfs-pool-card
+                    class="flex gt-sm:w-1/2 min-w-80 p-4"
+                    [poolSummary]="poolSummary"
+                    [config]="config"
+                    (poolArchived)="onPoolArchived($event)"
+                    (poolUnarchived)="onPoolUnarchived($event)"
+                    (poolDeleted)="onPoolDeleted($event)">
+                  </app-zfs-pool-card>
+                }
+              }
+            </div>
+          </div>
+        }
+
+      </div>
+    </div>
+  </div>
+} @else {
+  <div class="dashboard-placeholder content-layout fullwidth-basic-content-scroll">
+    <img
+      class="image"
+      src="assets/images/dashboard-placeholder.png">
+
+    <h1>No ZFS Pools Detected!</h1>
+
+    <p style="max-width:700px;">
+      Scrutiny includes a ZFS Collector agent that you must run on systems with ZFS pools.
+      The ZFS Collector is responsible for detecting ZFS pools and
+      collecting health metrics on a configurable schedule.
+    </p>
+
+    <p>
+      <br />
+      You can trigger the ZFS Collector manually by running the following command,
+      then refreshing this page:
+    </p>
+
+    <code>scrutiny-collector-zfs run</code>
+  </div>
+}

--- a/webapp/frontend/src/app/modules/zfs-pools/zfs-pools.component.scss
+++ b/webapp/frontend/src/app/modules/zfs-pools/zfs-pools.component.scss
@@ -1,0 +1,24 @@
+:host {
+    display: flex;
+    flex: 1 1 auto;
+
+    .dashboard-placeholder {
+        display: flex;
+        flex: 1;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+        text-align: center;
+
+        .image {
+            max-width: 300px;
+        }
+
+        code {
+            padding: 10px 20px;
+            background: #2d2d2d;
+            color: white;
+            display: block;
+        }
+    }
+}

--- a/webapp/frontend/src/app/modules/zfs-pools/zfs-pools.component.ts
+++ b/webapp/frontend/src/app/modules/zfs-pools/zfs-pools.component.ts
@@ -1,0 +1,110 @@
+import {
+    ChangeDetectionStrategy,
+    Component,
+    OnDestroy,
+    OnInit,
+    ViewEncapsulation
+} from '@angular/core';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+import { ZFSPoolsService } from 'app/modules/zfs-pools/zfs-pools.service';
+import { AppConfig } from 'app/core/config/app.config';
+import { ScrutinyConfigService } from 'app/core/config/scrutiny-config.service';
+import { Router } from '@angular/router';
+import { ZFSPoolSummaryModel } from 'app/core/models/zfs-pool-summary-model';
+
+@Component({
+    selector: 'zfs-pools',
+    templateUrl: './zfs-pools.component.html',
+    styleUrls: ['./zfs-pools.component.scss'],
+    encapsulation: ViewEncapsulation.None,
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    standalone: false
+})
+export class ZFSPoolsComponent implements OnInit, OnDestroy {
+    summaryData: { [guid: string]: ZFSPoolSummaryModel };
+    hostGroups: { [hostId: string]: string[] } = {};
+    config: AppConfig;
+    showArchived: boolean;
+
+    private _unsubscribeAll: Subject<void>;
+
+    constructor(
+        private _zfsPoolsService: ZFSPoolsService,
+        private _configService: ScrutinyConfigService,
+        private router: Router,
+    ) {
+        this._unsubscribeAll = new Subject();
+    }
+
+    ngOnInit(): void {
+        // Subscribe to config changes
+        this._configService.config$
+            .pipe(takeUntil(this._unsubscribeAll))
+            .subscribe((config: AppConfig) => {
+                const oldConfig = JSON.stringify(this.config);
+                const newConfig = JSON.stringify(config);
+
+                if (oldConfig !== newConfig) {
+                    this.config = config;
+                    if (oldConfig) {
+                        this.refreshComponent();
+                    }
+                }
+            });
+
+        // Get the data
+        this._zfsPoolsService.data$
+            .pipe(takeUntil(this._unsubscribeAll))
+            .subscribe((data) => {
+                this.summaryData = data;
+
+                // Generate group data by host
+                this.hostGroups = {};
+                for (const guid in this.summaryData) {
+                    const hostId = this.summaryData[guid].pool.host_id;
+                    const hostPoolList = this.hostGroups[hostId] || [];
+                    hostPoolList.push(guid);
+                    this.hostGroups[hostId] = hostPoolList;
+                }
+            });
+    }
+
+    ngOnDestroy(): void {
+        this._unsubscribeAll.next();
+        this._unsubscribeAll.complete();
+    }
+
+    private refreshComponent(): void {
+        const currentUrl = this.router.url;
+        this.router.routeReuseStrategy.shouldReuseRoute = () => false;
+        this.router.onSameUrlNavigation = 'reload';
+        this.router.navigate([currentUrl]);
+    }
+
+    poolSummariesForHostGroup(hostGroupGUIDs: string[]): ZFSPoolSummaryModel[] {
+        const poolSummaries: ZFSPoolSummaryModel[] = [];
+        for (const guid of hostGroupGUIDs) {
+            if (this.summaryData[guid]) {
+                poolSummaries.push(this.summaryData[guid]);
+            }
+        }
+        return poolSummaries;
+    }
+
+    onPoolDeleted(guid: string): void {
+        delete this.summaryData[guid];
+    }
+
+    onPoolArchived(guid: string): void {
+        this.summaryData[guid].pool.archived = true;
+    }
+
+    onPoolUnarchived(guid: string): void {
+        this.summaryData[guid].pool.archived = false;
+    }
+
+    trackByFn(index: number, item: any): any {
+        return item.id || index;
+    }
+}

--- a/webapp/frontend/src/app/modules/zfs-pools/zfs-pools.module.ts
+++ b/webapp/frontend/src/app/modules/zfs-pools/zfs-pools.module.ts
@@ -1,0 +1,35 @@
+import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { SharedModule } from 'app/shared/shared.module';
+import { ZFSPoolsComponent } from 'app/modules/zfs-pools/zfs-pools.component';
+import { zfsPoolsRoutes } from 'app/modules/zfs-pools/zfs-pools.routing';
+import { MatButtonModule as MatButtonModule } from '@angular/material/button';
+import { MatDividerModule } from '@angular/material/divider';
+import { MatIconModule } from '@angular/material/icon';
+import { MatMenuModule as MatMenuModule } from '@angular/material/menu';
+import { MatProgressBarModule as MatProgressBarModule } from '@angular/material/progress-bar';
+import { MatSortModule } from '@angular/material/sort';
+import { MatTableModule as MatTableModule } from '@angular/material/table';
+import { MatTooltipModule as MatTooltipModule } from '@angular/material/tooltip';
+import { ZFSPoolCardModule } from 'app/layout/common/zfs-pool-card/zfs-pool-card.module';
+
+@NgModule({
+    declarations: [
+        ZFSPoolsComponent
+    ],
+    imports: [
+        RouterModule.forChild(zfsPoolsRoutes),
+        MatButtonModule,
+        MatDividerModule,
+        MatTooltipModule,
+        MatIconModule,
+        MatMenuModule,
+        MatProgressBarModule,
+        MatSortModule,
+        MatTableModule,
+        SharedModule,
+        ZFSPoolCardModule
+    ]
+})
+export class ZFSPoolsModule {
+}

--- a/webapp/frontend/src/app/modules/zfs-pools/zfs-pools.resolvers.ts
+++ b/webapp/frontend/src/app/modules/zfs-pools/zfs-pools.resolvers.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@angular/core';
+import { ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
+import { Observable } from 'rxjs';
+import { ZFSPoolsService } from 'app/modules/zfs-pools/zfs-pools.service';
+import { ZFSPoolSummaryModel } from 'app/core/models/zfs-pool-summary-model';
+
+@Injectable({
+    providedIn: 'root'
+})
+export class ZFSPoolsResolver {
+    constructor(
+        private _zfsPoolsService: ZFSPoolsService
+    ) {
+    }
+
+    resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<{ [guid: string]: ZFSPoolSummaryModel }> {
+        return this._zfsPoolsService.getSummaryData();
+    }
+}

--- a/webapp/frontend/src/app/modules/zfs-pools/zfs-pools.routing.ts
+++ b/webapp/frontend/src/app/modules/zfs-pools/zfs-pools.routing.ts
@@ -1,0 +1,13 @@
+import { Route } from '@angular/router';
+import { ZFSPoolsComponent } from 'app/modules/zfs-pools/zfs-pools.component';
+import { ZFSPoolsResolver } from 'app/modules/zfs-pools/zfs-pools.resolvers';
+
+export const zfsPoolsRoutes: Route[] = [
+    {
+        path: '',
+        component: ZFSPoolsComponent,
+        resolve: {
+            pools: ZFSPoolsResolver
+        }
+    }
+];

--- a/webapp/frontend/src/app/modules/zfs-pools/zfs-pools.service.ts
+++ b/webapp/frontend/src/app/modules/zfs-pools/zfs-pools.service.ts
@@ -1,0 +1,67 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { BehaviorSubject, Observable } from 'rxjs';
+import { map, tap } from 'rxjs/operators';
+import { getBasePath } from 'app/app.routing';
+import { ZFSPoolSummaryModel, ZFSPoolSummaryResponseWrapper } from 'app/core/models/zfs-pool-summary-model';
+
+@Injectable({
+    providedIn: 'root'
+})
+export class ZFSPoolsService {
+    // Observables
+    private _data: BehaviorSubject<{ [guid: string]: ZFSPoolSummaryModel }>;
+
+    constructor(
+        private _httpClient: HttpClient
+    ) {
+        this._data = new BehaviorSubject(null);
+    }
+
+    // -----------------------------------------------------------------------------------------------------
+    // @ Accessors
+    // -----------------------------------------------------------------------------------------------------
+
+    get data$(): Observable<{ [guid: string]: ZFSPoolSummaryModel }> {
+        return this._data.asObservable();
+    }
+
+    // -----------------------------------------------------------------------------------------------------
+    // @ Public methods
+    // -----------------------------------------------------------------------------------------------------
+
+    getSummaryData(): Observable<{ [guid: string]: ZFSPoolSummaryModel }> {
+        return this._httpClient.get(getBasePath() + '/api/zfs/summary').pipe(
+            map((response: ZFSPoolSummaryResponseWrapper) => {
+                return response.data.summary;
+            }),
+            tap((response: { [guid: string]: ZFSPoolSummaryModel }) => {
+                this._data.next(response);
+            })
+        );
+    }
+
+    archivePool(guid: string): Observable<any> {
+        return this._httpClient.post(getBasePath() + `/api/zfs/pool/${guid}/archive`, {});
+    }
+
+    unarchivePool(guid: string): Observable<any> {
+        return this._httpClient.post(getBasePath() + `/api/zfs/pool/${guid}/unarchive`, {});
+    }
+
+    mutePool(guid: string): Observable<any> {
+        return this._httpClient.post(getBasePath() + `/api/zfs/pool/${guid}/mute`, {});
+    }
+
+    unmutePool(guid: string): Observable<any> {
+        return this._httpClient.post(getBasePath() + `/api/zfs/pool/${guid}/unmute`, {});
+    }
+
+    deletePool(guid: string): Observable<any> {
+        return this._httpClient.delete(getBasePath() + `/api/zfs/pool/${guid}`);
+    }
+
+    setLabel(guid: string, label: string): Observable<any> {
+        return this._httpClient.post(getBasePath() + `/api/zfs/pool/${guid}/label`, { label });
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds comprehensive ZFS pool monitoring to Scrutiny with a dedicated collector, API endpoints, and UI section.

- Separate `scrutiny-collector-zfs` binary with its own cron schedule
- Monitor pools: health, status, capacity, vdev structure, scrub status
- Dedicated "ZFS Pools" section in UI (separate from S.M.A.R.T devices)
- Linux + FreeBSD platform support

## Initial Release - Testing Requested

**This is the initial ZFS support implementation.** We would greatly appreciate testing and feedback from users with ZFS pools. Please report any issues you encounter to help us improve this feature.

### What to test:
- Pool detection on different ZFS configurations (mirrors, raidz, nested vdevs)
- Scrub status tracking
- Error count reporting
- UI display and navigation
- Different pool states (ONLINE, DEGRADED, etc.)

## Changes

### Backend
- ZFSPool and ZFSVdev GORM models with database migration
- ZFSPoolMetrics InfluxDB measurement for time-series data
- Full API endpoints: register, summary, metrics upload, details
- Archive/unarchive, mute/unmute, label, delete operations

### Collector
- CLI entry point with run command and configuration
- Detection logic parsing `zpool list` and `zpool status` output
- Vdev tree parsing with error tracking
- Scrub status monitoring

### Frontend
- ZFS pool models and summary interfaces
- Dashboard module with pool cards grouped by host
- Detail view with vdev tree visualization and capacity history
- Navigation links added to horizontal layout

### Build & CI
- Makefile targets for `binary-collector-zfs` and `docker-collector-zfs`
- CI/CD workflows updated to include ZFS collector binaries
- Docker container with `zfsutils-linux` dependency
- Example configuration file (`example.collector-zfs.yaml`)

## API Endpoints

| Endpoint | Method | Description |
|----------|--------|-------------|
| `/api/zfs/pools/register` | POST | Register detected pools |
| `/api/zfs/summary` | GET | Dashboard summary |
| `/api/zfs/pool/:guid/metrics` | POST | Upload pool metrics |
| `/api/zfs/pool/:guid/details` | GET | Pool details with vdev tree |
| `/api/zfs/pool/:guid/archive` | POST | Archive pool |
| `/api/zfs/pool/:guid/unarchive` | POST | Unarchive pool |
| `/api/zfs/pool/:guid/mute` | POST | Mute notifications |
| `/api/zfs/pool/:guid/unmute` | POST | Unmute notifications |
| `/api/zfs/pool/:guid/label` | POST | Update label |
| `/api/zfs/pool/:guid` | DELETE | Delete pool |

## Usage

```bash
# Run ZFS collector manually
scrutiny-collector-zfs run --api-endpoint http://localhost:8080

# Or with Docker (ZFS tools required on host)
docker run --privileged -v /dev:/dev analogj/scrutiny:collector-zfs
```

Closes #66

---

Generated with [Claude Code](https://claude.ai/code)