### PR TITLE
fix(ui): dark mode improvements and drive filter toggle (#165)

### DIFF
--- a/webapp/frontend/src/app/modules/dashboard/dashboard.component.html
+++ b/webapp/frontend/src/app/modules/dashboard/dashboard.component.html
@@ -165,7 +165,7 @@
                       <mat-checkbox
                         [checked]="allDrivesVisible"
                         [indeterminate]="someDrivesVisible && !allDrivesVisible"
-                        (click)="$event.stopPropagation()">
+                        (click)="toggleAllDrives(); $event.stopPropagation()">
                         All Drives
                       </mat-checkbox>
                     </button>
@@ -174,7 +174,7 @@
                       <button mat-menu-item (click)="toggleDriveVisibility(device.key); $event.stopPropagation()">
                         <mat-checkbox
                           [checked]="visibleDrives[device.key]"
-                          (click)="$event.stopPropagation()">
+                          (click)="toggleDriveVisibility(device.key); $event.stopPropagation()">
                           {{ device.value.device | deviceTitle:config?.dashboard_display }}
                         </mat-checkbox>
                       </button>

--- a/webapp/frontend/src/app/modules/dashboard/dashboard.component.ts
+++ b/webapp/frontend/src/app/modules/dashboard/dashboard.component.ts
@@ -1,6 +1,7 @@
 import {
     AfterViewInit,
     ChangeDetectionStrategy,
+    ChangeDetectorRef,
     Component,
     OnDestroy,
     OnInit,
@@ -53,6 +54,7 @@ export class DashboardComponent implements OnInit, AfterViewInit, OnDestroy
     constructor(
         private _dashboardService: DashboardService,
         private _configService: ScrutinyConfigService,
+        private _changeDetectorRef: ChangeDetectorRef,
         public dialog: MatDialog,
         private router: Router,
     )
@@ -334,12 +336,14 @@ export class DashboardComponent implements OnInit, AfterViewInit, OnDestroy
         for (const wwn in this.visibleDrives) {
             this.visibleDrives[wwn] = newState;
         }
-        this.tempChart.updateSeries(this._deviceDataTemperatureSeries());
+        this.tempChart?.updateSeries(this._deviceDataTemperatureSeries());
+        this._changeDetectorRef.markForCheck();
     }
 
     toggleDriveVisibility(wwn: string): void {
         this.visibleDrives[wwn] = !this.visibleDrives[wwn];
-        this.tempChart.updateSeries(this._deviceDataTemperatureSeries());
+        this.tempChart?.updateSeries(this._deviceDataTemperatureSeries());
+        this._changeDetectorRef.markForCheck();
     }
 
     /*
@@ -361,8 +365,8 @@ export class DashboardComponent implements OnInit, AfterViewInit, OnDestroy
                     this.summaryData[wwn].temp_history = tempHistoryData[wwn] || []
                 }
 
-                // Prepare the chart series data
-                this.tempChart.updateSeries(this._deviceDataTemperatureSeries())
+                // Prepare the chart series data (filtered by visibility)
+                this.tempChart.updateSeries(this._deviceDataTemperatureSeries());
             });
     }
 

--- a/webapp/frontend/src/app/modules/detail/detail.component.html
+++ b/webapp/frontend/src/app/modules/detail/detail.component.html
@@ -210,7 +210,7 @@
                     <div class="font-bold text-md text-secondary uppercase tracking-wider">S.M.A.R.T {{device?.device_protocol}} Attributes</div>
                     <div class="text-sm text-hint font-medium">{{this.smartAttributeDataSource.data.length}} visible, {{getHiddenAttributes()}} hidden</div>
                 </div>
-                <div class="overflow-auto table-scroll-container">
+                <div class="overflow-auto">
                     <table class="w-full bg-transparent"
                            mat-table
                            matSort

--- a/webapp/frontend/src/app/modules/detail/detail.component.scss
+++ b/webapp/frontend/src/app/modules/detail/detail.component.scss
@@ -58,38 +58,3 @@ tr.attribute-row:not(.attribute-expanded-row):active {
     // vertical-align: middle;
 }
 
-// Scroll shadow indicators for table overflow
-.table-scroll-container {
-    position: relative;
-    // Scroll shadow on right edge when content overflows
-    background:
-        // Left shadow (appears when scrolled right)
-        linear-gradient(to right, white 30%, rgba(255, 255, 255, 0)),
-        linear-gradient(to right, rgba(255, 255, 255, 0), white 70%),
-        // Shadow indicators
-        linear-gradient(to right, rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0)),
-        linear-gradient(to left, rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0));
-    background-position: left center, right center, left center, right center;
-    background-repeat: no-repeat;
-    background-size: 20px 100%, 20px 100%, 10px 100%, 10px 100%;
-    background-attachment: local, local, scroll, scroll;
-}
-
-// Dark mode support for scroll shadows
-@include treo-theme {
-    $is-dark: map-get($theme, is-dark);
-
-    @if $is-dark {
-        detail .table-scroll-container {
-            background:
-                linear-gradient(to right, #1e293b 30%, rgba(30, 41, 59, 0)),
-                linear-gradient(to right, rgba(30, 41, 59, 0), #1e293b 70%),
-                linear-gradient(to right, rgba(0, 0, 0, 0.3), rgba(0, 0, 0, 0)),
-                linear-gradient(to left, rgba(0, 0, 0, 0.3), rgba(0, 0, 0, 0));
-            background-position: left center, right center, left center, right center;
-            background-repeat: no-repeat;
-            background-size: 20px 100%, 20px 100%, 10px 100%, 10px 100%;
-            background-attachment: local, local, scroll, scroll;
-        }
-    }
-}

--- a/webapp/frontend/src/styles/styles.scss
+++ b/webapp/frontend/src/styles/styles.scss
@@ -8,13 +8,14 @@
 .treo-theme-dark {
     .yellow-50 {
         background-color: #242b38 !important;
+        color: #e2e8f0 !important;
 
         .mat-icon {
-            color: #0694a2 !important;
+            color: #38bdf8 !important;
         }
 
         .text-secondary {
-            color: #0694a2 !important
+            color: #cbd5e1 !important;
         }
     }
 


### PR DESCRIPTION
## Summary

- Fix dark mode text contrast in SMART attributes table for better readability
- Remove scroll shadow indicators that caused white frame on table
- Fix temperature graph drive filter checkbox click handling

## Changes

1. **Dark mode text contrast** - Changed text colors from low-contrast teal to light gray
2. **White frame fix** - Removed scroll shadow CSS that used white color against dark backgrounds
3. **Drive filter toggle** - Added click handlers to checkboxes so toggling drives updates the chart

## Related

Closes #165

## Test plan

- [ ] Verify SMART attributes table text is readable in dark mode
- [ ] Verify no white frame appears around the SMART table
- [ ] Verify clicking drive checkboxes in temperature graph filter updates the chart