### PR TITLE
fix(frontend): update zfs pool model scrub property names to match the backend response

### DIFF
--- a/webapp/frontend/src/app/core/models/zfs-pool-model.ts
+++ b/webapp/frontend/src/app/core/models/zfs-pool-model.ts
@@ -15,10 +15,13 @@ export interface ZFSPoolModel {
     capacity_percent: number;
 
     scrub_state: ZFSScrubState;
-    scrub_start: string;
-    scrub_end: string;
-    scrub_percent: number;
-    scrub_errors: number;
+    scrub_start_time?: string;
+    scrub_end_time?: string;
+    scrub_scanned_bytes: number;
+    scrub_issued_bytes: number;
+    scrub_total_bytes: number;
+    scrub_errors_count: number;
+    scrub_percent_complete: number;
 
     total_read_errors: number;
     total_write_errors: number;

--- a/webapp/frontend/src/app/layout/common/zfs-pool-card/zfs-pool-card.component.ts
+++ b/webapp/frontend/src/app/layout/common/zfs-pool-card/zfs-pool-card.component.ts
@@ -101,9 +101,9 @@ export class ZFSPoolCardComponent implements OnInit {
             case 'none':
                 return 'Never';
             case 'scanning':
-                return `In Progress (${pool.scrub_percent}%)`;
+                return `In Progress (${pool.scrub_percent_complete}%)`;
             case 'finished':
-                return moment(pool.scrub_end).fromNow();
+                return moment(pool.scrub_end_time).fromNow();
             case 'canceled':
                 return 'Canceled';
             default:

--- a/webapp/frontend/src/app/modules/zfs-pool-detail/zfs-pool-detail.component.html
+++ b/webapp/frontend/src/app/modules/zfs-pool-detail/zfs-pool-detail.component.html
@@ -76,13 +76,13 @@
           }
           @case ('scanning') {
             <div class="font-bold text-3xl text-yellow">In Progress</div>
-            <div class="text-sm text-hint mt-2">{{ pool.scrub_percent }}% complete</div>
+            <div class="text-sm text-hint mt-2">{{ pool.scrub_percent_complete }}% complete</div>
           }
           @case ('finished') {
             <div class="font-bold text-3xl text-green">Completed</div>
-            <div class="text-sm text-hint mt-2">{{ pool.scrub_end | date:'MMM dd, yyyy HH:mm' }}</div>
-            @if (pool.scrub_errors > 0) {
-              <div class="text-sm text-red mt-1">{{ pool.scrub_errors }} errors found</div>
+            <div class="text-sm text-hint mt-2">{{ pool.scrub_end_time | date:'MMM dd, yyyy HH:mm' }}</div>
+            @if (pool.scrub_errors_count > 0) {
+              <div class="text-sm text-red mt-1">{{ pool.scrub_errors_count }} errors found</div>
             }
           }
           @case ('canceled') {


### PR DESCRIPTION
## Summary
This PR fixes the property name mismatches described in #102 
<!-- Brief description of what this PR does -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues
 Fixes #102 
<!-- Link to related issues, e.g., "Fixes #123" or "Related to #456" -->

## Changes Made

<!-- List the specific changes made in this PR -->

- `ZFSPoolModel` model property names updated
- `ZFSPoolCardComponent` updated with the new property names
- `ZFSPoolDetailComponent` updated with the new property names

## Testing

<!-- Describe the testing you've done -->

- [x] I have tested this locally
- [ ] I have added/updated tests that prove my fix/feature works
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary (particularly complex areas)
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [x] No console.log, debug statements, or commented-out code

## Screenshots (if applicable)
<img width="2171" height="1000" alt="image" src="https://github.com/user-attachments/assets/9103499e-13ed-4da2-a646-5b2312adc5d7" />

<img width="2162" height="999" alt="image" src="https://github.com/user-attachments/assets/7cf80f8c-9463-4a35-b30f-161787b5b5f9" />

<!-- Add screenshots to demonstrate visual changes -->

## Additional Notes
You can see on the provided screenshots, that after this fix, the last scrub values are displayed correctly, before this patch the value for my boot-pool and fast-data-pool was "a few seconds ago" because the underlying value always `undefined` (caused by the property name mismatch) and `moment()` will return the current date if `undefined` is passed as input value.
<!-- Any additional information reviewers should know -->
