### PR TITLE
fix(backend): reset device status when SMART data passes and add notification logging

### DIFF
--- a/webapp/backend/pkg/database/interface.go
+++ b/webapp/backend/pkg/database/interface.go
@@ -19,6 +19,7 @@ type DeviceRepo interface {
 	GetDevices(ctx context.Context) ([]models.Device, error)
 	UpdateDevice(ctx context.Context, wwn string, collectorSmartData collector.SmartInfo) (models.Device, error)
 	UpdateDeviceStatus(ctx context.Context, wwn string, status pkg.DeviceStatus) (models.Device, error)
+	ResetDeviceStatus(ctx context.Context, wwn string) (models.Device, error)
 	GetDeviceDetails(ctx context.Context, wwn string) (models.Device, error)
 	UpdateDeviceArchived(ctx context.Context, wwn string, archived bool) error
 	UpdateDeviceMuted(ctx context.Context, wwn string, muted bool) error

--- a/webapp/backend/pkg/database/mock/mock_database.go
+++ b/webapp/backend/pkg/database/mock/mock_database.go
@@ -272,6 +272,21 @@ func (mr *MockDeviceRepoMockRecorder) RegisterZFSPool(ctx, pool interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterZFSPool", reflect.TypeOf((*MockDeviceRepo)(nil).RegisterZFSPool), ctx, pool)
 }
 
+// ResetDeviceStatus mocks base method.
+func (m *MockDeviceRepo) ResetDeviceStatus(ctx context.Context, wwn string) (models.Device, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ResetDeviceStatus", ctx, wwn)
+	ret0, _ := ret[0].(models.Device)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ResetDeviceStatus indicates an expected call of ResetDeviceStatus.
+func (mr *MockDeviceRepoMockRecorder) ResetDeviceStatus(ctx, wwn interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetDeviceStatus", reflect.TypeOf((*MockDeviceRepo)(nil).ResetDeviceStatus), ctx, wwn)
+}
+
 // SaveSettings mocks base method.
 func (m *MockDeviceRepo) SaveSettings(ctx context.Context, settings models.Settings) error {
 	m.ctrl.T.Helper()

--- a/webapp/backend/pkg/database/scrutiny_repository_device.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_device.go
@@ -62,6 +62,17 @@ func (sr *scrutinyRepository) UpdateDeviceStatus(ctx context.Context, wwn string
 	return device, sr.gormClient.Model(&device).Updates(device).Error
 }
 
+// ResetDeviceStatus clears all failure flags when device SMART data shows all attributes passing
+func (sr *scrutinyRepository) ResetDeviceStatus(ctx context.Context, wwn string) (models.Device, error) {
+	var device models.Device
+	if err := sr.gormClient.WithContext(ctx).Where("wwn = ?", wwn).First(&device).Error; err != nil {
+		return device, fmt.Errorf("Could not get device from DB: %v", err)
+	}
+
+	device.DeviceStatus = pkg.DeviceStatusPassed
+	return device, sr.gormClient.Model(&device).Updates(device).Error
+}
+
 func (sr *scrutinyRepository) GetDeviceDetails(ctx context.Context, wwn string) (models.Device, error) {
 	var device models.Device
 

--- a/webapp/backend/pkg/models/device.go
+++ b/webapp/backend/pkg/models/device.go
@@ -169,6 +169,9 @@ func (dv *Device) UpdateFromCollectorSmartInfo(info collector.SmartInfo) error {
 
 	if !info.SmartStatus.Passed {
 		dv.DeviceStatus = pkg.DeviceStatusSet(dv.DeviceStatus, pkg.DeviceStatusFailedSmart)
+	} else {
+		// Clear SMART failure flag when manufacturer status passes
+		dv.DeviceStatus = pkg.DeviceStatusClear(dv.DeviceStatus, pkg.DeviceStatusFailedSmart)
 	}
 
 	return nil

--- a/webapp/backend/pkg/notify/notify.go
+++ b/webapp/backend/pkg/notify/notify.go
@@ -35,11 +35,13 @@ const NotifyFailureTypeScrutinyFailure = "ScrutinyFailure"
 func ShouldNotify(logger logrus.FieldLogger, device models.Device, smartAttrs measurements.Smart, statusThreshold pkg.MetricsStatusThreshold, statusFilterAttributes pkg.MetricsStatusFilterAttributes, repeatNotifications bool, c *gin.Context, deviceRepo database.DeviceRepo) bool {
 	// 1. check if the device is healthy
 	if device.DeviceStatus == pkg.DeviceStatusPassed {
+		logger.Debugf("ShouldNotify: skipping device %s - device status is passed", device.WWN)
 		return false
 	}
 
 	// If the device is muted, skip notification regardless of status
 	if device.Muted {
+		logger.Debugf("ShouldNotify: skipping device %s - device is muted", device.WWN)
 		return false
 	}
 
@@ -107,6 +109,8 @@ func ShouldNotify(logger logrus.FieldLogger, device models.Device, smartAttrs me
 		failingAttributes = append(failingAttributes, attrId)
 	}
 
+	logger.Debugf("ShouldNotify: device %s has %d failing attributes after filters (device_status=%d)", device.WWN, len(failingAttributes), device.DeviceStatus)
+
 	// If the user doesn't want repeated notifications when the failing value doesn't change, we need to get the last value from the db
 	var lastPoints []measurements.Smart
 	var err error
@@ -129,6 +133,7 @@ func ShouldNotify(logger logrus.FieldLogger, device models.Device, smartAttrs me
 			}
 		}
 	}
+	logger.Debugf("ShouldNotify: no qualifying failures found for device %s", device.WWN)
 	return false
 }
 

--- a/webapp/backend/pkg/web/handler/upload_device_metrics.go
+++ b/webapp/backend/pkg/web/handler/upload_device_metrics.go
@@ -59,6 +59,15 @@ func UploadDeviceMetrics(c *gin.Context) {
 			c.JSON(http.StatusInternalServerError, gin.H{"success": false})
 			return
 		}
+	} else if updatedDevice.DeviceStatus != pkg.DeviceStatusPassed {
+		// Clear failure status when current SMART data shows all attributes passing
+		updatedDevice, err = deviceRepo.ResetDeviceStatus(c, c.Param("wwn"))
+		if err != nil {
+			logger.Errorln("An error occurred while resetting device status", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"success": false})
+			return
+		}
+		logger.Infof("Device %s status reset to passed - all SMART attributes now within thresholds", c.Param("wwn"))
 	}
 
 	// save smart temperature data (ignore failures)
@@ -88,7 +97,9 @@ func UploadDeviceMetrics(c *gin.Context) {
 			updatedDevice,
 			false,
 		)
-		_ = liveNotify.Send() //we ignore error message when sending notifications.
+		if err := liveNotify.Send(); err != nil {
+			logger.Warnf("Failed to send notification for device %s: %v", c.Param("wwn"), err)
+		}
 	}
 
 	// Update Prometheus metrics (if enabled)


