### PR TITLE
fix(notify): correct repeat notification detection to compare against previous submission

### DIFF
--- a/webapp/backend/pkg/database/interface.go
+++ b/webapp/backend/pkg/database/interface.go
@@ -29,6 +29,9 @@ type DeviceRepo interface {
 
 	SaveSmartAttributes(ctx context.Context, wwn string, collectorSmartData collector.SmartInfo) (measurements.Smart, error)
 	GetSmartAttributeHistory(ctx context.Context, wwn string, durationKey string, selectEntries int, selectEntriesOffset int, attributes []string) ([]measurements.Smart, error)
+	// GetPreviousSmartSubmission returns the previous raw SMART submission (without daily aggregation)
+	// for use in repeat notification detection. Returns the submission before the most recent one.
+	GetPreviousSmartSubmission(ctx context.Context, wwn string) ([]measurements.Smart, error)
 
 	SaveSmartTemperature(ctx context.Context, wwn string, deviceProtocol string, collectorSmartData collector.SmartInfo, retrieveSCTTemperatureHistory bool) error
 

--- a/webapp/backend/pkg/database/mock/mock_database.go
+++ b/webapp/backend/pkg/database/mock/mock_database.go
@@ -126,6 +126,21 @@ func (mr *MockDeviceRepoMockRecorder) GetSmartAttributeHistory(ctx, wwn, duratio
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSmartAttributeHistory", reflect.TypeOf((*MockDeviceRepo)(nil).GetSmartAttributeHistory), ctx, wwn, durationKey, selectEntries, selectEntriesOffset, attributes)
 }
 
+// GetPreviousSmartSubmission mocks base method.
+func (m *MockDeviceRepo) GetPreviousSmartSubmission(ctx context.Context, wwn string) ([]measurements.Smart, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPreviousSmartSubmission", ctx, wwn)
+	ret0, _ := ret[0].([]measurements.Smart)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetPreviousSmartSubmission indicates an expected call of GetPreviousSmartSubmission.
+func (mr *MockDeviceRepoMockRecorder) GetPreviousSmartSubmission(ctx, wwn interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPreviousSmartSubmission", reflect.TypeOf((*MockDeviceRepo)(nil).GetPreviousSmartSubmission), ctx, wwn)
+}
+
 // GetSmartTemperatureHistory mocks base method.
 func (m *MockDeviceRepo) GetSmartTemperatureHistory(ctx context.Context, durationKey string) (map[string][]measurements.SmartTemperature, error) {
 	m.ctrl.T.Helper()

--- a/webapp/backend/pkg/database/scrutiny_repository_device_smart_attributes.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_device_smart_attributes.go
@@ -87,6 +87,49 @@ func (sr *scrutinyRepository) GetSmartAttributeHistory(ctx context.Context, wwn 
 
 }
 
+// GetPreviousSmartSubmission returns the previous raw SMART submission without daily aggregation.
+// This is used for repeat notification detection to compare against the actual previous submission,
+// not the previous day's aggregated value.
+// Returns the second most recent submission (skipping the one just saved).
+func (sr *scrutinyRepository) GetPreviousSmartSubmission(ctx context.Context, wwn string) ([]measurements.Smart, error) {
+	// Query raw data from the metrics bucket (last week) without aggregation
+	// Use offset=1 to skip the most recent entry (which is the one just saved)
+	queryStr := fmt.Sprintf(`
+import "influxdata/influxdb/schema"
+from(bucket: "%s")
+|> range(start: -1w, stop: now())
+|> filter(fn: (r) => r["_measurement"] == "smart")
+|> filter(fn: (r) => r["device_wwn"] == "%s")
+|> schema.fieldsAsCols()
+|> group()
+|> sort(columns: ["_time"], desc: true)
+|> limit(n: 1, offset: 1)
+`, sr.appConfig.GetString("web.influxdb.bucket"), wwn)
+
+	log.Debugln("GetPreviousSmartSubmission query:", queryStr)
+
+	smartResults := []measurements.Smart{}
+
+	result, err := sr.influxQueryApi.Query(ctx, queryStr)
+	if err != nil {
+		return nil, err
+	}
+
+	for result.Next() {
+		smartData, err := measurements.NewSmartFromInfluxDB(result.Record().Values())
+		if err != nil {
+			return nil, err
+		}
+		smartResults = append(smartResults, *smartData)
+	}
+
+	if result.Err() != nil {
+		return nil, result.Err()
+	}
+
+	return smartResults, nil
+}
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Helper Methods
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/webapp/backend/pkg/notify/notify_test.go
+++ b/webapp/backend/pkg/notify/notify_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/analogj/scrutiny/webapp/backend/pkg"
-	"github.com/analogj/scrutiny/webapp/backend/pkg/database"
 	mock_database "github.com/analogj/scrutiny/webapp/backend/pkg/database/mock"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/models"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/models/measurements"
@@ -226,7 +225,7 @@ func TestShouldNotify_NoRepeat_DatabaseFailure(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	fakeDatabase := mock_database.NewMockDeviceRepo(mockCtrl)
-	fakeDatabase.EXPECT().GetSmartAttributeHistory(&gin.Context{}, "", database.DURATION_KEY_FOREVER, 1, 1, []string{"5"}).Return([]measurements.Smart{}, errors.New("")).Times(1)
+	fakeDatabase.EXPECT().GetPreviousSmartSubmission(&gin.Context{}, "").Return([]measurements.Smart{}, errors.New("")).Times(1)
 
 	//assert
 	require.True(t, ShouldNotify(logrus.StandardLogger(), device, smartAttrs, statusThreshold, notifyFilterAttributes, false, &gin.Context{}, fakeDatabase, nil))
@@ -248,7 +247,7 @@ func TestShouldNotify_NoRepeat_NoDatabaseData(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	fakeDatabase := mock_database.NewMockDeviceRepo(mockCtrl)
-	fakeDatabase.EXPECT().GetSmartAttributeHistory(&gin.Context{}, "", database.DURATION_KEY_FOREVER, 1, 1, []string{"5"}).Return([]measurements.Smart{}, nil).Times(1)
+	fakeDatabase.EXPECT().GetPreviousSmartSubmission(&gin.Context{}, "").Return([]measurements.Smart{}, nil).Times(1)
 
 	//assert
 	require.True(t, ShouldNotify(logrus.StandardLogger(), device, smartAttrs, statusThreshold, notifyFilterAttributes, false, &gin.Context{}, fakeDatabase, nil))
@@ -270,7 +269,7 @@ func TestShouldNotify_NoRepeat(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	fakeDatabase := mock_database.NewMockDeviceRepo(mockCtrl)
-	fakeDatabase.EXPECT().GetSmartAttributeHistory(&gin.Context{}, "", database.DURATION_KEY_FOREVER, 1, 1, []string{"5"}).Return([]measurements.Smart{smartAttrs}, nil).Times(1)
+	fakeDatabase.EXPECT().GetPreviousSmartSubmission(&gin.Context{}, "").Return([]measurements.Smart{smartAttrs}, nil).Times(1)
 
 	//assert
 	require.False(t, ShouldNotify(logrus.StandardLogger(), device, smartAttrs, statusThreshold, notifyFilterAttributes, false, &gin.Context{}, fakeDatabase, nil))


### PR DESCRIPTION
## Summary

- Fixes notification repeat issue reported in #67 where notifications repeated despite "only when value changes" setting
- Adds `GetPreviousSmartSubmission()` method that queries raw SMART data without daily aggregation
- Updates `ShouldNotify()` to compare against the actual previous submission instead of the previous day's aggregated value
- Fixes logging bug where `err == nil` was incorrectly used instead of `err != nil`

## Root Cause

The repeat detection logic was using `GetSmartAttributeHistory()` with daily aggregation (`aggregateWindow(every: 1d)`) and `offset=1`. This meant:

1. All submissions within a day were aggregated into a single entry
2. `offset=1` skipped today's aggregated entry and returned yesterday's value
3. Comparison was always `current_value != yesterday_value`

This caused every collector run to notify if the value changed from the previous day, even when the value was stable throughout the current day.

## Fix

Added a new method `GetPreviousSmartSubmission()` that queries raw data points without aggregation, allowing proper comparison against the actual previous submission.

## Test plan

- [x] All existing notify tests pass
- [x] Build compiles successfully
- [ ] Manual testing with repeat notifications disabled to verify notifications only fire when values actually change

Fixes #67