### PR TITLE
fix(docker): add SYS_ADMIN capability for NVMe device support

### DIFF
--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -4,11 +4,11 @@ services:
     image: ghcr.io/starosdev/scrutiny:develop-omnibus
     cap_add:
       - SYS_RAWIO
+      - SYS_ADMIN  # Required for NVMe devices
     ports:
       - "8081:8080"
     volumes:
       - ./config/dev:/opt/scrutiny/config
       - ./influxdb/dev:/opt/scrutiny/influxdb
-    privileged: true
     environment:
       - TZ=America/Los_Angeles

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -4,11 +4,11 @@ services:
     image: ghcr.io/starosdev/scrutiny:latest
     cap_add:
       - SYS_RAWIO
+      - SYS_ADMIN  # Required for NVMe devices
     ports:
       - "8080:8080"
     volumes:
       - ./config/prod:/opt/scrutiny/config
       - ./influxdb/prod:/opt/scrutiny/influxdb
-    privileged: true
     environment:
       - TZ=America/Los_Angeles

--- a/docker/example.hubspoke.docker-compose.yml
+++ b/docker/example.hubspoke.docker-compose.yml
@@ -39,6 +39,7 @@ services:
     image: 'ghcr.io/starosdev/scrutiny:latest-collector'
     cap_add:
       - SYS_RAWIO
+      - SYS_ADMIN  # Required for NVMe devices
     volumes:
       - '/run/udev:/run/udev:ro'
     environment:

--- a/docker/example.omnibus.docker-compose.yml
+++ b/docker/example.omnibus.docker-compose.yml
@@ -7,6 +7,7 @@ services:
     image: ghcr.io/starosdev/scrutiny:latest-omnibus
     cap_add:
       - SYS_RAWIO
+      - SYS_ADMIN  # Required for NVMe devices
     ports:
       - "8080:8080" # webapp
       - "8086:8086" # influxDB admin


### PR DESCRIPTION
## Summary

Fixes NVMe SMART data collection by adding the `SYS_ADMIN` capability to all docker-compose files. NVMe devices require both `SYS_RAWIO` and `SYS_ADMIN` capabilities to execute NVMe admin commands.

## Problem

Without `SYS_ADMIN`, smartctl cannot execute NVMe admin commands (`NVME_IOCTL_ADMIN_CMD`) and returns "Permission denied" errors. This causes NVMe devices to display:
- ∞°C temperature
- No power-on hours (--)
- 0% usage percentage
- Missing all SMART health data

## Root Cause

The README.md (line 133) documents that NVMe drives require `--cap-add SYS_ADMIN`, but the example docker-compose files only included `SYS_RAWIO`. New users copying these examples would encounter the same issue.

## Solution

Added `SYS_ADMIN` capability to all docker-compose configurations:
- `docker/example.omnibus.docker-compose.yml`
- `docker/example.hubspoke.docker-compose.yml`
- `docker-compose.dev.yaml`
- `docker-compose.prod.yaml`

Also removed unnecessary `privileged: true` from dev/prod files, as specific capabilities are more secure than privileged mode.

## Testing

Verified on dev environment:
- **Before**: NVMe devices returned "Permission denied" and 400 Bad Request errors
- **After**: NVMe devices successfully upload SMART data (200 OK) with valid metrics

NVMe0 (Samsung 960 EVO 250GB):
- Temperature: 38°C ✓
- Power-on hours: 15,400 ✓
- Percentage used: 64% ✓

NVMe1 (Samsung 980 1TB):
- Temperature: 37°C ✓
- Power-on hours: 21,964 ✓
- Percentage used: 47% ✓

## References

- README.md lines 132-133 (documents SYS_ADMIN requirement)
- docs/TROUBLESHOOTING_DEVICE_COLLECTOR.md lines 125-135
- Related issues: #26, #209