### PR TITLE
fix(notify): fix missed ping notifications not being sent (#126)

### DIFF
--- a/webapp/backend/pkg/database/scrutiny_repository.go
+++ b/webapp/backend/pkg/database/scrutiny_repository.go
@@ -570,6 +570,8 @@ func (sr *scrutinyRepository) GetDevicesLastSeenTimes(ctx context.Context) (map[
 	lastSeenTimes := map[string]time.Time{}
 
 	// Query to get the last submission time for each device from all buckets
+	// Note: We use "temp" field since it's always present in SMART data.
+	// The "date" field doesn't exist - Date is stored as the point timestamp (_time).
 	queryStr := fmt.Sprintf(`
 import "influxdata/influxdb/schema"
 bucketBaseName = "%s"
@@ -577,28 +579,28 @@ bucketBaseName = "%s"
 dailyData = from(bucket: bucketBaseName)
 |> range(start: -10y, stop: now())
 |> filter(fn: (r) => r["_measurement"] == "smart")
-|> filter(fn: (r) => r["_field"] == "date")
+|> filter(fn: (r) => r["_field"] == "temp")
 |> last()
 |> group(columns: ["device_wwn"])
 
 weeklyData = from(bucket: bucketBaseName + "_weekly")
 |> range(start: -10y, stop: now())
 |> filter(fn: (r) => r["_measurement"] == "smart")
-|> filter(fn: (r) => r["_field"] == "date")
+|> filter(fn: (r) => r["_field"] == "temp")
 |> last()
 |> group(columns: ["device_wwn"])
 
 monthlyData = from(bucket: bucketBaseName + "_monthly")
 |> range(start: -10y, stop: now())
 |> filter(fn: (r) => r["_measurement"] == "smart")
-|> filter(fn: (r) => r["_field"] == "date")
+|> filter(fn: (r) => r["_field"] == "temp")
 |> last()
 |> group(columns: ["device_wwn"])
 
 yearlyData = from(bucket: bucketBaseName + "_yearly")
 |> range(start: -10y, stop: now())
 |> filter(fn: (r) => r["_measurement"] == "smart")
-|> filter(fn: (r) => r["_field"] == "date")
+|> filter(fn: (r) => r["_field"] == "temp")
 |> last()
 |> group(columns: ["device_wwn"])
 

--- a/webapp/backend/pkg/models/missed_ping_status.go
+++ b/webapp/backend/pkg/models/missed_ping_status.go
@@ -7,6 +7,10 @@ type MissedPingStatusData struct {
 	TimeoutMinutes       int  `json:"timeout_minutes"`
 	CheckIntervalMinutes int  `json:"check_interval_minutes"`
 
+	// Notification configuration
+	NotifyConfigured    bool `json:"notify_configured"`
+	NotifyEndpointCount int  `json:"notify_endpoint_count"`
+
 	// Operational status
 	LastCheckTime  string `json:"last_check_time"`  // RFC3339
 	NextCheckTime  string `json:"next_check_time"`  // RFC3339

--- a/webapp/backend/pkg/notify/notify.go
+++ b/webapp/backend/pkg/notify/notify.go
@@ -284,8 +284,8 @@ func (n *Notify) Send() error {
 	n.Logger.Debugf("Configured notification services: %v", configUrls)
 
 	if len(configUrls) == 0 {
-		n.Logger.Infof("No notification endpoints configured. Skipping failure notification.")
-		return nil
+		n.Logger.Warnf("No notification endpoints configured. Cannot send notification.")
+		return errors.New("no notification endpoints configured")
 	}
 
 	//remove http:// https:// and script:// prefixed urls


### PR DESCRIPTION
## Summary

Fixes the missed ping notification feature that was not sending notifications even when devices exceeded their timeout thresholds.

**Root cause:** The InfluxDB query in `GetDevicesLastSeenTimes()` was filtering for `_field == "date"`, but the Date field in SMART data is stored as the InfluxDB point timestamp (`_time`), not as a separate field. This caused the query to return empty results, so no devices were ever detected as having missed pings.

### Changes

- Fixed InfluxDB query to use `_field == "temp"` (always present in SMART data) instead of non-existent `"date"` field
- Return error from `Send()` when no notification endpoints configured (previously returned nil, causing devices to be incorrectly marked as "notified")
- Added `notify_configured` and `notify_endpoint_count` fields to diagnostic endpoint
- Improved logging when notifications cannot be sent due to missing configuration
- Updated tests for new behavior

### Files Changed

- `webapp/backend/pkg/database/scrutiny_repository.go` - Fixed InfluxDB query
- `webapp/backend/pkg/notify/notify.go` - Return error when no endpoints
- `webapp/backend/pkg/models/missed_ping_status.go` - Added diagnostic fields
- `webapp/backend/pkg/web/missed_ping_monitor.go` - Handle no-endpoints error, add notify status
- `webapp/backend/pkg/web/missed_ping_monitor_test.go` - Updated tests

## Test plan

- [x] Deployed to dev environment with 17 physical drives
- [x] Verified diagnostic endpoint shows correct device count and notify configuration
- [x] Verified all 17 devices detected as having missed pings
- [x] Verified 17 notifications sent to test webhook endpoint
- [x] Verified deduplication prevents duplicate notifications

Closes #126