### PR TITLE
fix(backend): use safe type assertions for SMART metrics parsing

### DIFF
--- a/webapp/backend/pkg/models/measurements/smart.go
+++ b/webapp/backend/pkg/models/measurements/smart.go
@@ -69,11 +69,23 @@ func NewSmartFromInfluxDB(attrs map[string]interface{}) (*Smart, error) {
 	for key, val := range attrs {
 		switch key {
 		case "temp":
-			sm.Temp = val.(int64)
+			if intVal, ok := val.(int64); ok {
+				sm.Temp = intVal
+			} else {
+				log.Printf("unable to parse temp information: %v", val)
+			}
 		case "power_on_hours":
-			sm.PowerOnHours = val.(int64)
+			if intVal, ok := val.(int64); ok {
+				sm.PowerOnHours = intVal
+			} else {
+				log.Printf("unable to parse power_on_hours information: %v", val)
+			}
 		case "power_cycle_count":
-			sm.PowerCycleCount = val.(int64)
+			if intVal, ok := val.(int64); ok {
+				sm.PowerCycleCount = intVal
+			} else {
+				log.Printf("unable to parse power_cycle_count information: %v", val)
+			}
 		case "logical_block_size":
 			if intVal, ok := val.(int64); ok {
 				sm.LogicalBlockSize = intVal


### PR DESCRIPTION
## Summary
- Add safe type assertions with `ok` checks for `temp`, `power_on_hours`, and `power_cycle_count` fields in `NewSmartFromInfluxDB`
- Prevents panics when InfluxDB returns unexpected data types (nil, float64, etc.)
- Follows existing pattern used for `logical_block_size` in the same function

## Test plan
- [x] Existing `TestNewSmartFromInfluxDB_*` tests pass
- [x] Full backend test suite passes
- [ ] Verify no panics occur with malformed InfluxDB data in production

Closes #107

:robot: Generated with [Claude Code](https://claude.ai/code)