### PR TITLE
feat(diagnostics): add comprehensive diagnostics for missed ping monitoring

### DIFF
--- a/webapp/backend/pkg/database/interface.go
+++ b/webapp/backend/pkg/database/interface.go
@@ -56,6 +56,10 @@ type DeviceRepo interface {
 	// This is used for missed collector ping detection.
 	GetDevicesLastSeenTimes(ctx context.Context) (map[string]time.Time, error)
 
+	// GetAvailableInfluxDBBuckets returns a list of bucket names available in InfluxDB.
+	// This is used for diagnostics to verify required buckets exist.
+	GetAvailableInfluxDBBuckets(ctx context.Context) ([]string, error)
+
 	LoadSettings(ctx context.Context) (*models.Settings, error)
 	SaveSettings(ctx context.Context, settings models.Settings) error
 

--- a/webapp/backend/pkg/database/mock/mock_database.go
+++ b/webapp/backend/pkg/database/mock/mock_database.go
@@ -55,6 +55,20 @@ func (mr *MockDeviceRepoMockRecorder) Close() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockDeviceRepo)(nil).Close))
 }
 
+// DeleteAttributeOverride mocks base method.
+func (m *MockDeviceRepo) DeleteAttributeOverride(ctx context.Context, id uint) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteAttributeOverride", ctx, id)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteAttributeOverride indicates an expected call of DeleteAttributeOverride.
+func (mr *MockDeviceRepoMockRecorder) DeleteAttributeOverride(ctx, id interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAttributeOverride", reflect.TypeOf((*MockDeviceRepo)(nil).DeleteAttributeOverride), ctx, id)
+}
+
 // DeleteDevice mocks base method.
 func (m *MockDeviceRepo) DeleteDevice(ctx context.Context, wwn string) error {
 	m.ctrl.T.Helper()
@@ -81,6 +95,36 @@ func (m *MockDeviceRepo) DeleteZFSPool(ctx context.Context, guid string) error {
 func (mr *MockDeviceRepoMockRecorder) DeleteZFSPool(ctx, guid interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteZFSPool", reflect.TypeOf((*MockDeviceRepo)(nil).DeleteZFSPool), ctx, guid)
+}
+
+// GetAttributeOverrides mocks base method.
+func (m *MockDeviceRepo) GetAttributeOverrides(ctx context.Context) ([]models.AttributeOverride, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAttributeOverrides", ctx)
+	ret0, _ := ret[0].([]models.AttributeOverride)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAttributeOverrides indicates an expected call of GetAttributeOverrides.
+func (mr *MockDeviceRepoMockRecorder) GetAttributeOverrides(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAttributeOverrides", reflect.TypeOf((*MockDeviceRepo)(nil).GetAttributeOverrides), ctx)
+}
+
+// GetAvailableInfluxDBBuckets mocks base method.
+func (m *MockDeviceRepo) GetAvailableInfluxDBBuckets(ctx context.Context) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAvailableInfluxDBBuckets", ctx)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAvailableInfluxDBBuckets indicates an expected call of GetAvailableInfluxDBBuckets.
+func (mr *MockDeviceRepoMockRecorder) GetAvailableInfluxDBBuckets(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAvailableInfluxDBBuckets", reflect.TypeOf((*MockDeviceRepo)(nil).GetAvailableInfluxDBBuckets), ctx)
 }
 
 // GetDeviceDetails mocks base method.
@@ -113,19 +157,33 @@ func (mr *MockDeviceRepoMockRecorder) GetDevices(ctx interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDevices", reflect.TypeOf((*MockDeviceRepo)(nil).GetDevices), ctx)
 }
 
-// GetSmartAttributeHistory mocks base method.
-func (m *MockDeviceRepo) GetSmartAttributeHistory(ctx context.Context, wwn, durationKey string, selectEntries, selectEntriesOffset int, attributes []string) ([]measurements.Smart, error) {
+// GetDevicesLastSeenTimes mocks base method.
+func (m *MockDeviceRepo) GetDevicesLastSeenTimes(ctx context.Context) (map[string]time.Time, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetSmartAttributeHistory", ctx, wwn, durationKey, selectEntries, selectEntriesOffset, attributes)
-	ret0, _ := ret[0].([]measurements.Smart)
+	ret := m.ctrl.Call(m, "GetDevicesLastSeenTimes", ctx)
+	ret0, _ := ret[0].(map[string]time.Time)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetSmartAttributeHistory indicates an expected call of GetSmartAttributeHistory.
-func (mr *MockDeviceRepoMockRecorder) GetSmartAttributeHistory(ctx, wwn, durationKey, selectEntries, selectEntriesOffset, attributes interface{}) *gomock.Call {
+// GetDevicesLastSeenTimes indicates an expected call of GetDevicesLastSeenTimes.
+func (mr *MockDeviceRepoMockRecorder) GetDevicesLastSeenTimes(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSmartAttributeHistory", reflect.TypeOf((*MockDeviceRepo)(nil).GetSmartAttributeHistory), ctx, wwn, durationKey, selectEntries, selectEntriesOffset, attributes)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDevicesLastSeenTimes", reflect.TypeOf((*MockDeviceRepo)(nil).GetDevicesLastSeenTimes), ctx)
+}
+
+// GetMergedOverrides mocks base method.
+func (m *MockDeviceRepo) GetMergedOverrides(ctx context.Context) []overrides.AttributeOverride {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMergedOverrides", ctx)
+	ret0, _ := ret[0].([]overrides.AttributeOverride)
+	return ret0
+}
+
+// GetMergedOverrides indicates an expected call of GetMergedOverrides.
+func (mr *MockDeviceRepoMockRecorder) GetMergedOverrides(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMergedOverrides", reflect.TypeOf((*MockDeviceRepo)(nil).GetMergedOverrides), ctx)
 }
 
 // GetPreviousSmartSubmission mocks base method.
@@ -141,6 +199,21 @@ func (m *MockDeviceRepo) GetPreviousSmartSubmission(ctx context.Context, wwn str
 func (mr *MockDeviceRepoMockRecorder) GetPreviousSmartSubmission(ctx, wwn interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPreviousSmartSubmission", reflect.TypeOf((*MockDeviceRepo)(nil).GetPreviousSmartSubmission), ctx, wwn)
+}
+
+// GetSmartAttributeHistory mocks base method.
+func (m *MockDeviceRepo) GetSmartAttributeHistory(ctx context.Context, wwn, durationKey string, selectEntries, selectEntriesOffset int, attributes []string) ([]measurements.Smart, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSmartAttributeHistory", ctx, wwn, durationKey, selectEntries, selectEntriesOffset, attributes)
+	ret0, _ := ret[0].([]measurements.Smart)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetSmartAttributeHistory indicates an expected call of GetSmartAttributeHistory.
+func (mr *MockDeviceRepoMockRecorder) GetSmartAttributeHistory(ctx, wwn, durationKey, selectEntries, selectEntriesOffset, attributes interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSmartAttributeHistory", reflect.TypeOf((*MockDeviceRepo)(nil).GetSmartAttributeHistory), ctx, wwn, durationKey, selectEntries, selectEntriesOffset, attributes)
 }
 
 // GetSmartTemperatureHistory mocks base method.
@@ -171,21 +244,6 @@ func (m *MockDeviceRepo) GetSummary(ctx context.Context) (map[string]*models.Dev
 func (mr *MockDeviceRepoMockRecorder) GetSummary(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSummary", reflect.TypeOf((*MockDeviceRepo)(nil).GetSummary), ctx)
-}
-
-// GetDevicesLastSeenTimes mocks base method.
-func (m *MockDeviceRepo) GetDevicesLastSeenTimes(ctx context.Context) (map[string]time.Time, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetDevicesLastSeenTimes", ctx)
-	ret0, _ := ret[0].(map[string]time.Time)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetDevicesLastSeenTimes indicates an expected call of GetDevicesLastSeenTimes.
-func (mr *MockDeviceRepoMockRecorder) GetDevicesLastSeenTimes(ctx interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDevicesLastSeenTimes", reflect.TypeOf((*MockDeviceRepo)(nil).GetDevicesLastSeenTimes), ctx)
 }
 
 // GetZFSPoolDetails mocks base method.
@@ -319,6 +377,20 @@ func (m *MockDeviceRepo) ResetDeviceStatus(ctx context.Context, wwn string) (mod
 func (mr *MockDeviceRepoMockRecorder) ResetDeviceStatus(ctx, wwn interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetDeviceStatus", reflect.TypeOf((*MockDeviceRepo)(nil).ResetDeviceStatus), ctx, wwn)
+}
+
+// SaveAttributeOverride mocks base method.
+func (m *MockDeviceRepo) SaveAttributeOverride(ctx context.Context, override *models.AttributeOverride) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SaveAttributeOverride", ctx, override)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SaveAttributeOverride indicates an expected call of SaveAttributeOverride.
+func (mr *MockDeviceRepoMockRecorder) SaveAttributeOverride(ctx, override interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveAttributeOverride", reflect.TypeOf((*MockDeviceRepo)(nil).SaveAttributeOverride), ctx, override)
 }
 
 // SaveSettings mocks base method.
@@ -490,61 +562,4 @@ func (m *MockDeviceRepo) UpdateZFSPoolMuted(ctx context.Context, guid string, mu
 func (mr *MockDeviceRepoMockRecorder) UpdateZFSPoolMuted(ctx, guid, muted interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateZFSPoolMuted", reflect.TypeOf((*MockDeviceRepo)(nil).UpdateZFSPoolMuted), ctx, guid, muted)
-}
-
-// GetAttributeOverrides mocks base method.
-func (m *MockDeviceRepo) GetAttributeOverrides(ctx context.Context) ([]models.AttributeOverride, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAttributeOverrides", ctx)
-	ret0, _ := ret[0].([]models.AttributeOverride)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetAttributeOverrides indicates an expected call of GetAttributeOverrides.
-func (mr *MockDeviceRepoMockRecorder) GetAttributeOverrides(ctx interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAttributeOverrides", reflect.TypeOf((*MockDeviceRepo)(nil).GetAttributeOverrides), ctx)
-}
-
-// GetMergedOverrides mocks base method.
-func (m *MockDeviceRepo) GetMergedOverrides(ctx context.Context) []overrides.AttributeOverride {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetMergedOverrides", ctx)
-	ret0, _ := ret[0].([]overrides.AttributeOverride)
-	return ret0
-}
-
-// GetMergedOverrides indicates an expected call of GetMergedOverrides.
-func (mr *MockDeviceRepoMockRecorder) GetMergedOverrides(ctx interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMergedOverrides", reflect.TypeOf((*MockDeviceRepo)(nil).GetMergedOverrides), ctx)
-}
-
-// SaveAttributeOverride mocks base method.
-func (m *MockDeviceRepo) SaveAttributeOverride(ctx context.Context, override *models.AttributeOverride) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SaveAttributeOverride", ctx, override)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// SaveAttributeOverride indicates an expected call of SaveAttributeOverride.
-func (mr *MockDeviceRepoMockRecorder) SaveAttributeOverride(ctx, override interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveAttributeOverride", reflect.TypeOf((*MockDeviceRepo)(nil).SaveAttributeOverride), ctx, override)
-}
-
-// DeleteAttributeOverride mocks base method.
-func (m *MockDeviceRepo) DeleteAttributeOverride(ctx context.Context, id uint) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteAttributeOverride", ctx, id)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteAttributeOverride indicates an expected call of DeleteAttributeOverride.
-func (mr *MockDeviceRepoMockRecorder) DeleteAttributeOverride(ctx, id interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAttributeOverride", reflect.TypeOf((*MockDeviceRepo)(nil).DeleteAttributeOverride), ctx, id)
 }

--- a/webapp/backend/pkg/database/scrutiny_repository.go
+++ b/webapp/backend/pkg/database/scrutiny_repository.go
@@ -632,6 +632,25 @@ union(tables: [dailyData, weeklyData, monthlyData, yearlyData])
 	return lastSeenTimes, nil
 }
 
+// GetAvailableInfluxDBBuckets returns a list of bucket names available in InfluxDB.
+// This is used for diagnostics to verify required buckets exist.
+func (sr *scrutinyRepository) GetAvailableInfluxDBBuckets(ctx context.Context) ([]string, error) {
+	org := sr.appConfig.GetString("web.influxdb.org")
+
+	// Query InfluxDB for all buckets in the organization
+	buckets, err := sr.influxClient.BucketsAPI().FindBucketsByOrgName(ctx, org)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query InfluxDB buckets: %w", err)
+	}
+
+	bucketNames := make([]string, 0, len(*buckets))
+	for _, bucket := range *buckets {
+		bucketNames = append(bucketNames, bucket.Name)
+	}
+
+	return bucketNames, nil
+}
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Helper Methods
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/webapp/backend/pkg/models/missed_ping_status.go
+++ b/webapp/backend/pkg/models/missed_ping_status.go
@@ -1,0 +1,43 @@
+package models
+
+// MissedPingStatusData contains the current status of the missed ping monitor
+type MissedPingStatusData struct {
+	// Configuration
+	Enabled              bool `json:"enabled"`
+	TimeoutMinutes       int  `json:"timeout_minutes"`
+	CheckIntervalMinutes int  `json:"check_interval_minutes"`
+
+	// Operational status
+	LastCheckTime  string `json:"last_check_time"`  // RFC3339
+	NextCheckTime  string `json:"next_check_time"`  // RFC3339
+	MonitorRunning bool   `json:"monitor_running"`
+
+	// Device tracking
+	TotalDevices           int                  `json:"total_devices"`
+	MonitoredDevices       int                  `json:"monitored_devices"`
+	NotifiedDevices        []string             `json:"notified_devices"`
+	NotifiedDevicesDetails []NotifiedDeviceInfo `json:"notified_devices_details"`
+
+	// InfluxDB validation
+	InfluxDBStatus InfluxDBStatusInfo `json:"influxdb_status"`
+
+	// Errors
+	LastError     string `json:"last_error,omitempty"`
+	LastErrorTime string `json:"last_error_time,omitempty"`
+}
+
+// NotifiedDeviceInfo contains details about a device with an active notification
+type NotifiedDeviceInfo struct {
+	WWN              string `json:"wwn"`
+	DeviceName       string `json:"device_name"`
+	NotificationTime string `json:"notification_time"`
+	LastSeenTime     string `json:"last_seen_time"`
+}
+
+// InfluxDBStatusInfo contains status of InfluxDB bucket validation
+type InfluxDBStatusInfo struct {
+	Available      bool     `json:"available"`
+	BucketsFound   []string `json:"buckets_found"`
+	BucketsMissing []string `json:"buckets_missing,omitempty"`
+	Error          string   `json:"error,omitempty"`
+}

--- a/webapp/backend/pkg/web/handler/get_missed_ping_status.go
+++ b/webapp/backend/pkg/web/handler/get_missed_ping_status.go
@@ -1,0 +1,48 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/analogj/scrutiny/webapp/backend/pkg/models"
+	"github.com/gin-gonic/gin"
+	"github.com/sirupsen/logrus"
+)
+
+// MissedPingMonitor interface to avoid import cycle
+type MissedPingMonitor interface {
+	GetStatus(ctx interface{}) (*models.MissedPingStatusData, error)
+}
+
+// GetMissedPingStatus returns the current status of the missed ping monitor for diagnostics
+func GetMissedPingStatus(c *gin.Context) {
+	logger := c.MustGet("LOGGER").(*logrus.Entry)
+	monitor := c.MustGet("MISSED_PING_MONITOR").(MissedPingMonitor)
+
+	logger.Debugf("Retrieving missed ping monitor status")
+
+	status, err := monitor.GetStatus(c.Request.Context())
+	if err != nil {
+		logger.Errorf("Failed to get missed ping monitor status: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"success": false,
+			"error":   err.Error(),
+		})
+		return
+	}
+
+	// Determine overall status string
+	statusStr := "disabled"
+	if status.Enabled {
+		if status.MonitorRunning {
+			statusStr = "enabled"
+		} else {
+			statusStr = "error"
+		}
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"success": true,
+		"status":  statusStr,
+		"data":    status,
+	})
+}

--- a/webapp/backend/pkg/web/middleware/missed_ping_monitor.go
+++ b/webapp/backend/pkg/web/middleware/missed_ping_monitor.go
@@ -1,0 +1,13 @@
+package middleware
+
+import (
+	"github.com/gin-gonic/gin"
+)
+
+// MissedPingMonitorMiddleware injects the missed ping monitor into the gin context
+func MissedPingMonitorMiddleware(monitor interface{}) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.Set("MISSED_PING_MONITOR", monitor)
+		c.Next()
+	}
+}


### PR DESCRIPTION
## Summary

Adds comprehensive diagnostics and improved logging to the missed collector ping monitoring feature to help users troubleshoot notification issues.

Closes #126

## Problem

User reported in Issue #126 that missed ping notifications weren't working, with no visibility in logs to understand why. The feature was:
- Logging "disabled" status at DEBUG level only (invisible by default)
- Failing silently when InfluxDB queries failed
- Providing no way to check configuration or operational status
- Not validating that required InfluxDB buckets exist

## Solution

### New Diagnostic Endpoint: GET /api/health/missed-ping-status

Returns comprehensive status including enabled state, timing info, device counts, InfluxDB bucket validation, and error details.

### Improved Logging

- Changed "disabled" message from DEBUG to INFO (now visible by default)
- Added detailed error logging at every failure point
- Added contextual hints (e.g., "Check InfluxDB connection and bucket configuration")
- Added success confirmation logging

### InfluxDB Bucket Validation

- Validates all 4 required buckets exist (daily, weekly, monthly, yearly)
- Returns which buckets are found/missing in diagnostic endpoint
- Warns in logs when buckets are missing

### Status Tracking

- Tracks last check time, next check time
- Tracks last error and error timestamp
- Thread-safe access with separate mutex

## Changes

### Files Created (3)
- `webapp/backend/pkg/models/missed_ping_status.go` - Data models for diagnostics
- `webapp/backend/pkg/web/handler/get_missed_ping_status.go` - Diagnostic endpoint handler
- `webapp/backend/pkg/web/middleware/missed_ping_monitor.go` - Middleware for monitor injection

### Files Modified (5)
- `webapp/backend/pkg/web/missed_ping_monitor.go` - Status tracking, GetStatus method, improved logging
- `webapp/backend/pkg/web/server.go` - AppEngine field, middleware, route registration
- `webapp/backend/pkg/database/interface.go` - GetAvailableInfluxDBBuckets method
- `webapp/backend/pkg/database/scrutiny_repository.go` - Bucket validation implementation
- `webapp/backend/pkg/database/mock/mock_database.go` - Regenerated mocks

## Test Plan

- [x] Code compiles without errors
- [x] All 15 existing missed ping tests pass
- [x] Import cycles resolved
- [x] No regressions in existing functionality

### Manual Testing Steps

1. Start server and check diagnostic endpoint works
2. Verify feature status (disabled by default)
3. Enable feature via settings API
4. Verify status updates show enabled state
5. Check logs show INFO level messages
6. Verify InfluxDB bucket validation works

## Benefits

**For Users:**
- Can verify if feature is enabled via API
- See real-time operational status
- Get immediate feedback on InfluxDB issues
- Troubleshoot notification problems without reading code

**For Developers:**
- Better error visibility in logs
- Structured diagnostic data for debugging
- Consistent with existing health check patterns
- Easy to extend with additional diagnostics

**For Issue #126 Reporter:**
- Clear visibility into why notifications aren't working
- Easy path to enable and verify the feature
- Logs visible at INFO level by default

## Additional Notes

- Thread-safe implementation with separate mutex for status fields
- Used interface type in handler to avoid import cycles
- Followed existing patterns from /api/health endpoint
- No breaking changes to existing API or behavior

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
