### PR TITLE
refactor(backend): replace fmt.Printf with structured logging (#136)

### DIFF
--- a/webapp/backend/cmd/scrutiny/scrutiny.go
+++ b/webapp/backend/cmd/scrutiny/scrutiny.go
@@ -111,7 +111,7 @@ OPTIONS:
 						err = config.ReadConfig(c.String("config"), bootstrapLogger) // Find and read the config file
 						if err != nil {                                              // Handle errors reading the config file
 							//ignore "could not find config file"
-							fmt.Printf("Could not find config file at specified path: %s", c.String("config"))
+							bootstrapLogger.Printf("Could not find config file at specified path: %s", c.String("config"))
 							return err
 						}
 					}

--- a/webapp/backend/pkg/database/scrutiny_repository.go
+++ b/webapp/backend/pkg/database/scrutiny_repository.go
@@ -504,7 +504,7 @@ func (sr *scrutinyRepository) GetSummary(ctx context.Context) (map[string]*model
 			}
 		}
 		if result.Err() != nil {
-			fmt.Printf("Query error: %s\n", result.Err().Error())
+			sr.logger.Errorf("Query error: %s", result.Err().Error())
 		}
 	} else {
 		return nil, err
@@ -512,12 +512,7 @@ func (sr *scrutinyRepository) GetSummary(ctx context.Context) (map[string]*model
 
 	deviceTempHistory, err := sr.GetSmartTemperatureHistory(ctx, DURATION_KEY_FOREVER)
 	if err != nil {
-		sr.logger.Printf("========================>>>>>>>>======================")
-		sr.logger.Printf("========================>>>>>>>>======================")
-		sr.logger.Printf("========================>>>>>>>>======================")
-		sr.logger.Printf("========================>>>>>>>>======================")
-		sr.logger.Printf("========================>>>>>>>>======================")
-		sr.logger.Printf("Error: %v", err)
+		sr.logger.Errorf("Error getting temperature history: %v", err)
 	}
 	for wwn, tempHistory := range deviceTempHistory {
 		summaries[wwn].TempHistory = tempHistory

--- a/webapp/backend/pkg/database/scrutiny_repository_device.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_device.go
@@ -76,7 +76,7 @@ func (sr *scrutinyRepository) ResetDeviceStatus(ctx context.Context, wwn string)
 func (sr *scrutinyRepository) GetDeviceDetails(ctx context.Context, wwn string) (models.Device, error) {
 	var device models.Device
 
-	fmt.Println("GetDeviceDetails from GORM")
+	sr.logger.Debugln("GetDeviceDetails from GORM")
 
 	if err := sr.gormClient.WithContext(ctx).Where("wwn = ?", wwn).First(&device).Error; err != nil {
 		return models.Device{}, err

--- a/webapp/backend/pkg/database/scrutiny_repository_device_smart_attributes.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_device_smart_attributes.go
@@ -65,7 +65,7 @@ func (sr *scrutinyRepository) GetSmartAttributeHistory(ctx context.Context, wwn 
 
 		}
 		if result.Err() != nil {
-			fmt.Printf("Query error: %s\n", result.Err().Error())
+			sr.logger.Errorf("Query error: %s", result.Err().Error())
 		}
 	} else {
 		return nil, err

--- a/webapp/backend/pkg/database/scrutiny_repository_temperature.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_temperature.go
@@ -91,7 +91,7 @@ func (sr *scrutinyRepository) GetSmartTemperatureHistory(ctx context.Context, du
 			}
 		}
 		if result.Err() != nil {
-			fmt.Printf("Query error: %s\n", result.Err().Error())
+			sr.logger.Errorf("Query error: %s", result.Err().Error())
 		}
 	} else {
 		return nil, err

--- a/webapp/backend/pkg/notify/notify.go
+++ b/webapp/backend/pkg/notify/notify.go
@@ -393,8 +393,6 @@ func (n *Notify) SendScriptNotification(scriptUrl string) error {
 }
 
 func (n *Notify) SendShoutrrrNotification(shoutrrrUrl string) error {
-
-	fmt.Printf("Sending Notifications to %v", shoutrrrUrl)
 	n.Logger.Infof("Sending notifications to %v", shoutrrrUrl)
 
 	sender, err := shoutrrr.CreateSender(shoutrrrUrl)


### PR DESCRIPTION
## Summary

- Remove duplicate `fmt.Printf` in notify.go (was logging same message twice)
- Replace debug `fmt.Println` with `sr.logger.Debugln` in repository_device.go
- Replace `fmt.Printf` error logging with `sr.logger.Errorf` in repository files
- Clean up debug print statements (`===` lines) in scrutiny_repository.go
- Use `bootstrapLogger` instead of `fmt.Printf` in scrutiny.go startup

## Test plan

- [x] Build passes (`go build ./...`)
- [x] All tests pass (`go test ./...`)
- [ ] Manual verification that logs appear correctly

Closes #136