### PR TITLE
feat(backend): add SMART attribute overrides support (SCR-114)

### DIFF
--- a/example.scrutiny.yaml
+++ b/example.scrutiny.yaml
@@ -82,6 +82,55 @@ failures:
     nvme: []      # NVME attribute IDs, e.g., ["media_errors"]
     scsi: []      # SCSI attribute IDs, e.g., ["scsi_grown_defect_list"]
 
+######################################################################
+# SMART Attribute Overrides
+#
+# Customize how individual SMART attributes are evaluated.
+# Use this to suppress false positives, force specific statuses,
+# or set custom warning/failure thresholds.
+#
+# Each override requires:
+#   - protocol: ATA, NVMe, or SCSI
+#   - attribute_id: The attribute ID as a string (e.g., "5", "media_errors", "devstat_7_8")
+#
+# Optional fields:
+#   - wwn: Limit the override to a specific device (by WWN)
+#   - action: "ignore" (skip attribute) or "force_status" (set specific status)
+#   - status: For force_status action: "passed", "warn", or "failed"
+#   - warn_above: Custom threshold - warn when raw value exceeds this
+#   - fail_above: Custom threshold - fail when raw value exceeds this (takes precedence)
+#
+#smart:
+#  attribute_overrides:
+#    # Example 1: Ignore a specific attribute that causes false positives
+#    - protocol: ATA
+#      attribute_id: "187"        # Reported_Uncorrect - often false positive on some drives
+#      action: ignore
+#
+#    # Example 2: Ignore attribute only for a specific device
+#    - protocol: ATA
+#      attribute_id: "197"        # Current_Pending_Sector
+#      wwn: "0x5000cca264eb01d7"  # Only apply to this drive
+#      action: ignore
+#
+#    # Example 3: Force an attribute status to passed (suppress alerts)
+#    - protocol: NVMe
+#      attribute_id: "media_errors"
+#      action: force_status
+#      status: passed
+#
+#    # Example 4: Set custom thresholds for Reallocated Sectors Count
+#    - protocol: ATA
+#      attribute_id: "5"
+#      warn_above: 5              # Warn when raw value > 5
+#      fail_above: 10             # Fail when raw value > 10
+#
+#    # Example 5: Device statistics override
+#    - protocol: ATA
+#      attribute_id: "devstat_7_8"  # Percentage Used Endurance Indicator
+#      warn_above: 80
+#      fail_above: 95
+
 # Notification "urls" look like the following. For more information about service specific configuration see
 # Shoutrrr's documentation: https://containrrr.dev/shoutrrr/services/overview/
 #

--- a/webapp/backend/pkg/config/config.go
+++ b/webapp/backend/pkg/config/config.go
@@ -56,6 +56,9 @@ func (c *configuration) Init() error {
 
 	c.SetDefault("failures.transient.ata", []int{195})
 
+	// SMART attribute overrides - allows users to ignore, force status, or set custom thresholds
+	c.SetDefault("smart.attribute_overrides", []map[string]interface{}{})
+
 	// Metrics settings
 	c.SetDefault("web.metrics.enabled", true)
 

--- a/webapp/backend/pkg/database/scrutiny_repository_migrations.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_migrations.go
@@ -632,7 +632,7 @@ func m20201107210306_FromPreInfluxDBSmartResultsCreatePostInfluxDBSmartResults(d
 			}
 		}
 
-		postDeviceSmartData.ProcessNvmeSmartInfo(postNvmeSmartHealthInformation)
+		postDeviceSmartData.ProcessNvmeSmartInfo(nil, postNvmeSmartHealthInformation)
 
 	} else if preDevice.IsScsi() {
 		//info collector.SmartInfo
@@ -688,7 +688,7 @@ func m20201107210306_FromPreInfluxDBSmartResultsCreatePostInfluxDBSmartResults(d
 				postScsiErrorCounterLog.Write.TotalUncorrectedErrors = int64(preScsiAttribute.Value)
 			}
 		}
-		postDeviceSmartData.ProcessScsiSmartInfo(postScsiGrownDefectList, postScsiErrorCounterLog, nil)
+		postDeviceSmartData.ProcessScsiSmartInfo(nil, postScsiGrownDefectList, postScsiErrorCounterLog, nil)
 	} else {
 		return fmt.Errorf("Unknown device protocol: %s", preDevice.DeviceProtocol), postDeviceSmartData
 	}

