### PR TITLE
ci(docker): add ZFS collector image to Docker build workflow

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -77,6 +77,64 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+  collector-zfs:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: 'arm64,arm'
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
+          tags: |
+            # Manual trigger
+            type=raw,value=${{ inputs.tag_suffix }}-collector-zfs,enable=${{ github.event_name == 'workflow_dispatch' }}
+            # Branch builds
+            type=raw,value=latest-collector-zfs,enable=${{ (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')) && github.event_name != 'workflow_dispatch' }}
+            type=raw,value=develop-collector-zfs,enable=${{ github.ref == 'refs/heads/develop' && github.event_name != 'workflow_dispatch' }}
+            # Version tags
+            type=semver,pattern={{version}}-collector-zfs
+            type=semver,pattern={{major}}.{{minor}}-collector-zfs
+            type=semver,pattern={{major}}-collector-zfs,enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          context: .
+          file: docker/Dockerfile.collector-zfs
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
   web:
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary

- Add new `collector-zfs` job to the Docker build workflow to build and publish the ZFS collector Docker image
- The Dockerfile (`docker/Dockerfile.collector-zfs`) and supporting files already exist but were not included in the CI/CD pipeline

## Why

Users with hub-spoke deployments need a separate ZFS collector container. The binary is being released, but the Docker image was never published.

## Tags Published

After merge, the following image tags will be available at `ghcr.io/starosdev/scrutiny`:

| Trigger | Tags |
|---------|------|
| Push to `master` | `latest-collector-zfs` |
| Push to `develop` | `develop-collector-zfs` |
| Version tag `v1.9.2` | `1.9.2-collector-zfs`, `1.9-collector-zfs`, `1-collector-zfs` |
| Manual dispatch | `{input}-collector-zfs` |

## Test Plan

- [ ] Merge to develop and verify `develop-collector-zfs` tag is published
- [ ] Manually trigger workflow with `tag_suffix=test` to verify image builds correctly
- [ ] Pull and run the image to verify it starts: `docker run --rm ghcr.io/starosdev/scrutiny:develop-collector-zfs --help`

Closes #85