### PR TITLE
test(notify): add unit test for muted device notification skip

### DIFF
--- a/webapp/backend/pkg/notify/notify_test.go
+++ b/webapp/backend/pkg/notify/notify_test.go
@@ -34,6 +34,24 @@ func TestShouldNotify_MustSkipPassingDevices(t *testing.T) {
 	require.False(t, ShouldNotify(logrus.StandardLogger(), device, smartAttrs, statusThreshold, notifyFilterAttributes, true, &gin.Context{}, fakeDatabase, nil))
 }
 
+func TestShouldNotify_MustSkipMutedDevices(t *testing.T) {
+	t.Parallel()
+	//setup
+	device := models.Device{
+		DeviceStatus: pkg.DeviceStatusFailedSmart,
+		Muted:        true,
+	}
+	smartAttrs := measurements.Smart{}
+	statusThreshold := pkg.MetricsStatusThresholdBoth
+	notifyFilterAttributes := pkg.MetricsStatusFilterAttributesAll
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	fakeDatabase := mock_database.NewMockDeviceRepo(mockCtrl)
+	//assert
+	require.False(t, ShouldNotify(logrus.StandardLogger(), device, smartAttrs, statusThreshold, notifyFilterAttributes, true, &gin.Context{}, fakeDatabase, nil))
+}
+
 func TestShouldNotify_MetricsStatusThresholdBoth_FailingSmartDevice(t *testing.T) {
 	t.Parallel()
 	//setupD


### PR DESCRIPTION
## Summary

- Adds test coverage for the muted device check in `ShouldNotify()` function
- Verifies that failing devices with `Muted=true` do not trigger notifications

## Context

Issue #113 (Device notification mute/unmute) is fully implemented. This PR adds the only missing piece: a unit test for the notification skip logic.

## Test plan

- [x] New test `TestShouldNotify_MustSkipMutedDevices` passes
- [x] All 17 existing notify tests continue to pass

Closes #113

Generated with [Claude Code](https://claude.ai/code)