### PR TITLE
fix(api): return attribute override ID after save for UI deletion

### DIFF
--- a/webapp/backend/pkg/database/interface.go
+++ b/webapp/backend/pkg/database/interface.go
@@ -62,7 +62,7 @@ type DeviceRepo interface {
 
 	// Attribute Override operations
 	GetAttributeOverrides(ctx context.Context) ([]models.AttributeOverride, error)
-	SaveAttributeOverride(ctx context.Context, override models.AttributeOverride) error
+	SaveAttributeOverride(ctx context.Context, override *models.AttributeOverride) error
 	DeleteAttributeOverride(ctx context.Context, id uint) error
 	GetMergedOverrides(ctx context.Context) []overrides.AttributeOverride
 }

--- a/webapp/backend/pkg/database/mock/mock_database.go
+++ b/webapp/backend/pkg/database/mock/mock_database.go
@@ -520,7 +520,7 @@ func (mr *MockDeviceRepoMockRecorder) GetMergedOverrides(ctx interface{}) *gomoc
 }
 
 // SaveAttributeOverride mocks base method.
-func (m *MockDeviceRepo) SaveAttributeOverride(ctx context.Context, override models.AttributeOverride) error {
+func (m *MockDeviceRepo) SaveAttributeOverride(ctx context.Context, override *models.AttributeOverride) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SaveAttributeOverride", ctx, override)
 	ret0, _ := ret[0].(error)

--- a/webapp/backend/pkg/database/scrutiny_repository_overrides.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_overrides.go
@@ -38,16 +38,17 @@ func (sr *scrutinyRepository) GetMergedOverrides(ctx context.Context) []override
 
 // SaveAttributeOverride creates or updates an attribute override
 // If the override has an ID, it will update; otherwise it will create
-func (sr *scrutinyRepository) SaveAttributeOverride(ctx context.Context, override models.AttributeOverride) error {
+// Uses pointer so that GORM can populate the ID field after creation
+func (sr *scrutinyRepository) SaveAttributeOverride(ctx context.Context, override *models.AttributeOverride) error {
 	// Ensure source is set to "ui" for database-saved overrides
 	override.Source = "ui"
 
 	if override.ID == 0 {
 		// Create new override
-		return sr.gormClient.WithContext(ctx).Create(&override).Error
+		return sr.gormClient.WithContext(ctx).Create(override).Error
 	}
 	// Update existing override
-	return sr.gormClient.WithContext(ctx).Save(&override).Error
+	return sr.gormClient.WithContext(ctx).Save(override).Error
 }
 
 // DeleteAttributeOverride removes an attribute override by ID

--- a/webapp/backend/pkg/models/attribute_override.go
+++ b/webapp/backend/pkg/models/attribute_override.go
@@ -1,6 +1,8 @@
 package models
 
 import (
+	"time"
+
 	"github.com/analogj/scrutiny/webapp/backend/pkg/overrides"
 	"gorm.io/gorm"
 )
@@ -9,7 +11,11 @@ import (
 // stored in the database. This allows users to ignore attributes, force their status,
 // or set custom warning/failure thresholds via the UI.
 type AttributeOverride struct {
-	gorm.Model
+	// Explicit ID field with lowercase JSON tag for frontend compatibility
+	ID        uint           `json:"id" gorm:"primaryKey"`
+	CreatedAt time.Time      `json:"created_at"`
+	UpdatedAt time.Time      `json:"updated_at"`
+	DeletedAt gorm.DeletedAt `json:"deleted_at" gorm:"index"`
 
 	// Required: Protocol type (ATA, NVMe, SCSI)
 	Protocol string `json:"protocol" gorm:"not null;index:idx_override_lookup"`

--- a/webapp/backend/pkg/web/handler/attribute_overrides.go
+++ b/webapp/backend/pkg/web/handler/attribute_overrides.go
@@ -98,7 +98,7 @@ func SaveAttributeOverride(c *gin.Context) {
 	// Source is always "ui" for API-created overrides
 	override.Source = "ui"
 
-	if err := deviceRepo.SaveAttributeOverride(c, override); err != nil {
+	if err := deviceRepo.SaveAttributeOverride(c, &override); err != nil {
 		logger.Errorln("Error saving attribute override:", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": "Failed to save override"})
 		return


### PR DESCRIPTION
## Summary
- Fixes delete button not working for SMART attribute overrides in the UI
- Two bugs were identified and fixed:
  1. `SaveAttributeOverride` passed struct by value, so GORM's auto-generated ID wasn't returned
  2. `gorm.Model` serialized ID as `"ID"` but frontend expected lowercase `"id"`

## Changes
- Replace `gorm.Model` embedding with explicit fields + proper `json:"id"` tag
- Change `SaveAttributeOverride` to use pointer parameter so ID propagates back
- Update interface, handler, and mock signatures to match

## Test plan
- [x] Backend builds successfully
- [x] All backend tests pass
- [ ] Manual test: Add attribute override via UI, verify delete button works immediately

Fixes #141