### PR TITLE
fix(overrides): force_status=failed bypasses threshold filter

### DIFF
--- a/webapp/backend/pkg/database/interface.go
+++ b/webapp/backend/pkg/database/interface.go
@@ -40,6 +40,7 @@ type DeviceRepo interface {
 	UpdateDeviceMuted(ctx context.Context, wwn string, muted bool) error
 	UpdateDeviceLabel(ctx context.Context, wwn string, label string) error
 	UpdateDeviceSmartDisplayMode(ctx context.Context, wwn string, mode string) error
+	UpdateDeviceHasForcedFailure(ctx context.Context, wwn string, hasForcedFailure bool) error
 	DeleteDevice(ctx context.Context, wwn string) error
 	// RecalculateDeviceStatusFromHistory re-evaluates device status from stored SMART data
 	// with current overrides applied. Used when overrides are added/modified/deleted.

--- a/webapp/backend/pkg/database/migrations/m20260131000000/device.go
+++ b/webapp/backend/pkg/database/migrations/m20260131000000/device.go
@@ -1,0 +1,44 @@
+package m20260131000000
+
+import (
+	"github.com/analogj/scrutiny/webapp/backend/pkg"
+	"time"
+)
+
+type Device struct {
+	//GORM attributes, see: http://gorm.io/docs/conventions.html
+	Archived  bool `json:"archived"`
+	Muted     bool `json:"muted"`
+	CreatedAt time.Time
+	UpdatedAt time.Time
+	DeletedAt *time.Time
+
+	WWN string `json:"wwn" gorm:"primary_key"`
+
+	DeviceName     string `json:"device_name"`
+	DeviceUUID     string `json:"device_uuid"`
+	DeviceSerialID string `json:"device_serial_id"`
+	DeviceLabel    string `json:"device_label"`
+
+	Manufacturer   string `json:"manufacturer"`
+	ModelName      string `json:"model_name"`
+	InterfaceType  string `json:"interface_type"`
+	InterfaceSpeed string `json:"interface_speed"`
+	SerialNumber   string `json:"serial_number"`
+	Firmware       string `json:"firmware"`
+	RotationSpeed  int    `json:"rotational_speed"`
+	Capacity       int64  `json:"capacity"`
+	FormFactor     string `json:"form_factor"`
+	SmartSupport   bool   `json:"smart_support"`
+	DeviceProtocol string `json:"device_protocol"` //protocol determines which smart attribute types are available (ATA, NVMe, SCSI)
+	DeviceType     string `json:"device_type"`     //device type is used for querying with -d/t flag, should only be used by collector.
+
+	// User provided metadata
+	Label            string `json:"label"`
+	HostId           string `json:"host_id"`
+	SmartDisplayMode string `json:"smart_display_mode" gorm:"default:'scrutiny'"` // "scrutiny", "raw", or "normalized"
+
+	// Data set by Scrutiny
+	DeviceStatus     pkg.DeviceStatus `json:"device_status"`
+	HasForcedFailure bool             `json:"has_forced_failure" gorm:"default:false"` // True when override with action=force_status, status=failed is applied
+}

--- a/webapp/backend/pkg/database/mock/mock_database.go
+++ b/webapp/backend/pkg/database/mock/mock_database.go
@@ -565,6 +565,20 @@ func (mr *MockDeviceRepoMockRecorder) UpdateDeviceSmartDisplayMode(ctx, wwn, mod
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDeviceSmartDisplayMode", reflect.TypeOf((*MockDeviceRepo)(nil).UpdateDeviceSmartDisplayMode), ctx, wwn, mode)
 }
 
+// UpdateDeviceHasForcedFailure mocks base method.
+func (m *MockDeviceRepo) UpdateDeviceHasForcedFailure(ctx context.Context, wwn string, hasForcedFailure bool) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateDeviceHasForcedFailure", ctx, wwn, hasForcedFailure)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateDeviceHasForcedFailure indicates an expected call of UpdateDeviceHasForcedFailure.
+func (mr *MockDeviceRepoMockRecorder) UpdateDeviceHasForcedFailure(ctx, wwn, hasForcedFailure interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDeviceHasForcedFailure", reflect.TypeOf((*MockDeviceRepo)(nil).UpdateDeviceHasForcedFailure), ctx, wwn, hasForcedFailure)
+}
+
 // UpdateZFSPoolArchived mocks base method.
 func (m *MockDeviceRepo) UpdateZFSPoolArchived(ctx context.Context, guid string, archived bool) error {
 	m.ctrl.T.Helper()

--- a/webapp/backend/pkg/database/scrutiny_repository_migrations.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_migrations.go
@@ -18,6 +18,7 @@ import (
 	"github.com/analogj/scrutiny/webapp/backend/pkg/database/migrations/m20260108000000"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/database/migrations/m20260122000000"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/database/migrations/m20260129000000"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/database/migrations/m20260131000000"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/models"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/models/collector"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/models/measurements"
@@ -485,6 +486,13 @@ func (sr *scrutinyRepository) Migrate(ctx context.Context) error {
 			Migrate: func(tx *gorm.DB) error {
 				// adding column (smart_display_mode)
 				return tx.AutoMigrate(m20260129000000.Device{})
+			},
+		},
+		{
+			ID: "m20260131000000", // add has_forced_failure to device data
+			Migrate: func(tx *gorm.DB) error {
+				// adding column (has_forced_failure)
+				return tx.AutoMigrate(m20260131000000.Device{})
 			},
 		},
 	})

--- a/webapp/backend/pkg/models/device.go
+++ b/webapp/backend/pkg/models/device.go
@@ -46,7 +46,8 @@ type Device struct {
 	SmartDisplayMode string `json:"smart_display_mode" gorm:"default:'scrutiny'"` // "scrutiny", "raw", or "normalized"
 
 	// Data set by Scrutiny
-	DeviceStatus pkg.DeviceStatus `json:"device_status"`
+	DeviceStatus     pkg.DeviceStatus `json:"device_status"`
+	HasForcedFailure bool             `json:"has_forced_failure" gorm:"default:false"` // True when override with action=force_status, status=failed is applied
 }
 
 func (dv *Device) IsAta() bool {

--- a/webapp/backend/pkg/web/handler/upload_device_metrics.go
+++ b/webapp/backend/pkg/web/handler/upload_device_metrics.go
@@ -55,6 +55,11 @@ func UploadDeviceMetrics(c *gin.Context) {
 		return
 	}
 
+	// Update device's forced failure flag based on override processing
+	if err := deviceRepo.UpdateDeviceHasForcedFailure(c, wwn, smartData.HasForcedFailure); err != nil {
+		logger.Warnf("Failed to update has_forced_failure for device %s: %v", wwn, err)
+	}
+
 	if smartData.Status != pkg.DeviceStatusPassed {
 		//there is a failure detected by Scrutiny, update the device status on the homepage.
 		updatedDevice, err = deviceRepo.UpdateDeviceStatus(c, wwn, smartData.Status)

--- a/webapp/frontend/src/app/core/models/device-model.ts
+++ b/webapp/frontend/src/app/core/models/device-model.ts
@@ -26,4 +26,5 @@ export interface DeviceModel {
     smart_display_mode?: string; // "scrutiny", "raw", or "normalized"
 
     device_status: number;
+    has_forced_failure?: boolean;
 }

--- a/webapp/frontend/src/app/shared/device-status.pipe.ts
+++ b/webapp/frontend/src/app/shared/device-status.pipe.ts
@@ -35,6 +35,12 @@ export class DeviceStatusPipe implements PipeTransform {
             return 'unknown'
         }
 
+        // If user has forced a failure via override, always show as failed
+        // regardless of threshold setting
+        if (deviceModel.has_forced_failure) {
+            return includeReason ? 'failed: override' : 'failed'
+        }
+
         let statusNameLookup = DEVICE_STATUS_NAMES
         if (includeReason) {
             statusNameLookup = DEVICE_STATUS_NAMES_WITH_REASON


### PR DESCRIPTION
## Summary

- Adds `has_forced_failure` flag to track when overrides force a failure status
- Frontend bypasses threshold filter when flag is true, ensuring forced failures are always visible
- Fixes edge case where `force_status: failed` could be hidden by threshold setting

## Test plan

- [x] Backend tests pass
- [x] Frontend tests pass (124/124)
- [x] Tested on Zeus dev environment
- [x] Database migration verified

Closes #164