### PR TITLE
fix(smart): Patriot Burst Elite temperature and data unit fixes

### DIFF
--- a/webapp/backend/pkg/models/measurements/smart.go
+++ b/webapp/backend/pkg/models/measurements/smart.go
@@ -153,8 +153,9 @@ func (sm *Smart) FromCollectorSmartInfoWithOverrides(cfg config.Interface, wwn s
 			sm.Temp = temp.Current
 		}
 	}
-	// For ATA drives, if standard temperature field is 0, check attribute 194 (Temperature)
-	if sm.Temp == 0 && info.Device.Protocol == pkg.DeviceProtocolAta {
+	// For ATA drives, if standard temperature is unreasonable, check attribute 194 (Temperature)
+	// Covers: zero (not reported), negative (e.g., -53 from corrupted device statistics), or >150C
+	if (sm.Temp <= 0 || sm.Temp > 150) && info.Device.Protocol == pkg.DeviceProtocolAta {
 		for _, attr := range info.AtaSmartAttributes.Table {
 			if attr.ID == 194 && attr.Raw.Value > 0 {
 				// Apply same bit-mask as the Transform function (lowest byte contains temp in Celsius)


### PR DESCRIPTION
## Summary

- **Temperature fallback for ATA drives**: When `temperature.current` is 0, negative, or >150C (e.g., Patriot Burst Elite reporting -53C from corrupted device statistics), extract temperature from SMART attribute 194 with bit-mask and sanity checks
- **Improved data read/write calculation**: Enhanced `convertToTB()` with multi-attribute support (devstat_1_24/1_40, attributes 241/242/244/246/249) and heuristic detection for budget SSDs that use 32 MiB units despite generic attribute names

## Files changed

- `webapp/backend/pkg/models/measurements/smart.go` — temperature fallback logic
- `webapp/backend/pkg/models/measurements/smart_test.go` — 3 new test cases
- `webapp/frontend/src/app/modules/detail/detail.component.ts` — improved TB read/write calculation

## Test plan

- [ ] Verify backend tests pass (`go test ./webapp/backend/pkg/models/measurements/...`)
- [ ] Verify frontend builds (`cd webapp/frontend && npm run build:prod`)
- [ ] Confirm Patriot Burst Elite drives show correct temperature and data written/read values