--- a/webapp/backend/pkg/models/measurements/smart_test.go
+++ b/webapp/backend/pkg/models/measurements/smart_test.go
@@ -322,6 +322,7 @@ func TestFromCollectorSmartInfo(t *testing.T) {
 	defer mockCtrl.Finish()
 	fakeConfig := mock_config.NewMockInterface(mockCtrl)
 	fakeConfig.EXPECT().GetIntSlice("failures.transient.ata").Return([]int{195}).AnyTimes()
+	fakeConfig.EXPECT().Get("smart.attribute_overrides").Return(nil).AnyTimes()
 
 	smartDataFile, err := os.Open("../testdata/smart-ata.json")
 	require.NoError(t, err)
@@ -359,6 +360,7 @@ func TestFromCollectorSmartInfo_Fail_Smart(t *testing.T) {
 	defer mockCtrl.Finish()
 	fakeConfig := mock_config.NewMockInterface(mockCtrl)
 	fakeConfig.EXPECT().GetIntSlice("failures.transient.ata").Return([]int{195}).AnyTimes()
+	fakeConfig.EXPECT().Get("smart.attribute_overrides").Return(nil).AnyTimes()
 
 	smartDataFile, err := os.Open("../testdata/smart-fail.json")
 	require.NoError(t, err)
@@ -388,6 +390,7 @@ func TestFromCollectorSmartInfo_Fail_ScrutinySmart(t *testing.T) {
 	defer mockCtrl.Finish()
 	fakeConfig := mock_config.NewMockInterface(mockCtrl)
 	fakeConfig.EXPECT().GetIntSlice("failures.transient.ata").Return([]int{195}).AnyTimes()
+	fakeConfig.EXPECT().Get("smart.attribute_overrides").Return(nil).AnyTimes()
 
 	smartDataFile, err := os.Open("../testdata/smart-fail2.json")
 	require.NoError(t, err)
@@ -417,6 +420,7 @@ func TestFromCollectorSmartInfo_Fail_ScrutinyNonCriticalFailed(t *testing.T) {
 	defer mockCtrl.Finish()
 	fakeConfig := mock_config.NewMockInterface(mockCtrl)
 	fakeConfig.EXPECT().GetIntSlice("failures.transient.ata").Return([]int{195}).AnyTimes()
+	fakeConfig.EXPECT().Get("smart.attribute_overrides").Return(nil).AnyTimes()
 
 	smartDataFile, err := os.Open("../testdata/smart-ata-failed-scrutiny.json")
 	require.NoError(t, err)
@@ -455,6 +459,7 @@ func TestFromCollectorSmartInfo_NVMe_Fail_Scrutiny(t *testing.T) {
 	defer mockCtrl.Finish()
 	fakeConfig := mock_config.NewMockInterface(mockCtrl)
 	fakeConfig.EXPECT().GetIntSlice("failures.transient.ata").Return([]int{195}).AnyTimes()
+	fakeConfig.EXPECT().Get("smart.attribute_overrides").Return(nil).AnyTimes()
 
 	smartDataFile, err := os.Open("../testdata/smart-nvme-failed.json")
 	require.NoError(t, err)
@@ -491,6 +496,7 @@ func TestFromCollectorSmartInfo_Nvme(t *testing.T) {
 	defer mockCtrl.Finish()
 	fakeConfig := mock_config.NewMockInterface(mockCtrl)
 	fakeConfig.EXPECT().GetIntSlice("failures.transient.ata").Return([]int{195}).AnyTimes()
+	fakeConfig.EXPECT().Get("smart.attribute_overrides").Return(nil).AnyTimes()
 
 	smartDataFile, err := os.Open("../testdata/smart-nvme.json")
 	require.NoError(t, err)
@@ -523,6 +529,7 @@ func TestFromCollectorSmartInfo_Scsi(t *testing.T) {
 	defer mockCtrl.Finish()
 	fakeConfig := mock_config.NewMockInterface(mockCtrl)
 	fakeConfig.EXPECT().GetIntSlice("failures.transient.ata").Return([]int{195}).AnyTimes()
+	fakeConfig.EXPECT().Get("smart.attribute_overrides").Return(nil).AnyTimes()
 
 	smartDataFile, err := os.Open("../testdata/smart-scsi.json")
 	require.NoError(t, err)
@@ -558,6 +565,7 @@ func TestFromCollectorSmartInfo_Scsi_SAS_EnvironmentalReports(t *testing.T) {
 	defer mockCtrl.Finish()
 	fakeConfig := mock_config.NewMockInterface(mockCtrl)
 	fakeConfig.EXPECT().GetIntSlice("failures.transient.ata").Return([]int{195}).AnyTimes()
+	fakeConfig.EXPECT().Get("smart.attribute_overrides").Return(nil).AnyTimes()
 
 	smartDataFile, err := os.Open("../testdata/smart-scsi-sas-env-temp.json")
 	require.NoError(t, err)
@@ -593,6 +601,7 @@ func TestFromCollectorSmartInfo_ATA_DeviceStatistics(t *testing.T) {
 	defer mockCtrl.Finish()
 	fakeConfig := mock_config.NewMockInterface(mockCtrl)
 	fakeConfig.EXPECT().GetIntSlice("failures.transient.ata").Return([]int{195}).AnyTimes()
+	fakeConfig.EXPECT().Get("smart.attribute_overrides").Return(nil).AnyTimes()
 
 	smartDataFile, err := os.Open("../testdata/smart-ata-full.json")
 	require.NoError(t, err)
@@ -706,6 +715,7 @@ func TestFromCollectorSmartInfo_ATA_DeviceStatistics_StatusPropagation(t *testin
 	fakeConfig := mock_config.NewMockInterface(mockCtrl)
 	fakeConfig.EXPECT().GetIntSlice("failures.transient.ata").Return([]int{}).AnyTimes()
 	fakeConfig.EXPECT().GetStringSlice("failures.ignored.devstat").Return([]string{}).AnyTimes()
+	fakeConfig.EXPECT().Get("smart.attribute_overrides").Return(nil).AnyTimes()
 
 	// Create minimal smartctl output with a failing devstat attribute
 	smartJson := collector.SmartInfo{
@@ -803,6 +813,7 @@ func TestFromCollectorSmartInfo_ATA_DeviceStatistics_IgnoreList(t *testing.T) {
 	fakeConfig.EXPECT().GetIntSlice("failures.transient.ata").Return([]int{}).AnyTimes()
 	// Add devstat_7_8 to the ignore list
 	fakeConfig.EXPECT().GetStringSlice("failures.ignored.devstat").Return([]string{"devstat_7_8"}).AnyTimes()
+	fakeConfig.EXPECT().Get("smart.attribute_overrides").Return(nil).AnyTimes()
 
 	// Create smartctl output with a failing devstat attribute that's ignored
 	smartJson := collector.SmartInfo{
@@ -897,6 +908,7 @@ func TestFromCollectorSmartInfo_ATA_DeviceStatistics_InvalidValue(t *testing.T) 
 	fakeConfig := mock_config.NewMockInterface(mockCtrl)
 	fakeConfig.EXPECT().GetIntSlice("failures.transient.ata").Return([]int{}).AnyTimes()
 	fakeConfig.EXPECT().GetStringSlice("failures.ignored.devstat").Return([]string{}).AnyTimes()
+	fakeConfig.EXPECT().Get("smart.attribute_overrides").Return(nil).AnyTimes()
 
 	// Create smartctl output with an impossibly high value (like reported in issue #84)
 	smartJson := collector.SmartInfo{

--- a/webapp/backend/pkg/notify/notify_test.go
+++ b/webapp/backend/pkg/notify/notify_test.go
@@ -31,7 +31,7 @@ func TestShouldNotify_MustSkipPassingDevices(t *testing.T) {
 	defer mockCtrl.Finish()
 	fakeDatabase := mock_database.NewMockDeviceRepo(mockCtrl)
 	//assert
-	require.False(t, ShouldNotify(logrus.StandardLogger(), device, smartAttrs, statusThreshold, notifyFilterAttributes, true, &gin.Context{}, fakeDatabase))
+	require.False(t, ShouldNotify(logrus.StandardLogger(), device, smartAttrs, statusThreshold, notifyFilterAttributes, true, &gin.Context{}, fakeDatabase, nil))
 }
 
 func TestShouldNotify_MetricsStatusThresholdBoth_FailingSmartDevice(t *testing.T) {
@@ -47,7 +47,7 @@ func TestShouldNotify_MetricsStatusThresholdBoth_FailingSmartDevice(t *testing.T
 	defer mockCtrl.Finish()
 	fakeDatabase := mock_database.NewMockDeviceRepo(mockCtrl)
 	//assert
-	require.True(t, ShouldNotify(logrus.StandardLogger(), device, smartAttrs, statusThreshold, notifyFilterAttributes, true, &gin.Context{}, fakeDatabase))
+	require.True(t, ShouldNotify(logrus.StandardLogger(), device, smartAttrs, statusThreshold, notifyFilterAttributes, true, &gin.Context{}, fakeDatabase, nil))
 }
 
 func TestShouldNotify_MetricsStatusThresholdSmart_FailingSmartDevice(t *testing.T) {
@@ -63,7 +63,7 @@ func TestShouldNotify_MetricsStatusThresholdSmart_FailingSmartDevice(t *testing.
 	defer mockCtrl.Finish()
 	fakeDatabase := mock_database.NewMockDeviceRepo(mockCtrl)
 	//assert
-	require.True(t, ShouldNotify(logrus.StandardLogger(), device, smartAttrs, statusThreshold, notifyFilterAttributes, true, &gin.Context{}, fakeDatabase))
+	require.True(t, ShouldNotify(logrus.StandardLogger(), device, smartAttrs, statusThreshold, notifyFilterAttributes, true, &gin.Context{}, fakeDatabase, nil))
 }
 
 func TestShouldNotify_MetricsStatusThresholdScrutiny_FailingSmartDevice(t *testing.T) {
@@ -79,7 +79,7 @@ func TestShouldNotify_MetricsStatusThresholdScrutiny_FailingSmartDevice(t *testi
 	defer mockCtrl.Finish()
 	fakeDatabase := mock_database.NewMockDeviceRepo(mockCtrl)
 	//assert
-	require.False(t, ShouldNotify(logrus.StandardLogger(), device, smartAttrs, statusThreshold, notifyFilterAttributes, true, &gin.Context{}, fakeDatabase))
+	require.False(t, ShouldNotify(logrus.StandardLogger(), device, smartAttrs, statusThreshold, notifyFilterAttributes, true, &gin.Context{}, fakeDatabase, nil))
 }
 
 func TestShouldNotify_MetricsStatusFilterAttributesCritical_WithCriticalAttrs(t *testing.T) {
@@ -100,7 +100,7 @@ func TestShouldNotify_MetricsStatusFilterAttributesCritical_WithCriticalAttrs(t 
 	fakeDatabase := mock_database.NewMockDeviceRepo(mockCtrl)
 
 	//assert
-	require.True(t, ShouldNotify(logrus.StandardLogger(), device, smartAttrs, statusThreshold, notifyFilterAttributes, true, &gin.Context{}, fakeDatabase))
+	require.True(t, ShouldNotify(logrus.StandardLogger(), device, smartAttrs, statusThreshold, notifyFilterAttributes, true, &gin.Context{}, fakeDatabase, nil))
 }
 
 func TestShouldNotify_MetricsStatusFilterAttributesCritical_WithMultipleCriticalAttrs(t *testing.T) {
@@ -124,7 +124,7 @@ func TestShouldNotify_MetricsStatusFilterAttributesCritical_WithMultipleCritical
 	fakeDatabase := mock_database.NewMockDeviceRepo(mockCtrl)
 
 	//assert
-	require.True(t, ShouldNotify(logrus.StandardLogger(), device, smartAttrs, statusThreshold, notifyFilterAttributes, true, &gin.Context{}, fakeDatabase))
+	require.True(t, ShouldNotify(logrus.StandardLogger(), device, smartAttrs, statusThreshold, notifyFilterAttributes, true, &gin.Context{}, fakeDatabase, nil))
 }
 
 func TestShouldNotify_MetricsStatusFilterAttributesCritical_WithNoCriticalAttrs(t *testing.T) {
@@ -145,7 +145,7 @@ func TestShouldNotify_MetricsStatusFilterAttributesCritical_WithNoCriticalAttrs(
 	fakeDatabase := mock_database.NewMockDeviceRepo(mockCtrl)
 
 	//assert
-	require.False(t, ShouldNotify(logrus.StandardLogger(), device, smartAttrs, statusThreshold, notifyFilterAttributes, true, &gin.Context{}, fakeDatabase))
+	require.False(t, ShouldNotify(logrus.StandardLogger(), device, smartAttrs, statusThreshold, notifyFilterAttributes, true, &gin.Context{}, fakeDatabase, nil))
 }
 
 func TestShouldNotify_MetricsStatusFilterAttributesCritical_WithNoFailingCriticalAttrs(t *testing.T) {
@@ -166,7 +166,7 @@ func TestShouldNotify_MetricsStatusFilterAttributesCritical_WithNoFailingCritica
 	fakeDatabase := mock_database.NewMockDeviceRepo(mockCtrl)
 
 	//assert
-	require.False(t, ShouldNotify(logrus.StandardLogger(), device, smartAttrs, statusThreshold, notifyFilterAttributes, true, &gin.Context{}, fakeDatabase))
+	require.False(t, ShouldNotify(logrus.StandardLogger(), device, smartAttrs, statusThreshold, notifyFilterAttributes, true, &gin.Context{}, fakeDatabase, nil))
 }
 
 func TestShouldNotify_MetricsStatusFilterAttributesCritical_MetricsStatusThresholdSmart_WithCriticalAttrsFailingScrutiny(t *testing.T) {
@@ -190,7 +190,7 @@ func TestShouldNotify_MetricsStatusFilterAttributesCritical_MetricsStatusThresho
 	fakeDatabase := mock_database.NewMockDeviceRepo(mockCtrl)
 
 	//assert
-	require.False(t, ShouldNotify(logrus.StandardLogger(), device, smartAttrs, statusThreshold, notifyFilterAttributes, true, &gin.Context{}, fakeDatabase))
+	require.False(t, ShouldNotify(logrus.StandardLogger(), device, smartAttrs, statusThreshold, notifyFilterAttributes, true, &gin.Context{}, fakeDatabase, nil))
 }
 func TestShouldNotify_NoRepeat_DatabaseFailure(t *testing.T) {
 	t.Parallel()
@@ -211,7 +211,7 @@ func TestShouldNotify_NoRepeat_DatabaseFailure(t *testing.T) {
 	fakeDatabase.EXPECT().GetSmartAttributeHistory(&gin.Context{}, "", database.DURATION_KEY_FOREVER, 1, 1, []string{"5"}).Return([]measurements.Smart{}, errors.New("")).Times(1)
 
 	//assert
-	require.True(t, ShouldNotify(logrus.StandardLogger(), device, smartAttrs, statusThreshold, notifyFilterAttributes, false, &gin.Context{}, fakeDatabase))
+	require.True(t, ShouldNotify(logrus.StandardLogger(), device, smartAttrs, statusThreshold, notifyFilterAttributes, false, &gin.Context{}, fakeDatabase, nil))
 }
 
 func TestShouldNotify_NoRepeat_NoDatabaseData(t *testing.T) {
@@ -233,7 +233,7 @@ func TestShouldNotify_NoRepeat_NoDatabaseData(t *testing.T) {
 	fakeDatabase.EXPECT().GetSmartAttributeHistory(&gin.Context{}, "", database.DURATION_KEY_FOREVER, 1, 1, []string{"5"}).Return([]measurements.Smart{}, nil).Times(1)
 
 	//assert
-	require.True(t, ShouldNotify(logrus.StandardLogger(), device, smartAttrs, statusThreshold, notifyFilterAttributes, false, &gin.Context{}, fakeDatabase))
+	require.True(t, ShouldNotify(logrus.StandardLogger(), device, smartAttrs, statusThreshold, notifyFilterAttributes, false, &gin.Context{}, fakeDatabase, nil))
 }
 func TestShouldNotify_NoRepeat(t *testing.T) {
 	t.Parallel()
@@ -255,7 +255,7 @@ func TestShouldNotify_NoRepeat(t *testing.T) {
 	fakeDatabase.EXPECT().GetSmartAttributeHistory(&gin.Context{}, "", database.DURATION_KEY_FOREVER, 1, 1, []string{"5"}).Return([]measurements.Smart{smartAttrs}, nil).Times(1)
 
 	//assert
-	require.False(t, ShouldNotify(logrus.StandardLogger(), device, smartAttrs, statusThreshold, notifyFilterAttributes, false, &gin.Context{}, fakeDatabase))
+	require.False(t, ShouldNotify(logrus.StandardLogger(), device, smartAttrs, statusThreshold, notifyFilterAttributes, false, &gin.Context{}, fakeDatabase, nil))
 }
 
 func TestNewPayload(t *testing.T) {

--- a/webapp/backend/pkg/overrides/applier.go
+++ b/webapp/backend/pkg/overrides/applier.go
@@ -1,0 +1,169 @@
+package overrides
+
+import (
+	"github.com/analogj/scrutiny/webapp/backend/pkg"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/config"
+	"github.com/mitchellh/mapstructure"
+)
+
+// AttributeOverrideAction defines what action to take for an override
+type AttributeOverrideAction string
+
+const (
+	AttributeOverrideActionIgnore      AttributeOverrideAction = "ignore"
+	AttributeOverrideActionForceStatus AttributeOverrideAction = "force_status"
+)
+
+// AttributeOverride defines a user-configured override for SMART attribute evaluation
+type AttributeOverride struct {
+	// Required: Protocol type (ATA, NVMe, SCSI)
+	Protocol string `json:"protocol" mapstructure:"protocol"`
+
+	// Required: Attribute ID (string for all protocols)
+	// ATA: "5", "187", etc.
+	// ATA DevStats: "devstat_7_8"
+	// NVMe: "media_errors", "percentage_used"
+	// SCSI: "scsi_grown_defect_list"
+	AttributeId string `json:"attribute_id" mapstructure:"attribute_id"`
+
+	// Optional: Limit override to specific device by WWN
+	WWN string `json:"wwn,omitempty" mapstructure:"wwn"`
+
+	// Optional: Action to take (ignore or force_status)
+	// If not set, custom thresholds are applied
+	Action AttributeOverrideAction `json:"action,omitempty" mapstructure:"action"`
+
+	// For force_status action: the status to set
+	// Values: "passed", "warn", "failed"
+	Status string `json:"status,omitempty" mapstructure:"status"`
+
+	// Custom threshold: warn when value exceeds this
+	WarnAbove *int64 `json:"warn_above,omitempty" mapstructure:"warn_above"`
+
+	// Custom threshold: fail when value exceeds this (takes precedence over warn)
+	FailAbove *int64 `json:"fail_above,omitempty" mapstructure:"fail_above"`
+}
+
+// Matches checks if this override applies to the given attribute
+func (ao *AttributeOverride) Matches(protocol, attributeId, wwn string) bool {
+	if ao.Protocol != protocol {
+		return false
+	}
+	if ao.AttributeId != attributeId {
+		return false
+	}
+	// WWN is optional - if not set, matches all devices
+	if ao.WWN != "" && ao.WWN != wwn {
+		return false
+	}
+	return true
+}
+
+// GetForcedStatus converts the status string to AttributeStatus
+func (ao *AttributeOverride) GetForcedStatus() pkg.AttributeStatus {
+	switch ao.Status {
+	case "passed":
+		return pkg.AttributeStatusPassed
+	case "warn":
+		return pkg.AttributeStatusWarningScrutiny
+	case "failed":
+		return pkg.AttributeStatusFailedScrutiny
+	default:
+		return pkg.AttributeStatusPassed
+	}
+}
+
+// FindOverride searches the override list for a matching override
+func FindOverride(overrides []AttributeOverride, protocol, attributeId, wwn string) *AttributeOverride {
+	for i := range overrides {
+		if overrides[i].Matches(protocol, attributeId, wwn) {
+			return &overrides[i]
+		}
+	}
+	return nil
+}
+
+// Result contains the outcome of applying an override
+type Result struct {
+	// ShouldIgnore indicates the attribute should be completely ignored
+	ShouldIgnore bool
+	// Status is the forced status (if set)
+	Status *pkg.AttributeStatus
+	// StatusReason explains why the status was set
+	StatusReason string
+	// WarnAbove is the custom warning threshold
+	WarnAbove *int64
+	// FailAbove is the custom failure threshold
+	FailAbove *int64
+}
+
+// ParseOverrides converts raw config data to typed AttributeOverride slice
+func ParseOverrides(cfg config.Interface) []AttributeOverride {
+	var result []AttributeOverride
+	if cfg == nil {
+		return result
+	}
+
+	raw := cfg.Get("smart.attribute_overrides")
+	if raw == nil {
+		return result
+	}
+
+	// Use mapstructure to decode the raw config into typed structs
+	if err := mapstructure.Decode(raw, &result); err != nil {
+		return result
+	}
+	return result
+}
+
+// Apply checks if an override exists for the given attribute and returns the result.
+// Returns nil if no override matches.
+func Apply(cfg config.Interface, protocol, attributeId, wwn string) *Result {
+	overrideList := ParseOverrides(cfg)
+	override := FindOverride(overrideList, protocol, attributeId, wwn)
+
+	if override == nil {
+		return nil
+	}
+
+	result := &Result{}
+
+	switch override.Action {
+	case AttributeOverrideActionIgnore:
+		result.ShouldIgnore = true
+		result.StatusReason = "Attribute ignored by user configuration"
+
+	case AttributeOverrideActionForceStatus:
+		status := override.GetForcedStatus()
+		result.Status = &status
+		result.StatusReason = "Status forced by user configuration"
+	}
+
+	// Custom thresholds (can be combined with force_status or standalone)
+	result.WarnAbove = override.WarnAbove
+	result.FailAbove = override.FailAbove
+
+	return result
+}
+
+// ApplyThresholds evaluates custom thresholds against a value.
+// Returns the status to set based on thresholds, or nil if no threshold exceeded.
+// FailAbove takes precedence over WarnAbove.
+func ApplyThresholds(result *Result, value int64) *pkg.AttributeStatus {
+	if result == nil {
+		return nil
+	}
+
+	// FailAbove takes precedence
+	if result.FailAbove != nil && value > *result.FailAbove {
+		status := pkg.AttributeStatusFailedScrutiny
+		return &status
+	}
+
+	if result.WarnAbove != nil && value > *result.WarnAbove {
+		status := pkg.AttributeStatusWarningScrutiny
+		return &status
+	}
+
+	return nil
+}

--- a/webapp/backend/pkg/overrides/applier_test.go
+++ b/webapp/backend/pkg/overrides/applier_test.go
@@ -1,0 +1,297 @@
+package overrides
+
+import (
+	"testing"
+
+	"github.com/analogj/scrutiny/webapp/backend/pkg"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAttributeOverride_Matches(t *testing.T) {
+	tests := []struct {
+		name        string
+		override    AttributeOverride
+		protocol    string
+		attributeId string
+		wwn         string
+		expected    bool
+	}{
+		{
+			name:        "exact match without WWN filter",
+			override:    AttributeOverride{Protocol: "ATA", AttributeId: "5"},
+			protocol:    "ATA",
+			attributeId: "5",
+			wwn:         "0x123",
+			expected:    true,
+		},
+		{
+			name:        "protocol mismatch",
+			override:    AttributeOverride{Protocol: "NVMe", AttributeId: "5"},
+			protocol:    "ATA",
+			attributeId: "5",
+			wwn:         "",
+			expected:    false,
+		},
+		{
+			name:        "attribute_id mismatch",
+			override:    AttributeOverride{Protocol: "ATA", AttributeId: "5"},
+			protocol:    "ATA",
+			attributeId: "187",
+			wwn:         "",
+			expected:    false,
+		},
+		{
+			name:        "wwn filter match",
+			override:    AttributeOverride{Protocol: "ATA", AttributeId: "5", WWN: "0x123"},
+			protocol:    "ATA",
+			attributeId: "5",
+			wwn:         "0x123",
+			expected:    true,
+		},
+		{
+			name:        "wwn filter mismatch",
+			override:    AttributeOverride{Protocol: "ATA", AttributeId: "5", WWN: "0x123"},
+			protocol:    "ATA",
+			attributeId: "5",
+			wwn:         "0x456",
+			expected:    false,
+		},
+		{
+			name:        "nvme attribute match",
+			override:    AttributeOverride{Protocol: "NVMe", AttributeId: "media_errors"},
+			protocol:    "NVMe",
+			attributeId: "media_errors",
+			wwn:         "0xabc",
+			expected:    true,
+		},
+		{
+			name:        "scsi attribute match",
+			override:    AttributeOverride{Protocol: "SCSI", AttributeId: "scsi_grown_defect_list"},
+			protocol:    "SCSI",
+			attributeId: "scsi_grown_defect_list",
+			wwn:         "",
+			expected:    true,
+		},
+		{
+			name:        "devstat attribute match",
+			override:    AttributeOverride{Protocol: "ATA", AttributeId: "devstat_7_8"},
+			protocol:    "ATA",
+			attributeId: "devstat_7_8",
+			wwn:         "",
+			expected:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.override.Matches(tt.protocol, tt.attributeId, tt.wwn)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestAttributeOverride_GetForcedStatus(t *testing.T) {
+	tests := []struct {
+		name     string
+		status   string
+		expected pkg.AttributeStatus
+	}{
+		{
+			name:     "passed status",
+			status:   "passed",
+			expected: pkg.AttributeStatusPassed,
+		},
+		{
+			name:     "warn status",
+			status:   "warn",
+			expected: pkg.AttributeStatusWarningScrutiny,
+		},
+		{
+			name:     "failed status",
+			status:   "failed",
+			expected: pkg.AttributeStatusFailedScrutiny,
+		},
+		{
+			name:     "unknown status defaults to passed",
+			status:   "unknown",
+			expected: pkg.AttributeStatusPassed,
+		},
+		{
+			name:     "empty status defaults to passed",
+			status:   "",
+			expected: pkg.AttributeStatusPassed,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			override := AttributeOverride{Status: tt.status}
+			got := override.GetForcedStatus()
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestFindOverride(t *testing.T) {
+	overrides := []AttributeOverride{
+		{Protocol: "ATA", AttributeId: "5"},
+		{Protocol: "ATA", AttributeId: "187", WWN: "0x123"},
+		{Protocol: "NVMe", AttributeId: "media_errors"},
+	}
+
+	tests := []struct {
+		name        string
+		protocol    string
+		attributeId string
+		wwn         string
+		expectFound bool
+		expectId    string
+	}{
+		{
+			name:        "find ATA attribute without WWN",
+			protocol:    "ATA",
+			attributeId: "5",
+			wwn:         "0xabc",
+			expectFound: true,
+			expectId:    "5",
+		},
+		{
+			name:        "find ATA attribute with matching WWN",
+			protocol:    "ATA",
+			attributeId: "187",
+			wwn:         "0x123",
+			expectFound: true,
+			expectId:    "187",
+		},
+		{
+			name:        "no match for ATA attribute with wrong WWN",
+			protocol:    "ATA",
+			attributeId: "187",
+			wwn:         "0x456",
+			expectFound: false,
+		},
+		{
+			name:        "find NVMe attribute",
+			protocol:    "NVMe",
+			attributeId: "media_errors",
+			wwn:         "",
+			expectFound: true,
+			expectId:    "media_errors",
+		},
+		{
+			name:        "no match for unknown attribute",
+			protocol:    "ATA",
+			attributeId: "999",
+			wwn:         "",
+			expectFound: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := FindOverride(overrides, tt.protocol, tt.attributeId, tt.wwn)
+			if tt.expectFound {
+				assert.NotNil(t, result)
+				assert.Equal(t, tt.expectId, result.AttributeId)
+			} else {
+				assert.Nil(t, result)
+			}
+		})
+	}
+}
+
+func TestApplyThresholds(t *testing.T) {
+	warnThreshold := int64(5)
+	failThreshold := int64(10)
+
+	tests := []struct {
+		name           string
+		result         *Result
+		value          int64
+		expectStatus   *pkg.AttributeStatus
+		expectStatusIs pkg.AttributeStatus
+	}{
+		{
+			name:         "nil result returns nil",
+			result:       nil,
+			value:        100,
+			expectStatus: nil,
+		},
+		{
+			name:         "value below warn threshold",
+			result:       &Result{WarnAbove: &warnThreshold, FailAbove: &failThreshold},
+			value:        3,
+			expectStatus: nil,
+		},
+		{
+			name:           "value exceeds warn threshold",
+			result:         &Result{WarnAbove: &warnThreshold, FailAbove: &failThreshold},
+			value:          7,
+			expectStatusIs: pkg.AttributeStatusWarningScrutiny,
+		},
+		{
+			name:           "value exceeds fail threshold",
+			result:         &Result{WarnAbove: &warnThreshold, FailAbove: &failThreshold},
+			value:          15,
+			expectStatusIs: pkg.AttributeStatusFailedScrutiny,
+		},
+		{
+			name:           "fail threshold takes precedence",
+			result:         &Result{WarnAbove: &warnThreshold, FailAbove: &failThreshold},
+			value:          10, // exactly at fail, but > means it needs to exceed
+			expectStatusIs: pkg.AttributeStatusWarningScrutiny,
+		},
+		{
+			name:           "value exceeds fail threshold (greater than)",
+			result:         &Result{WarnAbove: &warnThreshold, FailAbove: &failThreshold},
+			value:          11,
+			expectStatusIs: pkg.AttributeStatusFailedScrutiny,
+		},
+		{
+			name:           "only warn threshold set",
+			result:         &Result{WarnAbove: &warnThreshold},
+			value:          7,
+			expectStatusIs: pkg.AttributeStatusWarningScrutiny,
+		},
+		{
+			name:           "only fail threshold set",
+			result:         &Result{FailAbove: &failThreshold},
+			value:          15,
+			expectStatusIs: pkg.AttributeStatusFailedScrutiny,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ApplyThresholds(tt.result, tt.value)
+			if tt.expectStatus == nil && got == nil {
+				return
+			}
+			if tt.expectStatus == nil && got != nil {
+				assert.Equal(t, tt.expectStatusIs, *got)
+			}
+		})
+	}
+}
+
+func TestResult_IgnoreAction(t *testing.T) {
+	result := &Result{
+		ShouldIgnore: true,
+		StatusReason: "Attribute ignored by user configuration",
+	}
+
+	assert.True(t, result.ShouldIgnore)
+	assert.Equal(t, "Attribute ignored by user configuration", result.StatusReason)
+}
+
+func TestResult_ForceStatusAction(t *testing.T) {
+	status := pkg.AttributeStatusFailedScrutiny
+	result := &Result{
+		Status:       &status,
+		StatusReason: "Status forced by user configuration",
+	}
+
+	assert.NotNil(t, result.Status)
+	assert.Equal(t, pkg.AttributeStatusFailedScrutiny, *result.Status)
+	assert.Equal(t, "Status forced by user configuration", result.StatusReason)
+}

--- a/webapp/backend/pkg/web/handler/upload_device_metrics.go
+++ b/webapp/backend/pkg/web/handler/upload_device_metrics.go
@@ -88,6 +88,7 @@ func UploadDeviceMetrics(c *gin.Context) {
 		appConfig.GetBool(fmt.Sprintf("%s.metrics.repeat_notifications", config.DB_USER_SETTINGS_SUBKEY)),
 		c,
 		deviceRepo,
+		appConfig,
 	) {
 		//send notifications
 

--- a/webapp/backend/pkg/web/server_test.go
+++ b/webapp/backend/pkg/web/server_test.go
@@ -121,6 +121,7 @@ func (suite *ServerTestSuite) TestHealthRoute() {
 
 	fakeConfig.EXPECT().GetIntSlice("failures.transient.ata").Return([]int{195}).AnyTimes()
 	fakeConfig.EXPECT().GetStringSlice("failures.ignored.devstat").Return([]string{}).AnyTimes()
+	fakeConfig.EXPECT().Get("smart.attribute_overrides").Return(nil).AnyTimes()
 	if _, isGithubActions := os.LookupEnv("GITHUB_ACTIONS"); isGithubActions {
 		// when running test suite in github actions, we run an influxdb service as a sidecar.
 		fakeConfig.EXPECT().GetString("web.influxdb.host").Return("influxdb").AnyTimes()
@@ -174,6 +175,7 @@ func (suite *ServerTestSuite) TestHealthRoute_MissingFrontend() {
 
 	fakeConfig.EXPECT().GetIntSlice("failures.transient.ata").Return([]int{195}).AnyTimes()
 	fakeConfig.EXPECT().GetStringSlice("failures.ignored.devstat").Return([]string{}).AnyTimes()
+	fakeConfig.EXPECT().Get("smart.attribute_overrides").Return(nil).AnyTimes()
 	if _, isGithubActions := os.LookupEnv("GITHUB_ACTIONS"); isGithubActions {
 		// when running test suite in github actions, we run an influxdb service as a sidecar.
 		fakeConfig.EXPECT().GetString("web.influxdb.host").Return("influxdb").AnyTimes()
@@ -223,6 +225,7 @@ func (suite *ServerTestSuite) TestRegisterDevicesRoute() {
 	fakeConfig.EXPECT().GetBool("web.influxdb.retention_policy").Return(false).AnyTimes()
 	fakeConfig.EXPECT().GetIntSlice("failures.transient.ata").Return([]int{195}).AnyTimes()
 	fakeConfig.EXPECT().GetStringSlice("failures.ignored.devstat").Return([]string{}).AnyTimes()
+	fakeConfig.EXPECT().Get("smart.attribute_overrides").Return(nil).AnyTimes()
 	if _, isGithubActions := os.LookupEnv("GITHUB_ACTIONS"); isGithubActions {
 		// when running test suite in github actions, we run an influxdb service as a sidecar.
 		fakeConfig.EXPECT().GetString("web.influxdb.host").Return("influxdb").AnyTimes()
@@ -274,6 +277,7 @@ func (suite *ServerTestSuite) TestUploadDeviceMetricsRoute() {
 	fakeConfig.EXPECT().GetBool("web.influxdb.retention_policy").Return(false).AnyTimes()
 	fakeConfig.EXPECT().GetIntSlice("failures.transient.ata").Return([]int{195}).AnyTimes()
 	fakeConfig.EXPECT().GetStringSlice("failures.ignored.devstat").Return([]string{}).AnyTimes()
+	fakeConfig.EXPECT().Get("smart.attribute_overrides").Return(nil).AnyTimes()
 	if _, isGithubActions := os.LookupEnv("GITHUB_ACTIONS"); isGithubActions {
 		// when running test suite in github actions, we run an influxdb service as a sidecar.
 		fakeConfig.EXPECT().GetString("web.influxdb.host").Return("influxdb").AnyTimes()
@@ -341,6 +345,7 @@ func (suite *ServerTestSuite) TestPopulateMultiple() {
 	fakeConfig.EXPECT().GetBool("web.influxdb.retention_policy").Return(false).AnyTimes()
 	fakeConfig.EXPECT().GetIntSlice("failures.transient.ata").Return([]int{195}).AnyTimes()
 	fakeConfig.EXPECT().GetStringSlice("failures.ignored.devstat").Return([]string{}).AnyTimes()
+	fakeConfig.EXPECT().Get("smart.attribute_overrides").Return(nil).AnyTimes()
 	if _, isGithubActions := os.LookupEnv("GITHUB_ACTIONS"); isGithubActions {
 		// when running test suite in github actions, we run an influxdb service as a sidecar.
 		fakeConfig.EXPECT().GetString("web.influxdb.host").Return("influxdb").AnyTimes()
@@ -446,6 +451,7 @@ func (suite *ServerTestSuite) TestSendTestNotificationRoute_WebhookFailure() {
 	fakeConfig.EXPECT().GetBool("web.influxdb.retention_policy").Return(false).AnyTimes()
 	fakeConfig.EXPECT().GetIntSlice("failures.transient.ata").Return([]int{195}).AnyTimes()
 	fakeConfig.EXPECT().GetStringSlice("failures.ignored.devstat").Return([]string{}).AnyTimes()
+	fakeConfig.EXPECT().Get("smart.attribute_overrides").Return(nil).AnyTimes()
 	fakeConfig.EXPECT().GetStringSlice("notify.urls").AnyTimes().Return([]string{"https://unroutable.domain.example.asdfghj"})
 	fakeConfig.EXPECT().GetString("notify.urls").Return("").AnyTimes()
 	fakeConfig.EXPECT().GetInt(fmt.Sprintf("%s.metrics.notify_level", config.DB_USER_SETTINGS_SUBKEY)).AnyTimes().Return(int(pkg.MetricsNotifyLevelFail))
@@ -499,6 +505,7 @@ func (suite *ServerTestSuite) TestSendTestNotificationRoute_ScriptFailure() {
 	fakeConfig.EXPECT().GetBool("web.influxdb.retention_policy").Return(false).AnyTimes()
 	fakeConfig.EXPECT().GetIntSlice("failures.transient.ata").Return([]int{195}).AnyTimes()
 	fakeConfig.EXPECT().GetStringSlice("failures.ignored.devstat").Return([]string{}).AnyTimes()
+	fakeConfig.EXPECT().Get("smart.attribute_overrides").Return(nil).AnyTimes()
 	fakeConfig.EXPECT().GetStringSlice("notify.urls").AnyTimes().Return([]string{"script:///missing/path/on/disk"})
 	fakeConfig.EXPECT().GetString("notify.urls").Return("").AnyTimes()
 	fakeConfig.EXPECT().GetInt(fmt.Sprintf("%s.metrics.notify_level", config.DB_USER_SETTINGS_SUBKEY)).AnyTimes().Return(int(pkg.MetricsNotifyLevelFail))
@@ -552,6 +559,7 @@ func (suite *ServerTestSuite) TestSendTestNotificationRoute_ScriptSuccess() {
 	fakeConfig.EXPECT().GetBool("web.influxdb.retention_policy").Return(false).AnyTimes()
 	fakeConfig.EXPECT().GetIntSlice("failures.transient.ata").Return([]int{195}).AnyTimes()
 	fakeConfig.EXPECT().GetStringSlice("failures.ignored.devstat").Return([]string{}).AnyTimes()
+	fakeConfig.EXPECT().Get("smart.attribute_overrides").Return(nil).AnyTimes()
 	fakeConfig.EXPECT().GetStringSlice("notify.urls").AnyTimes().Return([]string{"script:///usr/bin/env"})
 	fakeConfig.EXPECT().GetString("notify.urls").Return("").AnyTimes()
 	fakeConfig.EXPECT().GetInt(fmt.Sprintf("%s.metrics.notify_level", config.DB_USER_SETTINGS_SUBKEY)).AnyTimes().Return(int(pkg.MetricsNotifyLevelFail))
@@ -605,6 +613,7 @@ func (suite *ServerTestSuite) TestSendTestNotificationRoute_ShoutrrrFailure() {
 	fakeConfig.EXPECT().GetBool("web.influxdb.retention_policy").Return(false).AnyTimes()
 	fakeConfig.EXPECT().GetIntSlice("failures.transient.ata").Return([]int{195}).AnyTimes()
 	fakeConfig.EXPECT().GetStringSlice("failures.ignored.devstat").Return([]string{}).AnyTimes()
+	fakeConfig.EXPECT().Get("smart.attribute_overrides").Return(nil).AnyTimes()
 	fakeConfig.EXPECT().GetStringSlice("notify.urls").AnyTimes().Return([]string{"discord://invalidtoken@channel"})
 	fakeConfig.EXPECT().GetString("notify.urls").Return("").AnyTimes()
 	fakeConfig.EXPECT().GetInt(fmt.Sprintf("%s.metrics.notify_level", config.DB_USER_SETTINGS_SUBKEY)).AnyTimes().Return(int(pkg.MetricsNotifyLevelFail))
@@ -659,6 +668,7 @@ func (suite *ServerTestSuite) TestGetDevicesSummaryRoute_Nvme() {
 	fakeConfig.EXPECT().GetBool("web.influxdb.retention_policy").Return(false).AnyTimes()
 	fakeConfig.EXPECT().GetIntSlice("failures.transient.ata").Return([]int{195}).AnyTimes()
 	fakeConfig.EXPECT().GetStringSlice("failures.ignored.devstat").Return([]string{}).AnyTimes()
+	fakeConfig.EXPECT().Get("smart.attribute_overrides").Return(nil).AnyTimes()
 	fakeConfig.EXPECT().GetStringSlice("notify.urls").AnyTimes().Return([]string{})
 	fakeConfig.EXPECT().GetString("notify.urls").Return("").AnyTimes()
 	fakeConfig.EXPECT().GetInt(fmt.Sprintf("%s.metrics.notify_level", config.DB_USER_SETTINGS_SUBKEY)).AnyTimes().Return(int(pkg.MetricsNotifyLevelFail))
@@ -760,6 +770,7 @@ func (suite *ServerTestSuite) TestStaticFileMimeTypes() {
 	fakeConfig.EXPECT().GetBool("web.influxdb.retention_policy").Return(false).AnyTimes()
 	fakeConfig.EXPECT().GetIntSlice("failures.transient.ata").Return([]int{195}).AnyTimes()
 	fakeConfig.EXPECT().GetStringSlice("failures.ignored.devstat").Return([]string{}).AnyTimes()
+	fakeConfig.EXPECT().Get("smart.attribute_overrides").Return(nil).AnyTimes()
 	if _, isGithubActions := os.LookupEnv("GITHUB_ACTIONS"); isGithubActions {
 		fakeConfig.EXPECT().GetString("web.influxdb.host").Return("influxdb").AnyTimes()
 	} else {
@@ -841,6 +852,7 @@ func (suite *ServerTestSuite) TestBrowserSubdirectoryDetection() {
 	fakeConfig.EXPECT().GetBool("web.influxdb.retention_policy").Return(false).AnyTimes()
 	fakeConfig.EXPECT().GetIntSlice("failures.transient.ata").Return([]int{195}).AnyTimes()
 	fakeConfig.EXPECT().GetStringSlice("failures.ignored.devstat").Return([]string{}).AnyTimes()
+	fakeConfig.EXPECT().Get("smart.attribute_overrides").Return(nil).AnyTimes()
 	if _, isGithubActions := os.LookupEnv("GITHUB_ACTIONS"); isGithubActions {
 		fakeConfig.EXPECT().GetString("web.influxdb.host").Return("influxdb").AnyTimes()
 	} else {
@@ -907,6 +919,7 @@ func (suite *ServerTestSuite) TestBrowserSubdirectoryDetection_NoBrowserDir() {
 	fakeConfig.EXPECT().GetBool("web.influxdb.retention_policy").Return(false).AnyTimes()
 	fakeConfig.EXPECT().GetIntSlice("failures.transient.ata").Return([]int{195}).AnyTimes()
 	fakeConfig.EXPECT().GetStringSlice("failures.ignored.devstat").Return([]string{}).AnyTimes()
+	fakeConfig.EXPECT().Get("smart.attribute_overrides").Return(nil).AnyTimes()
 	if _, isGithubActions := os.LookupEnv("GITHUB_ACTIONS"); isGithubActions {
 		fakeConfig.EXPECT().GetString("web.influxdb.host").Return("influxdb").AnyTimes()
 	} else {


### PR DESCRIPTION
## Summary

Implements SCR-114: Allow users to override SMART attribute behavior via configuration. This ports the functionality from upstream PR #835.

Users can now:
- **Ignore specific attributes** to prevent false positives from problematic drives
- **Force attribute status** to passed/warn/failed regardless of actual values
- **Set custom thresholds** (warn_above/fail_above) for numeric attributes

## Changes

- Add new `overrides` package with `AttributeOverride` type and processing functions
- Update SMART processing pipeline (ATA, NVMe, SCSI, DevStats) to apply overrides
- Update `ShouldNotify` to respect ignored attributes when evaluating failures
- Add configuration default for `smart.attribute_overrides`
- Update `example.scrutiny.yaml` with documentation and 5 usage examples

## Configuration Example

```yaml
smart:
  attribute_overrides:
    # Ignore an attribute that causes false positives
    - protocol: ATA
      attribute_id: "187"
      action: ignore

    # Force status for a specific device
    - protocol: NVMe
      attribute_id: "media_errors"
      wwn: "0x5000cca264eb01d7"
      action: force_status
      status: passed

    # Custom thresholds
    - protocol: ATA
      attribute_id: "5"
      warn_above: 5
      fail_above: 10
```

## Test plan

- [x] Unit tests for override logic (26 tests in `pkg/overrides/`)
- [x] Unit tests for models, notify packages pass
- [x] Integration tests with InfluxDB pass
- [x] Build compiles successfully

## Files Changed

| File | Description |
|------|-------------|
| `pkg/overrides/applier.go` | New package with override types and logic |
| `pkg/overrides/applier_test.go` | Unit tests for overrides |
| `pkg/config/config.go` | Add default for `smart.attribute_overrides` |
| `pkg/models/measurements/smart.go` | Apply overrides in processing pipeline |
| `pkg/notify/notify.go` | Respect overrides in notification logic |
| `example.scrutiny.yaml` | Documentation and examples |

Closes #114