### PR TITLE
feat(frontend): add UI for configuring SMART attribute overrides

### DIFF
--- a/webapp/backend/pkg/database/interface.go
+++ b/webapp/backend/pkg/database/interface.go
@@ -7,6 +7,7 @@ import (
 	"github.com/analogj/scrutiny/webapp/backend/pkg/models"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/models/collector"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/models/measurements"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/overrides"
 )
 
 // Create mock using:
@@ -50,4 +51,10 @@ type DeviceRepo interface {
 	// ZFS Pool metrics
 	SaveZFSPoolMetrics(ctx context.Context, pool models.ZFSPool) error
 	GetZFSPoolMetricsHistory(ctx context.Context, guid string, durationKey string) ([]measurements.ZFSPoolMetrics, error)
+
+	// Attribute Override operations
+	GetAttributeOverrides(ctx context.Context) ([]models.AttributeOverride, error)
+	SaveAttributeOverride(ctx context.Context, override models.AttributeOverride) error
+	DeleteAttributeOverride(ctx context.Context, id uint) error
+	GetMergedOverrides(ctx context.Context) []overrides.AttributeOverride
 }

--- a/webapp/backend/pkg/database/migrations/m20260122000000/attribute_override.go
+++ b/webapp/backend/pkg/database/migrations/m20260122000000/attribute_override.go
@@ -1,0 +1,25 @@
+package m20260122000000
+
+import (
+	"gorm.io/gorm"
+)
+
+// AttributeOverride represents a user-configured override for SMART attribute evaluation
+// This is the migration version of the model
+type AttributeOverride struct {
+	gorm.Model
+
+	Protocol    string `gorm:"not null;index:idx_override_lookup"`
+	AttributeId string `gorm:"not null;index:idx_override_lookup"`
+	WWN         string `gorm:"index:idx_override_lookup"`
+	Action      string
+	Status      string
+	WarnAbove   *int64
+	FailAbove   *int64
+	Source      string `gorm:"default:'ui'"`
+}
+
+// TableName specifies the table name for GORM
+func (AttributeOverride) TableName() string {
+	return "attribute_overrides"
+}

--- a/webapp/backend/pkg/database/mock/mock_database.go
+++ b/webapp/backend/pkg/database/mock/mock_database.go
@@ -12,6 +12,7 @@ import (
 	models "github.com/analogj/scrutiny/webapp/backend/pkg/models"
 	collector "github.com/analogj/scrutiny/webapp/backend/pkg/models/collector"
 	measurements "github.com/analogj/scrutiny/webapp/backend/pkg/models/measurements"
+	overrides "github.com/analogj/scrutiny/webapp/backend/pkg/overrides"
 	gomock "github.com/golang/mock/gomock"
 )
 
