### PR TITLE
Fix ata gp logmapping Closes: #92

### DIFF
--- a/webapp/backend/pkg/thresholds/ata_attribute_metadata.go
+++ b/webapp/backend/pkg/thresholds/ata_attribute_metadata.go
@@ -1614,7 +1614,7 @@ var AtaDeviceStatsMetadata = map[string]AtaDeviceStatisticsMetadata{
 	// Page 1 (General Statistics)
 	"devstat_1_8": {
 		DisplayName: "Lifetime Power-On Resets",
-		Ideal:       ObservedThresholdIdealLow,
+		Ideal:       "",
 		Critical:    false,
 		Description: "Number of power-on reset events since device manufacture.",
 		DisplayType: AtaSmartAttributeDisplayTypeRaw,


### PR DESCRIPTION
mappings already exist in page 3.

According to the ATA GP Log 0x04 specification:
Page 3, offset 0x030 (48 decimal) = "Number of Mechanical Start Failures" Page 3, offset 0x038 (56 decimal) = "Number of Reallocation Candidate Logical Sectors" So:
devstat_3_48 is correct, devstat_3_56 is correct
The issue was that they were also incorrectly mapped in page 1, which is now fixed.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

Related to #92 

## Testing

<!-- Describe the testing you've done -->

- [ ] I have tested this locally
- [ ] I have added/updated tests that prove my fix/feature works
- [ ] All existing tests pass

## Checklist

- [ ] My code follows the project's code style
- [ ] I have performed a self-review of my code
- [ ] I have commented my code where necessary (particularly complex areas)
- [ ] I have updated the documentation if needed
- [ ] My changes generate no new warnings
- [ ] No console.log, debug statements, or commented-out code
