### PR TITLE
fix(docker): use exec in service scripts to reduce process overhead

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -78,4 +78,4 @@ RUN chmod 0644 /etc/cron.d/scrutiny && \
     chmod +x /etc/services.d/*/run && \
     chmod +x /etc/services.d/*/finish
 
-CMD ["/init"]
+ENTRYPOINT ["/init"]

--- a/rootfs/etc/services.d/cron/run
+++ b/rootfs/etc/services.d/cron/run
@@ -1,4 +1,4 @@
 #!/command/with-contenv bash
 
 echo "starting cron"
-cron -f -L 15
+exec cron -f -L 15

--- a/rootfs/etc/services.d/influxdb/run
+++ b/rootfs/etc/services.d/influxdb/run
@@ -14,4 +14,4 @@ EOF
 fi
 
 echo "starting influxdb"
-influxd run
+exec influxd run

--- a/rootfs/etc/services.d/scrutiny/run
+++ b/rootfs/etc/services.d/scrutiny/run
@@ -4,4 +4,4 @@ echo "waiting for influxdb"
 until $(curl --output /dev/null --silent --head --fail http://localhost:8086/health); do echo "influxdb not ready" && sleep 5; done
 
 echo "starting scrutiny"
-scrutiny start
+exec scrutiny start


### PR DESCRIPTION
## Summary

- Use `exec` in s6 service scripts to replace shell processes with main service processes
- Change `CMD` to `ENTRYPOINT` in omnibus Dockerfile for proper init system handling
- Eliminates 3 unnecessary bash processes from the container process tree

## Changes

| File | Change |
|------|--------|
| `docker/Dockerfile` | `CMD ["/init"]` to `ENTRYPOINT ["/init"]` |
| `rootfs/etc/services.d/cron/run` | Add `exec` before `cron -f -L 15` |
| `rootfs/etc/services.d/influxdb/run` | Add `exec` before `influxd run` |
| `rootfs/etc/services.d/scrutiny/run` | Add `exec` before `scrutiny start` |

## Files NOT Changed (intentional)

- **`entrypoint-collector.sh`** - Already uses `exec`
- **`collector-once/run`** - One-shot service with cleanup code after; `exec` would break it

## Expected Result

Process tree changes from:
```
s6-svscan
  |- s6-supervise -> bash -> cron
  |- s6-supervise -> bash -> influxd
  |- s6-supervise -> bash -> scrutiny
```

To:
```
s6-svscan
  |- s6-supervise -> cron
  |- s6-supervise -> influxd
  |- s6-supervise -> scrutiny
```

## Test plan

- [ ] Build omnibus Docker image
- [ ] Verify container starts correctly
- [ ] Check process tree shows no intermediate bash processes
- [ ] Test graceful container shutdown

Closes #111