@@ -456,4 +457,61 @@ func (m *MockDeviceRepo) UpdateZFSPoolMuted(ctx context.Context, guid string, mu
 func (mr *MockDeviceRepoMockRecorder) UpdateZFSPoolMuted(ctx, guid, muted interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateZFSPoolMuted", reflect.TypeOf((*MockDeviceRepo)(nil).UpdateZFSPoolMuted), ctx, guid, muted)
+}
+
+// GetAttributeOverrides mocks base method.
+func (m *MockDeviceRepo) GetAttributeOverrides(ctx context.Context) ([]models.AttributeOverride, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAttributeOverrides", ctx)
+	ret0, _ := ret[0].([]models.AttributeOverride)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAttributeOverrides indicates an expected call of GetAttributeOverrides.
+func (mr *MockDeviceRepoMockRecorder) GetAttributeOverrides(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAttributeOverrides", reflect.TypeOf((*MockDeviceRepo)(nil).GetAttributeOverrides), ctx)
+}
+
+// GetMergedOverrides mocks base method.
+func (m *MockDeviceRepo) GetMergedOverrides(ctx context.Context) []overrides.AttributeOverride {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMergedOverrides", ctx)
+	ret0, _ := ret[0].([]overrides.AttributeOverride)
+	return ret0
+}
+
+// GetMergedOverrides indicates an expected call of GetMergedOverrides.
+func (mr *MockDeviceRepoMockRecorder) GetMergedOverrides(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMergedOverrides", reflect.TypeOf((*MockDeviceRepo)(nil).GetMergedOverrides), ctx)
+}
+
+// SaveAttributeOverride mocks base method.
+func (m *MockDeviceRepo) SaveAttributeOverride(ctx context.Context, override models.AttributeOverride) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SaveAttributeOverride", ctx, override)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SaveAttributeOverride indicates an expected call of SaveAttributeOverride.
+func (mr *MockDeviceRepoMockRecorder) SaveAttributeOverride(ctx, override interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveAttributeOverride", reflect.TypeOf((*MockDeviceRepo)(nil).SaveAttributeOverride), ctx, override)
+}
+
+// DeleteAttributeOverride mocks base method.
+func (m *MockDeviceRepo) DeleteAttributeOverride(ctx context.Context, id uint) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteAttributeOverride", ctx, id)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteAttributeOverride indicates an expected call of DeleteAttributeOverride.
+func (mr *MockDeviceRepoMockRecorder) DeleteAttributeOverride(ctx, id interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAttributeOverride", reflect.TypeOf((*MockDeviceRepo)(nil).DeleteAttributeOverride), ctx, id)
 }

--- a/webapp/backend/pkg/database/scrutiny_repository_device_smart_attributes.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_device_smart_attributes.go
@@ -18,7 +18,11 @@ import (
 // //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 func (sr *scrutinyRepository) SaveSmartAttributes(ctx context.Context, wwn string, collectorSmartData collector.SmartInfo) (measurements.Smart, error) {
 	deviceSmartData := measurements.Smart{}
-	err := deviceSmartData.FromCollectorSmartInfo(sr.appConfig, wwn, collectorSmartData)
+
+	// Get merged overrides (config + database) for SMART attribute processing
+	mergedOverrides := sr.GetMergedOverrides(ctx)
+
+	err := deviceSmartData.FromCollectorSmartInfoWithOverrides(sr.appConfig, wwn, collectorSmartData, mergedOverrides)
 	if err != nil {
 		sr.logger.Errorln("Could not process SMART metrics", err)
 		return measurements.Smart{}, err

--- a/webapp/backend/pkg/database/scrutiny_repository_migrations.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_migrations.go
@@ -16,6 +16,7 @@ import (
 	"github.com/analogj/scrutiny/webapp/backend/pkg/database/migrations/m20250221084400"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/database/migrations/m20251108044508"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/database/migrations/m20260108000000"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/database/migrations/m20260122000000"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/models"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/models/collector"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/models/measurements"
@@ -443,6 +444,12 @@ func (sr *scrutinyRepository) Migrate(ctx context.Context) error {
 					&m20260108000000.ZFSPool{},
 					&m20260108000000.ZFSVdev{},
 				)
+			},
+		},
+		{
+			ID: "m20260122000000", // add attribute_overrides table for UI-configurable SMART overrides
+			Migrate: func(tx *gorm.DB) error {
+				return tx.AutoMigrate(&m20260122000000.AttributeOverride{})
 			},
 		},
 	})

--- a/webapp/backend/pkg/database/scrutiny_repository_overrides.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_overrides.go
@@ -1,0 +1,56 @@
+package database
+
+import (
+	"context"
+
+	"github.com/analogj/scrutiny/webapp/backend/pkg/models"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/overrides"
+)
+
+// GetAttributeOverrides retrieves all attribute overrides from the database
+func (sr *scrutinyRepository) GetAttributeOverrides(ctx context.Context) ([]models.AttributeOverride, error) {
+	var dbOverrides []models.AttributeOverride
+	if err := sr.gormClient.WithContext(ctx).Find(&dbOverrides).Error; err != nil {
+		return nil, err
+	}
+	return dbOverrides, nil
+}
+
+// GetMergedOverrides retrieves overrides from both config file and database,
+// merging them with database overrides taking precedence over config overrides.
+func (sr *scrutinyRepository) GetMergedOverrides(ctx context.Context) []overrides.AttributeOverride {
+	// Get config-based overrides
+	configOverrides := overrides.ParseOverrides(sr.appConfig)
+
+	// Get database overrides
+	dbOverrides, err := sr.GetAttributeOverrides(ctx)
+	if err != nil {
+		// If DB fails, just use config overrides
+		return configOverrides
+	}
+
+	// Convert DB overrides to overrides.AttributeOverride type
+	convertedDBOverrides := models.ConvertToOverrides(dbOverrides)
+
+	// Merge with DB overrides taking precedence
+	return overrides.MergeOverrides(configOverrides, convertedDBOverrides)
+}
+
+// SaveAttributeOverride creates or updates an attribute override
+// If the override has an ID, it will update; otherwise it will create
+func (sr *scrutinyRepository) SaveAttributeOverride(ctx context.Context, override models.AttributeOverride) error {
+	// Ensure source is set to "ui" for database-saved overrides
+	override.Source = "ui"
+
+	if override.ID == 0 {
+		// Create new override
+		return sr.gormClient.WithContext(ctx).Create(&override).Error
+	}
+	// Update existing override
+	return sr.gormClient.WithContext(ctx).Save(&override).Error
+}
+
+// DeleteAttributeOverride removes an attribute override by ID
+func (sr *scrutinyRepository) DeleteAttributeOverride(ctx context.Context, id uint) error {
+	return sr.gormClient.WithContext(ctx).Delete(&models.AttributeOverride{}, id).Error
+}

--- a/webapp/backend/pkg/models/attribute_override.go
+++ b/webapp/backend/pkg/models/attribute_override.go
@@ -1,0 +1,72 @@
+package models
+
+import (
+	"github.com/analogj/scrutiny/webapp/backend/pkg/overrides"
+	"gorm.io/gorm"
+)
+
+// AttributeOverride represents a user-configured override for SMART attribute evaluation
+// stored in the database. This allows users to ignore attributes, force their status,
+// or set custom warning/failure thresholds via the UI.
+type AttributeOverride struct {
+	gorm.Model
+
+	// Required: Protocol type (ATA, NVMe, SCSI)
+	Protocol string `json:"protocol" gorm:"not null;index:idx_override_lookup"`
+
+	// Required: Attribute ID (string for all protocols)
+	// ATA: "5", "187", etc.
+	// ATA DevStats: "devstat_7_8"
+	// NVMe: "media_errors", "percentage_used"
+	// SCSI: "scsi_grown_defect_list"
+	AttributeId string `json:"attribute_id" gorm:"not null;index:idx_override_lookup"`
+
+	// Optional: Limit override to specific device by WWN
+	// If empty, override applies to all devices
+	WWN string `json:"wwn,omitempty" gorm:"index:idx_override_lookup"`
+
+	// Optional: Action to take (ignore or force_status)
+	// If not set, custom thresholds are applied
+	Action string `json:"action,omitempty"`
+
+	// For force_status action: the status to set
+	// Values: "passed", "warn", "failed"
+	Status string `json:"status,omitempty"`
+
+	// Custom threshold: warn when value exceeds this
+	WarnAbove *int64 `json:"warn_above,omitempty"`
+
+	// Custom threshold: fail when value exceeds this (takes precedence over warn)
+	FailAbove *int64 `json:"fail_above,omitempty"`
+
+	// Source indicates where this override came from: "ui" or "config"
+	// UI overrides can be deleted from the interface; config overrides cannot
+	Source string `json:"source" gorm:"default:'ui'"`
+}
+
+// TableName specifies the table name for GORM
+func (AttributeOverride) TableName() string {
+	return "attribute_overrides"
+}
+
+// ToOverride converts the database model to the overrides package type
+func (ao *AttributeOverride) ToOverride() overrides.AttributeOverride {
+	return overrides.AttributeOverride{
+		Protocol:    ao.Protocol,
+		AttributeId: ao.AttributeId,
+		WWN:         ao.WWN,
+		Action:      overrides.AttributeOverrideAction(ao.Action),
+		Status:      ao.Status,
+		WarnAbove:   ao.WarnAbove,
+		FailAbove:   ao.FailAbove,
+	}
+}
+
+// ConvertToOverrides converts a slice of database models to overrides package types
+func ConvertToOverrides(dbOverrides []AttributeOverride) []overrides.AttributeOverride {
+	result := make([]overrides.AttributeOverride, len(dbOverrides))
+	for i := range dbOverrides {
+		result[i] = dbOverrides[i].ToOverride()
+	}
+	return result
+}

--- a/webapp/backend/pkg/web/handler/attribute_overrides.go
+++ b/webapp/backend/pkg/web/handler/attribute_overrides.go
@@ -1,0 +1,129 @@
+package handler
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/analogj/scrutiny/webapp/backend/pkg/database"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/models"
+	"github.com/gin-gonic/gin"
+	"github.com/sirupsen/logrus"
+)
+
+// validProtocols defines the allowed protocol values
+var validProtocols = map[string]bool{
+	"ATA":  true,
+	"NVMe": true,
+	"SCSI": true,
+}
+
+// validActions defines the allowed action values
+var validActions = map[string]bool{
+	"":             true, // empty means custom thresholds only
+	"ignore":       true,
+	"force_status": true,
+}
+
+// validStatuses defines the allowed status values for force_status action
+var validStatuses = map[string]bool{
+	"passed": true,
+	"warn":   true,
+	"failed": true,
+}
+
+// GetAttributeOverrides retrieves all attribute overrides from the database
+func GetAttributeOverrides(c *gin.Context) {
+	logger := c.MustGet("LOGGER").(*logrus.Entry)
+	deviceRepo := c.MustGet("DEVICE_REPOSITORY").(database.DeviceRepo)
+
+	overrides, err := deviceRepo.GetAttributeOverrides(c)
+	if err != nil {
+		logger.Errorln("Error retrieving attribute overrides:", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": "Failed to retrieve overrides"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"success": true,
+		"data":    overrides,
+	})
+}
+
+// SaveAttributeOverride creates or updates an attribute override
+func SaveAttributeOverride(c *gin.Context) {
+	logger := c.MustGet("LOGGER").(*logrus.Entry)
+	deviceRepo := c.MustGet("DEVICE_REPOSITORY").(database.DeviceRepo)
+
+	var override models.AttributeOverride
+	if err := c.BindJSON(&override); err != nil {
+		logger.Errorln("Cannot parse attribute override:", err)
+		c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": "Invalid override data"})
+		return
+	}
+
+	// Validate required fields
+	if override.Protocol == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": "Protocol is required"})
+		return
+	}
+	if override.AttributeId == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": "AttributeId is required"})
+		return
+	}
+
+	// Validate protocol
+	if !validProtocols[override.Protocol] {
+		c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": "Invalid protocol. Must be ATA, NVMe, or SCSI"})
+		return
+	}
+
+	// Validate action
+	if !validActions[override.Action] {
+		c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": "Invalid action. Must be empty, 'ignore', or 'force_status'"})
+		return
+	}
+
+	// Validate status if force_status action is used
+	if override.Action == "force_status" {
+		if override.Status == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": "Status is required when action is 'force_status'"})
+			return
+		}
+		if !validStatuses[override.Status] {
+			c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": "Invalid status. Must be 'passed', 'warn', or 'failed'"})
+			return
+		}
+	}
+
+	// Source is always "ui" for API-created overrides
+	override.Source = "ui"
+
+	if err := deviceRepo.SaveAttributeOverride(c, override); err != nil {
+		logger.Errorln("Error saving attribute override:", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": "Failed to save override"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"success": true, "data": override})
+}
+
+// DeleteAttributeOverride removes an attribute override by ID
+func DeleteAttributeOverride(c *gin.Context) {
+	logger := c.MustGet("LOGGER").(*logrus.Entry)
+	deviceRepo := c.MustGet("DEVICE_REPOSITORY").(database.DeviceRepo)
+
+	idStr := c.Param("id")
+	id, err := strconv.ParseUint(idStr, 10, 32)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": "Invalid ID format"})
+		return
+	}
+
+	if err := deviceRepo.DeleteAttributeOverride(c, uint(id)); err != nil {
+		logger.Errorln("Error deleting attribute override:", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": "Failed to delete override"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"success": true})
+}

--- a/webapp/backend/pkg/web/server.go
+++ b/webapp/backend/pkg/web/server.go
@@ -89,6 +89,11 @@ func (ae *AppEngine) Setup(logger *logrus.Entry) *gin.Engine {
 			api.GET("/settings", handler.GetSettings)   //used to get settings
 			api.POST("/settings", handler.SaveSettings) //used to save settings
 
+			// Attribute Override endpoints (UI-configurable SMART overrides)
+			api.GET("/settings/overrides", handler.GetAttributeOverrides)
+			api.POST("/settings/overrides", handler.SaveAttributeOverride)
+			api.DELETE("/settings/overrides/:id", handler.DeleteAttributeOverride)
+
 			// ZFS Pool API endpoints
 			zfs := api.Group("/zfs")
 			{

--- a/webapp/frontend/src/app/core/config/app.config.ts
+++ b/webapp/frontend/src/app/core/config/app.config.ts
@@ -38,6 +38,33 @@ export enum MetricsStatusThreshold {
     Both = 3
 }
 
+// Protocol types for SMART attribute overrides
+export type OverrideProtocol = 'ATA' | 'NVMe' | 'SCSI';
+
+// Action types for attribute overrides
+export type OverrideAction = 'ignore' | 'force_status' | '';
+
+// Status types for force_status action
+export type OverrideStatus = 'passed' | 'warn' | 'failed';
+
+// Source of the override
+export type OverrideSource = 'config' | 'ui';
+
+/**
+ * AttributeOverride interface for UI-configurable SMART attribute overrides
+ */
+export interface AttributeOverride {
+    id?: number;
+    protocol: OverrideProtocol;
+    attribute_id: string;
+    wwn?: string;
+    action?: OverrideAction;
+    status?: OverrideStatus;
+    warn_above?: number;
+    fail_above?: number;
+    source?: OverrideSource;
+}
+
 /**
  * AppConfig interface. Update this interface to strictly type your config
  * object.

--- a/webapp/frontend/src/app/core/config/attribute-override.service.ts
+++ b/webapp/frontend/src/app/core/config/attribute-override.service.ts
@@ -1,0 +1,55 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { getBasePath } from '../../app.routing';
+import { AttributeOverride } from './app.config';
+
+interface OverridesResponse {
+    success: boolean;
+    data: AttributeOverride[];
+}
+
+interface OverrideResponse {
+    success: boolean;
+    data: AttributeOverride;
+}
+
+interface DeleteResponse {
+    success: boolean;
+}
+
+@Injectable({
+    providedIn: 'root'
+})
+export class AttributeOverrideService {
+    constructor(private http: HttpClient) {}
+
+    /**
+     * Get all attribute overrides from the database
+     */
+    getOverrides(): Observable<AttributeOverride[]> {
+        return this.http.get<OverridesResponse>(
+            getBasePath() + '/api/settings/overrides'
+        ).pipe(map(response => response.data || []));
+    }
+
+    /**
+     * Save (create or update) an attribute override
+     */
+    saveOverride(override: AttributeOverride): Observable<AttributeOverride> {
+        return this.http.post<OverrideResponse>(
+            getBasePath() + '/api/settings/overrides',
+            override
+        ).pipe(map(response => response.data));
+    }
+
+    /**
+     * Delete an attribute override by ID
+     */
+    deleteOverride(id: number): Observable<void> {
+        return this.http.delete<DeleteResponse>(
+            getBasePath() + '/api/settings/overrides/' + id
+        ).pipe(map(() => undefined));
+    }
+}

--- a/webapp/frontend/src/app/layout/common/dashboard-settings/dashboard-settings.component.html
+++ b/webapp/frontend/src/app/layout/common/dashboard-settings/dashboard-settings.component.html
@@ -119,6 +119,126 @@
                 </mat-select>
             </mat-form-field>
         </div>
+
+        <!-- SMART Attribute Overrides Section -->
+        <mat-expansion-panel class="mt-5">
+            <mat-expansion-panel-header>
+                <mat-panel-title>SMART Attribute Overrides</mat-panel-title>
+                <mat-panel-description>
+                    Configure ignored attributes and custom thresholds
+                </mat-panel-description>
+            </mat-expansion-panel-header>
+
+            <div class="flex flex-col p-4">
+                <!-- Existing overrides table -->
+                <table mat-table [dataSource]="overrides" class="w-full" *ngIf="overrides.length > 0">
+                    <ng-container matColumnDef="protocol">
+                        <th mat-header-cell *matHeaderCellDef>Protocol</th>
+                        <td mat-cell *matCellDef="let override">{{override.protocol}}</td>
+                    </ng-container>
+
+                    <ng-container matColumnDef="attribute_id">
+                        <th mat-header-cell *matHeaderCellDef>Attribute ID</th>
+                        <td mat-cell *matCellDef="let override">{{override.attribute_id}}</td>
+                    </ng-container>
+
+                    <ng-container matColumnDef="action">
+                        <th mat-header-cell *matHeaderCellDef>Action</th>
+                        <td mat-cell *matCellDef="let override">{{getActionLabel(override.action)}}</td>
+                    </ng-container>
+
+                    <ng-container matColumnDef="source">
+                        <th mat-header-cell *matHeaderCellDef>Source</th>
+                        <td mat-cell *matCellDef="let override">
+                            <span class="px-2 py-1 text-xs rounded"
+                                  [class.bg-blue-100]="override.source === 'ui'"
+                                  [class.bg-gray-100]="override.source === 'config'">
+                                {{override.source}}
+                            </span>
+                        </td>
+                    </ng-container>
+
+                    <ng-container matColumnDef="actions">
+                        <th mat-header-cell *matHeaderCellDef></th>
+                        <td mat-cell *matCellDef="let override">
+                            <button mat-icon-button
+                                    (click)="removeOverride(override)"
+                                    [disabled]="override.source === 'config'"
+                                    matTooltip="Config file overrides cannot be deleted from UI">
+                                <mat-icon>delete</mat-icon>
+                            </button>
+                        </td>
+                    </ng-container>
+
+                    <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+                    <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+                </table>
+
+                <p *ngIf="overrides.length === 0" class="text-gray-500 italic my-4">
+                    No attribute overrides configured
+                </p>
+
+                <!-- Add new override form -->
+                <div class="mt-4 p-4 border rounded">
+                    <h4 class="mb-4 font-medium">Add New Override</h4>
+
+                    <div class="flex flex-wrap gap-4">
+                        <mat-form-field class="flex-1 min-w-[120px]">
+                            <mat-label>Protocol</mat-label>
+                            <mat-select [(ngModel)]="newOverride.protocol">
+                                <mat-option *ngFor="let p of protocols" [value]="p">{{p}}</mat-option>
+                            </mat-select>
+                        </mat-form-field>
+
+                        <mat-form-field class="flex-1 min-w-[150px]">
+                            <mat-label>Attribute ID</mat-label>
+                            <input matInput [(ngModel)]="newOverride.attribute_id"
+                                   placeholder="e.g., 5, media_errors">
+                        </mat-form-field>
+
+                        <mat-form-field class="flex-1 min-w-[120px]">
+                            <mat-label>Action</mat-label>
+                            <mat-select [(ngModel)]="newOverride.action">
+                                <mat-option *ngFor="let a of actions" [value]="a.value">{{a.label}}</mat-option>
+                            </mat-select>
+                        </mat-form-field>
+
+                        <mat-form-field class="flex-1 min-w-[120px]"
+                                        *ngIf="newOverride.action === 'force_status'">
+                            <mat-label>Status</mat-label>
+                            <mat-select [(ngModel)]="newOverride.status">
+                                <mat-option *ngFor="let s of statuses" [value]="s">{{s}}</mat-option>
+                            </mat-select>
+                        </mat-form-field>
+
+                        <mat-form-field class="flex-1 min-w-[100px]"
+                                        *ngIf="newOverride.action === ''">
+                            <mat-label>Warn Above</mat-label>
+                            <input matInput type="number" [(ngModel)]="newOverride.warn_above">
+                        </mat-form-field>
+
+                        <mat-form-field class="flex-1 min-w-[100px]"
+                                        *ngIf="newOverride.action === ''">
+                            <mat-label>Fail Above</mat-label>
+                            <input matInput type="number" [(ngModel)]="newOverride.fail_above">
+                        </mat-form-field>
+
+                        <mat-form-field class="flex-1 min-w-[200px]">
+                            <mat-label>Device WWN (optional)</mat-label>
+                            <input matInput [(ngModel)]="newOverride.wwn"
+                                   placeholder="Leave empty for all devices">
+                        </mat-form-field>
+                    </div>
+
+                    <button mat-raised-button color="primary"
+                            class="mt-4"
+                            (click)="addOverride()"
+                            [disabled]="!newOverride.protocol || !newOverride.attribute_id">
+                        Add Override
+                    </button>
+                </div>
+            </div>
+        </mat-expansion-panel>
     </div>
 
 </mat-dialog-content>

--- a/webapp/frontend/src/app/layout/common/dashboard-settings/dashboard-settings.module.ts
+++ b/webapp/frontend/src/app/layout/common/dashboard-settings/dashboard-settings.module.ts
@@ -15,6 +15,9 @@ import {MatTabsModule as MatTabsModule} from '@angular/material/tabs';
 import {MatSliderModule as MatSliderModule} from '@angular/material/slider';
 import {MatSlideToggleModule as MatSlideToggleModule} from '@angular/material/slide-toggle';
 import {MatTooltipModule as MatTooltipModule} from '@angular/material/tooltip';
+import {MatTableModule} from '@angular/material/table';
+import {MatExpansionModule} from '@angular/material/expansion';
+import {MatChipsModule} from '@angular/material/chips';
 
 @NgModule({
     declarations: [
@@ -34,6 +37,9 @@ import {MatTooltipModule as MatTooltipModule} from '@angular/material/tooltip';
         MatTooltipModule,
         MatSliderModule,
         MatSlideToggleModule,
+        MatTableModule,
+        MatExpansionModule,
+        MatChipsModule,
         SharedModule
     ],
     exports     : [


### PR DESCRIPTION
## Summary
- Add Dashboard Settings UI section for managing SMART attribute overrides
- Allow users to add/remove overrides without editing config files
- Database overrides take precedence over config file overrides

## Changes

### Backend
- Add `AttributeOverride` model with database migration (`attribute_overrides` table)
- Add repository methods: `GetAttributeOverrides`, `SaveAttributeOverride`, `DeleteAttributeOverride`, `GetMergedOverrides`
- Add API endpoints:
  - `GET /api/settings/overrides` - List all overrides
  - `POST /api/settings/overrides` - Create/update override
  - `DELETE /api/settings/overrides/:id` - Delete override
- Add `ApplyWithOverrides` and `MergeOverrides` functions to overrides package
- Integrate merged overrides into SMART attribute processing pipeline

### Frontend
- Add `AttributeOverride` TypeScript interface and related types
- Add `AttributeOverrideService` for API calls
- Add collapsible "SMART Attribute Overrides" section to Dashboard Settings
- Support three action types: Ignore, Force Status, Custom Threshold
- Show source indicator (config vs UI) with delete disabled for config overrides

## Test plan
- [x] Backend builds successfully
- [x] All backend tests pass
- [x] Frontend builds successfully
- [x] All 124 frontend tests pass
- [ ] Manual testing: Open Dashboard Settings, verify overrides section appears
- [ ] Manual testing: Add an override (e.g., ATA, attribute "5", action "ignore")
- [ ] Manual testing: Verify override appears in table
- [ ] Manual testing: Delete the override
- [ ] Manual testing: Post SMART data and verify override is applied

Closes #97