### PR TITLE
feat(config): make InfluxDB retention periods configurable (#138)

### DIFF
--- a/example.scrutiny.yaml
+++ b/example.scrutiny.yaml
@@ -51,6 +51,15 @@ web:
 #    org: 'my-org'
 #    bucket: 'bucket'
     retention_policy: true
+    # Retention periods for InfluxDB buckets (in seconds)
+    # These control how long metrics data is kept in each downsampling bucket
+    # See docs/DOWNSAMPLING.md for details on the bucket structure
+    #
+    # retention:
+    #   daily: 1296000    # 15 days (default) - raw metrics bucket
+    #   weekly: 5443200   # 9 weeks (default) - weekly aggregated data
+    #   monthly: 65318400 # 25 months (default) - monthly aggregated data
+    #   # yearly bucket has infinite retention (not configurable)
 
   # Prometheus metrics endpoint configuration
   metrics:

--- a/webapp/backend/pkg/config/config.go
+++ b/webapp/backend/pkg/config/config.go
@@ -54,6 +54,14 @@ func (c *configuration) Init() error {
 	c.SetDefault("web.influxdb.tls.insecure_skip_verify", false)
 	c.SetDefault("web.influxdb.retention_policy", true)
 
+	// InfluxDB retention period settings (in seconds)
+	// daily bucket: 15 days = 60*60*24*15 = 1,296,000 seconds
+	c.SetDefault("web.influxdb.retention.daily", 1_296_000)
+	// weekly bucket: 9 weeks = 60*60*24*7*9 = 5,443,200 seconds
+	c.SetDefault("web.influxdb.retention.weekly", 5_443_200)
+	// monthly bucket: 25 months = 60*60*24*7*(52+52+4) = 65,318,400 seconds
+	c.SetDefault("web.influxdb.retention.monthly", 65_318_400)
+
 	c.SetDefault("failures.transient.ata", []int{195})
 
 	// SMART attribute overrides - allows users to ignore, force status, or set custom thresholds

--- a/webapp/backend/pkg/database/scrutiny_repository.go
+++ b/webapp/backend/pkg/database/scrutiny_repository.go
@@ -25,14 +25,11 @@ import (
 )
 
 const (
-	// 60seconds * 60minutes * 24hours * 15 days
-	RETENTION_PERIOD_15_DAYS_IN_SECONDS = 1_296_000
-
-	// 60seconds * 60minutes * 24hours * 7 days * 9 weeks
-	RETENTION_PERIOD_9_WEEKS_IN_SECONDS = 5_443_200
-
-	// 60seconds * 60minutes * 24hours * 7 days * (52 + 52 + 4)weeks
-	RETENTION_PERIOD_25_MONTHS_IN_SECONDS = 65_318_400
+	// Default retention periods (in seconds) - can be overridden via config
+	// These constants are kept for backwards compatibility and migration code
+	DEFAULT_RETENTION_PERIOD_15_DAYS_IN_SECONDS = 1_296_000   // 60*60*24*15
+	DEFAULT_RETENTION_PERIOD_9_WEEKS_IN_SECONDS = 5_443_200   // 60*60*24*7*9
+	DEFAULT_RETENTION_PERIOD_25_MONTHS_IN_SECONDS = 65_318_400 // 60*60*24*7*(52+52+4)
 
 	DURATION_KEY_DAY     = "day"
 	DURATION_KEY_WEEK    = "week"
@@ -308,9 +305,9 @@ func (sr *scrutinyRepository) EnsureBuckets(ctx context.Context, org *domain.Org
 
 		// in tests, we may not want to set a retention policy. If "false", we can set data with old timestamps,
 		// then manually run the down sampling scripts. This should be true for production environments.
-		mainBucketRetentionRule = domain.RetentionRule{EverySeconds: RETENTION_PERIOD_15_DAYS_IN_SECONDS}
-		weeklyBucketRetentionRule = domain.RetentionRule{EverySeconds: RETENTION_PERIOD_9_WEEKS_IN_SECONDS}
-		monthlyBucketRetentionRule = domain.RetentionRule{EverySeconds: RETENTION_PERIOD_25_MONTHS_IN_SECONDS}
+		mainBucketRetentionRule = domain.RetentionRule{EverySeconds: int64(sr.appConfig.GetInt("web.influxdb.retention.daily"))}
+		weeklyBucketRetentionRule = domain.RetentionRule{EverySeconds: int64(sr.appConfig.GetInt("web.influxdb.retention.weekly"))}
+		monthlyBucketRetentionRule = domain.RetentionRule{EverySeconds: int64(sr.appConfig.GetInt("web.influxdb.retention.monthly"))}
 	}
 
 	mainBucket := sr.appConfig.GetString("web.influxdb.bucket")

--- a/webapp/backend/pkg/database/scrutiny_repository_migrations.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_migrations.go
@@ -96,9 +96,9 @@ func (sr *scrutinyRepository) Migrate(ctx context.Context) error {
 
 				//calculate bucket oldest dates
 				today := time.Now()
-				dailyBucketMax := today.Add(-RETENTION_PERIOD_15_DAYS_IN_SECONDS * time.Second)     //15 days
-				weeklyBucketMax := today.Add(-RETENTION_PERIOD_9_WEEKS_IN_SECONDS * time.Second)    //9 weeks
-				monthlyBucketMax := today.Add(-RETENTION_PERIOD_25_MONTHS_IN_SECONDS * time.Second) //25 weeks
+				dailyBucketMax := today.Add(-DEFAULT_RETENTION_PERIOD_15_DAYS_IN_SECONDS * time.Second)     //15 days
+				weeklyBucketMax := today.Add(-DEFAULT_RETENTION_PERIOD_9_WEEKS_IN_SECONDS * time.Second)    //9 weeks
+				monthlyBucketMax := today.Add(-DEFAULT_RETENTION_PERIOD_25_MONTHS_IN_SECONDS * time.Second) //25 months
 
 				for _, preDevice := range preDevices {
 					sr.logger.Debugf("====================================")


### PR DESCRIPTION
## Summary

- Add config options for retention periods:
  - `web.influxdb.retention.daily` (default: 15 days)
  - `web.influxdb.retention.weekly` (default: 9 weeks)
  - `web.influxdb.retention.monthly` (default: 25 months)
- Update `EnsureBuckets` to use config values instead of hardcoded constants
- Rename constants to `DEFAULT_*` prefix for backwards compatibility in migrations
- Document retention settings in example.scrutiny.yaml

Users can now customize how long metrics data is retained without recompiling.

## Test plan

- [x] Build passes (`go build ./...`)
- [x] All tests pass (`go test ./...`)
- [ ] Manual verification that retention periods are applied correctly

Closes #138