### PR DESCRIPTION
## Summary

- Fixes device status accumulation bug where failure status was never cleared
- Adds debug logging to notification decision logic
- Logs notification send failures instead of silently ignoring them

## Root Cause Analysis

### Issue 1: Devices Marked Failed Despite UI Showing "Within Range"

The device status uses bitwise flags that only accumulate and never clear. `DeviceStatusSet()` ORs in failure flags, but `DeviceStatusClear()` was never called anywhere in the codebase. This meant:

- A transient failure at any point sets the failure flag permanently
- Even when current SMART data shows all attributes passing, the old failure status persists
- Deleting and re-adding the device was the only workaround

### Issue 2: Notifications Not Triggering

The notification logic requires *current* failing attributes, not just device status. If a device has a failed status from the past but all current attributes are passing, the failing attributes list is empty and no notification is sent.

Additionally, notification errors were being silently ignored with `_ = liveNotify.Send()`.

## Changes

| File | Change |
|------|--------|
| `webapp/backend/pkg/database/interface.go` | Add `ResetDeviceStatus` interface method |
| `webapp/backend/pkg/database/scrutiny_repository_device.go` | Implement `ResetDeviceStatus()` |
| `webapp/backend/pkg/database/mock/mock_database.go` | Regenerate mock |
| `webapp/backend/pkg/models/device.go` | Clear SMART failure flag when manufacturer status passes |
| `webapp/backend/pkg/web/handler/upload_device_metrics.go` | Call reset when passing, log notification errors |
| `webapp/backend/pkg/notify/notify.go` | Add debug logging for notification decisions |

## Test plan

- [x] Code compiles successfully
- [x] Notify package tests pass (16/16)
- [x] Models/measurements tests pass
- [ ] Manual testing with InfluxDB to verify status reset behavior
- [ ] Test notification logging with `SCRUTINY_DEBUG=true`

Fixes #67