### PR TITLE
fix(ui): version display clipped on mobile viewports

### DIFF
--- a/webapp/frontend/src/app/layout/layouts/horizontal/material/material.component.html
+++ b/webapp/frontend/src/app/layout/layouts/horizontal/material/material.component.html
@@ -52,7 +52,10 @@
             <!-- Theme Toggle -->
             <theme-toggle class="mr-4"></theme-toggle>
 
-            <a href="https://github.com/Starosdev/scrutiny" target="_blank" rel="noopener noreferrer">
+            <a class="version-link"
+              href="https://github.com/Starosdev/scrutiny"
+              target="_blank"
+              rel="noopener noreferrer">
               <code>{{appVersion}}</code>
             </a>
 

--- a/webapp/frontend/src/app/layout/layouts/horizontal/material/material.component.scss
+++ b/webapp/frontend/src/app/layout/layouts/horizontal/material/material.component.scss
@@ -132,6 +132,30 @@ material-layout {
                     height: 1px;
                 }
 
+                .version-link {
+                    display: flex;
+                    align-items: center;
+                    white-space: nowrap;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    max-width: 200px;
+                    flex-shrink: 1;
+                    min-width: 0;
+
+                    code {
+                        overflow: hidden;
+                        text-overflow: ellipsis;
+                    }
+
+                    @include treo-breakpoint('lt-lg') {
+                        max-width: 150px;
+                    }
+
+                    @include treo-breakpoint('lt-md') {
+                        display: none;
+                    }
+                }
+
                 search {
                     margin-right: 8px;
                 }

--- a/webapp/frontend/src/app/modules/dashboard/dashboard.component.html
+++ b/webapp/frontend/src/app/modules/dashboard/dashboard.component.html
@@ -93,6 +93,11 @@
                     collector v{{ version }}
                   </span>
                 }
+                @if (config?.server_version) {
+                  <span class="gt-sm:hidden text-sm px-2 py-0.5 rounded-full text-white bg-gray-500">
+                    server v{{ config.server_version }}
+                  </span>
+                }
               </div>
             }
 


### PR DESCRIPTION
## Summary
- Hide header version link on narrow viewports (<960px) using responsive SCSS breakpoints with truncation/ellipsis on medium screens
- Show server version as a pill badge next to the collector version on the dashboard, visible only on mobile (`gt-sm:hidden`)

Closes #167

## Test plan
- [ ] Desktop (>=1440px): header version visible, no server badge on dashboard
- [ ] Medium (~1000px): header version truncates with ellipsis if long
- [ ] Mobile (<960px): header version hidden, server badge appears on dashboard next to collector badge
- [ ] Verify both light and dark themes