### PR TITLE
feat(notify): add periodic heartbeat notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ These S.M.A.R.T hard drive self-tests can help you detect and replace failing ha
 - **Improved UI Layout** - Top navigation for better S.M.A.R.T attribute visibility
 - **Mobile-Optimized Interface** - Better experience on mobile devices
 - **API Timeout Configuration** - Adjust timeouts for slow storage systems
+- **Heartbeat Notifications** - Periodic "all clear" alerts for uptime monitoring integration
 
 # Migration from AnalogJ/scrutiny
 
@@ -246,6 +247,14 @@ Scrutiny supports sending SMART device failure notifications via the following s
 Check the `notify.urls` section of [example.scrutiny.yml](example.scrutiny.yaml) for examples.
 
 For more information and troubleshooting, see the [TROUBLESHOOTING_NOTIFICATIONS.md](./docs/TROUBLESHOOTING_NOTIFICATIONS.md) file
+
+### Heartbeat Notifications
+
+Scrutiny can send periodic "all clear" heartbeat notifications to confirm the monitoring system is running and all drives are healthy. This is useful for integration with uptime monitoring tools like Uptime Kuma.
+
+- **Disabled by default** -- enable via Settings in the web UI or the `/api/settings` API
+- **Configurable interval** -- defaults to every 24 hours
+- **Suppressed during failures** -- heartbeat is not sent if any drive has active failures (failure notifications take priority)
 
 ### Per-Device Notification Control
 

--- a/docs/TROUBLESHOOTING_NOTIFICATIONS.md
+++ b/docs/TROUBLESHOOTING_NOTIFICATIONS.md
@@ -16,7 +16,7 @@ Data is provided to this script using the following environmental variables:
 ```
 SCRUTINY_SUBJECT - 	eg. "Scrutiny SMART error (%s) detected on device: %s"
 SCRUTINY_DATE 
-SCRUTINY_FAILURE_TYPE - EmailTest, SmartFail, ScrutinyFail
+SCRUTINY_FAILURE_TYPE - EmailTest, SmartFail, ScrutinyFail, MissedPing, Heartbeat
 SCRUTINY_DEVICE_NAME - eg. /dev/sda
 SCRUTINY_DEVICE_TYPE - ATA/SCSI/NVMe
 SCRUTINY_DEVICE_SERIAL - eg. WDDJ324KSO

--- a/example.scrutiny.yaml
+++ b/example.scrutiny.yaml
@@ -232,6 +232,28 @@ failures:
 #     -H "Content-Type: application/json" \
 #     -d '{"metrics": {"notify_on_missed_ping": true, "missed_ping_timeout_minutes": 60}}'
 
+######################################################################
+# Heartbeat Notifications (Periodic Health Check)
+#
+# Scrutiny can send periodic "all clear" heartbeat notifications to
+# confirm the monitoring system is running and all drives are healthy.
+# Useful for integration with uptime monitoring tools like Uptime Kuma.
+#
+# Heartbeat notifications are only sent when ALL monitored drives are
+# healthy. If any drive has failures, the heartbeat is suppressed
+# (failure notifications take priority).
+#
+# These settings are configured via the Settings API, not this config file.
+# Use the /api/settings endpoint to configure:
+#
+#   metrics.heartbeat_enabled: false          # Enable/disable feature
+#   metrics.heartbeat_interval_hours: 24      # Hours between heartbeats
+#
+# Example API call to enable daily heartbeat notifications:
+#   curl -X POST http://localhost:8080/api/settings \
+#     -H "Content-Type: application/json" \
+#     -d '{"metrics": {"heartbeat_enabled": true, "heartbeat_interval_hours": 24}}'
+
 ########################################################################################################################
 # FEATURES COMING SOON
 #

--- a/webapp/backend/pkg/database/scrutiny_repository_migrations.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_migrations.go
@@ -502,6 +502,27 @@ func (sr *scrutinyRepository) Migrate(ctx context.Context) error {
 				return tx.AutoMigrate(m20260202000000.Device{})
 			},
 		},
+		{
+			ID: "m20260207000000", // add heartbeat notification settings
+			Migrate: func(tx *gorm.DB) error {
+				// Add heartbeat notification settings with defaults
+				var defaultSettings = []m20220716214900.Setting{
+					{
+						SettingKeyName:        "metrics.heartbeat_enabled",
+						SettingKeyDescription: "Enable periodic heartbeat notifications when all drives are healthy (true | false)",
+						SettingDataType:       "bool",
+						SettingValueBool:      false,
+					},
+					{
+						SettingKeyName:        "metrics.heartbeat_interval_hours",
+						SettingKeyDescription: "Hours between heartbeat notifications (default: 24)",
+						SettingDataType:       "numeric",
+						SettingValueNumeric:   24,
+					},
+				}
+				return tx.Create(&defaultSettings).Error
+			},
+		},
 	})
 
 	if err := m.Migrate(); err != nil {

--- a/webapp/backend/pkg/models/settings.go
+++ b/webapp/backend/pkg/models/settings.go
@@ -31,5 +31,9 @@ type Settings struct {
 		NotifyOnMissedPing          bool `json:"notify_on_missed_ping" mapstructure:"notify_on_missed_ping"`
 		MissedPingTimeoutMinutes    int  `json:"missed_ping_timeout_minutes" mapstructure:"missed_ping_timeout_minutes"`
 		MissedPingCheckIntervalMins int  `json:"missed_ping_check_interval_mins" mapstructure:"missed_ping_check_interval_mins"`
+
+		// Heartbeat notification settings
+		HeartbeatEnabled       bool `json:"heartbeat_enabled" mapstructure:"heartbeat_enabled"`
+		HeartbeatIntervalHours int  `json:"heartbeat_interval_hours" mapstructure:"heartbeat_interval_hours"`
 	} `json:"metrics" mapstructure:"metrics"`
 }

--- a/webapp/backend/pkg/notify/notify.go
+++ b/webapp/backend/pkg/notify/notify.go
@@ -32,6 +32,7 @@ const NotifyFailureTypeBothFailure = "SmartFailure" //SmartFailure always takes 
 const NotifyFailureTypeSmartFailure = "SmartFailure"
 const NotifyFailureTypeScrutinyFailure = "ScrutinyFailure"
 const NotifyFailureTypeMissedPing = "MissedPing"
+const NotifyFailureTypeHeartbeat = "Heartbeat"
 
 // ShouldNotify check if the error Message should be filtered (level mismatch or filtered_attributes)
 func ShouldNotify(logger logrus.FieldLogger, device models.Device, smartAttrs measurements.Smart, statusThreshold pkg.MetricsStatusThreshold, statusFilterAttributes pkg.MetricsStatusFilterAttributes, repeatNotifications bool, c *gin.Context, deviceRepo database.DeviceRepo, cfg config.Interface) bool {
@@ -576,6 +577,68 @@ func NewMissedPing(logger logrus.FieldLogger, appconfig config.Interface, device
 		FailureType:  missedPingPayload.FailureType,
 		Subject:      missedPingPayload.Subject,
 		Message:      missedPingPayload.Message,
+	}
+
+	return Notify{
+		Logger:  logger,
+		Config:  appconfig,
+		Payload: payload,
+	}
+}
+
+// HeartbeatPayload represents a periodic "all clear" heartbeat notification
+type HeartbeatPayload struct {
+	MonitoredDevices int    `json:"monitored_devices"`
+	TotalDevices     int    `json:"total_devices"`
+	Date             string `json:"date"`
+	FailureType      string `json:"failure_type"`
+	Subject          string `json:"subject"`
+	Message          string `json:"message"`
+}
+
+// NewHeartbeatPayload creates a payload for heartbeat notifications
+func NewHeartbeatPayload(monitoredCount, totalCount int) HeartbeatPayload {
+	payload := HeartbeatPayload{
+		MonitoredDevices: monitoredCount,
+		TotalDevices:     totalCount,
+		Date:             time.Now().Format(time.RFC3339),
+		FailureType:      NotifyFailureTypeHeartbeat,
+	}
+
+	payload.Subject = payload.generateSubject()
+	payload.Message = payload.generateMessage()
+	return payload
+}
+
+func (p *HeartbeatPayload) generateSubject() string {
+	return fmt.Sprintf("Scrutiny heartbeat: All %d drives healthy", p.MonitoredDevices)
+}
+
+func (p *HeartbeatPayload) generateMessage() string {
+	messageParts := []string{
+		fmt.Sprintf("Scrutiny periodic health check: All %d monitored drives are healthy.", p.MonitoredDevices),
+		"",
+		fmt.Sprintf("Monitored devices: %d", p.MonitoredDevices),
+		fmt.Sprintf("Total devices (including archived/muted): %d", p.TotalDevices),
+		fmt.Sprintf("Date: %s", p.Date),
+		"",
+		"This is an automated heartbeat notification confirming that Scrutiny is running and all drives are healthy.",
+	}
+
+	return strings.Join(messageParts, "\n")
+}
+
+// NewHeartbeat creates a Notify instance for heartbeat notifications
+func NewHeartbeat(logger logrus.FieldLogger, appconfig config.Interface, monitoredCount, totalCount int) Notify {
+	heartbeatPayload := NewHeartbeatPayload(monitoredCount, totalCount)
+
+	// Convert HeartbeatPayload to standard Payload for compatibility with Send()
+	payload := Payload{
+		Test:        false,
+		Date:        heartbeatPayload.Date,
+		FailureType: heartbeatPayload.FailureType,
+		Subject:     heartbeatPayload.Subject,
+		Message:     heartbeatPayload.Message,
 	}
 
 	return Notify{

--- a/webapp/backend/pkg/web/heartbeat_monitor.go
+++ b/webapp/backend/pkg/web/heartbeat_monitor.go
@@ -1,0 +1,273 @@
+package web
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/analogj/scrutiny/webapp/backend/pkg"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/database"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/notify"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	// DefaultHeartbeatIntervalHours is the default interval between heartbeat notifications
+	DefaultHeartbeatIntervalHours = 24
+)
+
+// HeartbeatMonitor sends periodic "all clear" notifications when all drives are healthy
+type HeartbeatMonitor struct {
+	appEngine *AppEngine
+	logger    logrus.FieldLogger
+
+	// Persistent repository connection (created once, reused)
+	deviceRepo database.DeviceRepo
+	repoMu     sync.Mutex
+
+	// Channel to signal shutdown and context for cancellation
+	stopCh chan struct{}
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	// WaitGroup to track when the run goroutine has finished
+	wg sync.WaitGroup
+
+	// Status tracking for diagnostics
+	lastCheckTime time.Time
+	nextCheckTime time.Time
+	lastError     error
+	lastErrorTime time.Time
+	statusMu      sync.RWMutex
+}
+
+// NewHeartbeatMonitor creates a new heartbeat monitor
+func NewHeartbeatMonitor(ae *AppEngine) *HeartbeatMonitor {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &HeartbeatMonitor{
+		appEngine: ae,
+		logger:    ae.Logger,
+		stopCh:    make(chan struct{}),
+		ctx:       ctx,
+		cancel:    cancel,
+	}
+}
+
+// Start begins the background heartbeat loop
+func (m *HeartbeatMonitor) Start() {
+	m.wg.Add(1)
+	go m.run()
+}
+
+// Stop signals the monitor to stop and waits for it to finish
+func (m *HeartbeatMonitor) Stop() {
+	m.logger.Debug("Stopping heartbeat monitor...")
+	m.cancel()
+	close(m.stopCh)
+	m.wg.Wait()
+
+	// Close the persistent repository connection if it exists
+	m.repoMu.Lock()
+	if m.deviceRepo != nil {
+		m.deviceRepo.Close()
+		m.deviceRepo = nil
+	}
+	m.repoMu.Unlock()
+
+	m.logger.Info("Heartbeat monitor stopped")
+}
+
+func (m *HeartbeatMonitor) run() {
+	defer m.wg.Done()
+
+	// Load initial settings to get heartbeat interval
+	heartbeatInterval := m.getHeartbeatInterval()
+	ticker := time.NewTicker(heartbeatInterval)
+	defer ticker.Stop()
+
+	m.logger.Infof("Heartbeat monitor started with interval: %v", heartbeatInterval)
+
+	// Set initial next check time
+	m.statusMu.Lock()
+	m.nextCheckTime = time.Now().Add(heartbeatInterval)
+	m.statusMu.Unlock()
+
+	for {
+		select {
+		case <-m.stopCh:
+			return
+		case <-ticker.C:
+			m.checkAndSendHeartbeat()
+
+			// Update ticker interval in case settings changed
+			newInterval := m.getHeartbeatInterval()
+			if newInterval != heartbeatInterval {
+				ticker.Reset(newInterval)
+				heartbeatInterval = newInterval
+				m.logger.Debugf("Heartbeat interval updated to: %v", heartbeatInterval)
+			}
+
+			// Update next check time
+			m.statusMu.Lock()
+			m.nextCheckTime = time.Now().Add(heartbeatInterval)
+			m.statusMu.Unlock()
+		}
+	}
+}
+
+// getOrCreateRepo returns the persistent repository, creating it if necessary
+func (m *HeartbeatMonitor) getOrCreateRepo() (database.DeviceRepo, error) {
+	m.repoMu.Lock()
+	defer m.repoMu.Unlock()
+
+	if m.deviceRepo != nil {
+		return m.deviceRepo, nil
+	}
+
+	repo, err := database.NewScrutinyRepository(m.appEngine.Config, m.logger)
+	if err != nil {
+		return nil, err
+	}
+
+	m.deviceRepo = repo
+	return m.deviceRepo, nil
+}
+
+// resetRepo closes and clears the persistent repository (called on connection errors)
+func (m *HeartbeatMonitor) resetRepo() {
+	m.repoMu.Lock()
+	defer m.repoMu.Unlock()
+
+	if m.deviceRepo != nil {
+		m.deviceRepo.Close()
+		m.deviceRepo = nil
+	}
+}
+
+func (m *HeartbeatMonitor) getHeartbeatInterval() time.Duration {
+	// Check if context is already cancelled
+	if m.ctx.Err() != nil {
+		return time.Duration(DefaultHeartbeatIntervalHours) * time.Hour
+	}
+
+	// Try to get or create repository
+	deviceRepo, err := m.getOrCreateRepo()
+	if err != nil {
+		m.logger.Warnf("Failed to create repository for heartbeat settings: %v, using default interval", err)
+		return time.Duration(DefaultHeartbeatIntervalHours) * time.Hour
+	}
+
+	settings, err := deviceRepo.LoadSettings(m.ctx)
+	if err != nil {
+		m.resetRepo()
+		return time.Duration(DefaultHeartbeatIntervalHours) * time.Hour
+	}
+	if settings == nil {
+		return time.Duration(DefaultHeartbeatIntervalHours) * time.Hour
+	}
+
+	interval := settings.Metrics.HeartbeatIntervalHours
+	if interval <= 0 {
+		interval = DefaultHeartbeatIntervalHours
+	}
+
+	return time.Duration(interval) * time.Hour
+}
+
+func (m *HeartbeatMonitor) checkAndSendHeartbeat() {
+	if m.ctx.Err() != nil {
+		return
+	}
+
+	// Update last check time
+	m.statusMu.Lock()
+	m.lastCheckTime = time.Now()
+	m.statusMu.Unlock()
+
+	deviceRepo, err := m.getOrCreateRepo()
+	if err != nil {
+		m.logger.Errorf("Failed to get/create repository for heartbeat: %v", err)
+		m.statusMu.Lock()
+		m.lastError = err
+		m.lastErrorTime = time.Now()
+		m.statusMu.Unlock()
+		return
+	}
+
+	settings, err := deviceRepo.LoadSettings(m.ctx)
+	if err != nil {
+		m.resetRepo()
+		m.logger.Errorf("Failed to load settings for heartbeat: %v", err)
+		m.statusMu.Lock()
+		m.lastError = err
+		m.lastErrorTime = time.Now()
+		m.statusMu.Unlock()
+		return
+	}
+
+	if settings == nil || !settings.Metrics.HeartbeatEnabled {
+		m.logger.Debug("Heartbeat notifications are disabled")
+		m.statusMu.Lock()
+		m.lastError = nil
+		m.statusMu.Unlock()
+		return
+	}
+
+	devices, err := deviceRepo.GetDevices(m.ctx)
+	if err != nil {
+		m.resetRepo()
+		m.logger.Errorf("Failed to load devices for heartbeat: %v", err)
+		m.statusMu.Lock()
+		m.lastError = err
+		m.lastErrorTime = time.Now()
+		m.statusMu.Unlock()
+		return
+	}
+
+	// Clear previous error on successful data load
+	m.statusMu.Lock()
+	m.lastError = nil
+	m.statusMu.Unlock()
+
+	// Filter to monitored devices (not archived, not muted)
+	totalCount := len(devices)
+	monitoredCount := 0
+	allHealthy := true
+
+	for _, device := range devices {
+		if device.Archived || device.Muted {
+			continue
+		}
+		monitoredCount++
+		if device.DeviceStatus != pkg.DeviceStatusPassed {
+			allHealthy = false
+		}
+	}
+
+	// Don't send heartbeat if no monitored devices
+	if monitoredCount == 0 {
+		m.logger.Debug("No monitored devices found, skipping heartbeat")
+		return
+	}
+
+	// Don't send heartbeat if any device has failures
+	if !allHealthy {
+		m.logger.Debug("Active drive failures detected, skipping heartbeat (failure notifications take priority)")
+		return
+	}
+
+	// All monitored drives are healthy -- send heartbeat
+	m.logger.Infof("All %d monitored drives healthy, sending heartbeat notification", monitoredCount)
+
+	notification := notify.NewHeartbeat(m.logger, m.appEngine.Config, monitoredCount, totalCount)
+	if err := notification.Send(); err != nil {
+		if err.Error() == "no notification endpoints configured" {
+			m.logger.Warn("Heartbeat ready but no notification endpoints are configured. Configure notify.urls in scrutiny.yaml to receive heartbeat alerts.")
+			return
+		}
+		m.logger.Errorf("Failed to send heartbeat notification: %v", err)
+		return
+	}
+
+	m.logger.Info("Heartbeat notification sent successfully")
+}

--- a/webapp/backend/pkg/web/heartbeat_monitor_test.go
+++ b/webapp/backend/pkg/web/heartbeat_monitor_test.go
@@ -1,0 +1,289 @@
+package web
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/analogj/scrutiny/webapp/backend/pkg"
+	mock_config "github.com/analogj/scrutiny/webapp/backend/pkg/config/mock"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/models"
+	"github.com/golang/mock/gomock"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func createHeartbeatTestAppEngine(t *testing.T) (*AppEngine, *gomock.Controller) {
+	mockCtrl := gomock.NewController(t)
+	fakeConfig := mock_config.NewMockInterface(mockCtrl)
+
+	// Common config expectations
+	fakeConfig.EXPECT().GetStringSlice("notify.urls").Return([]string{}).AnyTimes()
+	fakeConfig.EXPECT().GetString("notify.urls").Return("").AnyTimes()
+
+	logger := logrus.New()
+	logger.SetLevel(logrus.DebugLevel)
+
+	ae := &AppEngine{
+		Config: fakeConfig,
+		Logger: logrus.NewEntry(logger),
+	}
+
+	return ae, mockCtrl
+}
+
+func TestHeartbeatMonitor_NewHeartbeatMonitor(t *testing.T) {
+	t.Parallel()
+
+	ae, mockCtrl := createHeartbeatTestAppEngine(t)
+	defer mockCtrl.Finish()
+
+	monitor := NewHeartbeatMonitor(ae)
+
+	require.NotNil(t, monitor)
+	require.NotNil(t, monitor.stopCh)
+	require.NotNil(t, monitor.ctx)
+	require.NotNil(t, monitor.cancel)
+	require.Equal(t, ae, monitor.appEngine)
+}
+
+func TestHeartbeatMonitor_StartAndStop(t *testing.T) {
+	t.Parallel()
+
+	ae, mockCtrl := createHeartbeatTestAppEngine(t)
+	defer mockCtrl.Finish()
+
+	monitor := NewHeartbeatMonitor(ae)
+
+	// Cancel context before starting to prevent repository creation attempts
+	monitor.cancel()
+
+	// Start the monitor (will use default interval due to cancelled context)
+	monitor.Start()
+
+	// Give it a moment to start
+	time.Sleep(10 * time.Millisecond)
+
+	// Stop should not hang and should complete quickly
+	done := make(chan struct{})
+	go func() {
+		monitor.Stop()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Success - stop completed
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stop() timed out - monitor did not shutdown gracefully")
+	}
+}
+
+func TestHeartbeatMonitor_ContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	ae, mockCtrl := createHeartbeatTestAppEngine(t)
+	defer mockCtrl.Finish()
+
+	monitor := NewHeartbeatMonitor(ae)
+
+	// Verify context is not cancelled initially
+	require.NoError(t, monitor.ctx.Err())
+
+	// Cancel via cancel func
+	monitor.cancel()
+
+	// Context should now be cancelled
+	require.Error(t, monitor.ctx.Err())
+	require.Equal(t, context.Canceled, monitor.ctx.Err())
+}
+
+func TestHeartbeatMonitor_GetHeartbeatInterval_Default(t *testing.T) {
+	t.Parallel()
+
+	ae, mockCtrl := createHeartbeatTestAppEngine(t)
+	defer mockCtrl.Finish()
+
+	monitor := NewHeartbeatMonitor(ae)
+
+	// Cancel context to simulate startup without database
+	monitor.cancel()
+
+	interval := monitor.getHeartbeatInterval()
+
+	require.Equal(t, time.Duration(DefaultHeartbeatIntervalHours)*time.Hour, interval)
+}
+
+func TestHeartbeatMonitor_CheckAndSendHeartbeat_SkipsWhenContextCancelled(t *testing.T) {
+	t.Parallel()
+
+	ae, mockCtrl := createHeartbeatTestAppEngine(t)
+	defer mockCtrl.Finish()
+
+	monitor := NewHeartbeatMonitor(ae)
+
+	// Cancel context
+	monitor.cancel()
+
+	// This should return early without doing anything
+	monitor.checkAndSendHeartbeat()
+
+	// Verify last check time was not set (context was cancelled before any work)
+	monitor.statusMu.RLock()
+	require.True(t, monitor.lastCheckTime.IsZero())
+	monitor.statusMu.RUnlock()
+}
+
+func TestHeartbeatMonitor_ResetRepo(t *testing.T) {
+	t.Parallel()
+
+	ae, mockCtrl := createHeartbeatTestAppEngine(t)
+	defer mockCtrl.Finish()
+
+	monitor := NewHeartbeatMonitor(ae)
+
+	// resetRepo should not panic even when repo is nil
+	monitor.resetRepo()
+
+	// Still nil
+	require.Nil(t, monitor.deviceRepo)
+}
+
+// TestHeartbeatMonitor_AllHealthyDevices verifies the logic for determining
+// if all devices are healthy (unit test of the filtering logic)
+func TestHeartbeatMonitor_AllHealthyDevices(t *testing.T) {
+	t.Parallel()
+
+	devices := []models.Device{
+		{WWN: "dev1", DeviceStatus: pkg.DeviceStatusPassed},
+		{WWN: "dev2", DeviceStatus: pkg.DeviceStatusPassed},
+		{WWN: "dev3", DeviceStatus: pkg.DeviceStatusPassed},
+	}
+
+	monitoredCount := 0
+	allHealthy := true
+	for _, device := range devices {
+		if device.Archived || device.Muted {
+			continue
+		}
+		monitoredCount++
+		if device.DeviceStatus != pkg.DeviceStatusPassed {
+			allHealthy = false
+		}
+	}
+
+	require.Equal(t, 3, monitoredCount)
+	require.True(t, allHealthy)
+}
+
+// TestHeartbeatMonitor_FailedDeviceSkipsHeartbeat verifies that heartbeat
+// is suppressed when any device has a failure status
+func TestHeartbeatMonitor_FailedDeviceSkipsHeartbeat(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name         string
+		devices      []models.Device
+		expectHealthy bool
+	}{
+		{
+			name: "smart failure",
+			devices: []models.Device{
+				{WWN: "dev1", DeviceStatus: pkg.DeviceStatusPassed},
+				{WWN: "dev2", DeviceStatus: pkg.DeviceStatusFailedSmart},
+			},
+			expectHealthy: false,
+		},
+		{
+			name: "scrutiny failure",
+			devices: []models.Device{
+				{WWN: "dev1", DeviceStatus: pkg.DeviceStatusPassed},
+				{WWN: "dev2", DeviceStatus: pkg.DeviceStatusFailedScrutiny},
+			},
+			expectHealthy: false,
+		},
+		{
+			name: "both failures",
+			devices: []models.Device{
+				{WWN: "dev1", DeviceStatus: pkg.DeviceStatusFailedSmart | pkg.DeviceStatusFailedScrutiny},
+			},
+			expectHealthy: false,
+		},
+		{
+			name: "all healthy",
+			devices: []models.Device{
+				{WWN: "dev1", DeviceStatus: pkg.DeviceStatusPassed},
+				{WWN: "dev2", DeviceStatus: pkg.DeviceStatusPassed},
+			},
+			expectHealthy: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			monitoredCount := 0
+			allHealthy := true
+			for _, device := range tc.devices {
+				if device.Archived || device.Muted {
+					continue
+				}
+				monitoredCount++
+				if device.DeviceStatus != pkg.DeviceStatusPassed {
+					allHealthy = false
+				}
+			}
+			require.Equal(t, tc.expectHealthy, allHealthy)
+			require.Greater(t, monitoredCount, 0)
+		})
+	}
+}
+
+// TestHeartbeatMonitor_ArchivedMutedDevicesExcluded verifies that archived
+// and muted devices are excluded from the health check
+func TestHeartbeatMonitor_ArchivedMutedDevicesExcluded(t *testing.T) {
+	t.Parallel()
+
+	devices := []models.Device{
+		{WWN: "dev1", DeviceStatus: pkg.DeviceStatusPassed},
+		{WWN: "dev2", DeviceStatus: pkg.DeviceStatusFailedSmart, Archived: true},
+		{WWN: "dev3", DeviceStatus: pkg.DeviceStatusFailedScrutiny, Muted: true},
+	}
+
+	monitoredCount := 0
+	allHealthy := true
+	for _, device := range devices {
+		if device.Archived || device.Muted {
+			continue
+		}
+		monitoredCount++
+		if device.DeviceStatus != pkg.DeviceStatusPassed {
+			allHealthy = false
+		}
+	}
+
+	// Only dev1 should be monitored, and it's healthy
+	require.Equal(t, 1, monitoredCount)
+	require.True(t, allHealthy)
+}
+
+// TestHeartbeatMonitor_NoMonitoredDevices verifies that heartbeat
+// is not sent when there are no monitored devices
+func TestHeartbeatMonitor_NoMonitoredDevices(t *testing.T) {
+	t.Parallel()
+
+	devices := []models.Device{
+		{WWN: "dev1", DeviceStatus: pkg.DeviceStatusPassed, Archived: true},
+		{WWN: "dev2", DeviceStatus: pkg.DeviceStatusPassed, Muted: true},
+	}
+
+	monitoredCount := 0
+	for _, device := range devices {
+		if device.Archived || device.Muted {
+			continue
+		}
+		monitoredCount++
+	}
+
+	// No monitored devices -- heartbeat should not be sent
+	require.Equal(t, 0, monitoredCount)
+}

--- a/webapp/backend/pkg/web/server.go
+++ b/webapp/backend/pkg/web/server.go
@@ -28,6 +28,7 @@ type AppEngine struct {
 	Logger            *logrus.Entry
 	MetricsCollector  *metrics.Collector
 	MissedPingMonitor *MissedPingMonitor
+	HeartbeatMonitor  *HeartbeatMonitor
 }
 
 func (ae *AppEngine) Setup(logger *logrus.Entry) *gin.Engine {
@@ -208,6 +209,12 @@ func (ae *AppEngine) Start() error {
 	missedPingMonitor.Start()
 	ae.Logger.Info("Missed ping monitor started")
 
+	// Create and start the heartbeat monitor
+	heartbeatMonitor := NewHeartbeatMonitor(ae)
+	ae.HeartbeatMonitor = heartbeatMonitor
+	heartbeatMonitor.Start()
+	ae.Logger.Info("Heartbeat monitor started")
+
 	// Load initial metrics data asynchronously at startup (if metrics enabled)
 	if ae.Config.GetBool("web.metrics.enabled") && ae.MetricsCollector != nil {
 		go func() {
@@ -247,9 +254,12 @@ func (ae *AppEngine) Start() error {
 	<-quit
 	ae.Logger.Info("Shutdown signal received, initiating graceful shutdown...")
 
-	// Stop the missed ping monitor first
+	// Stop background monitors
 	if ae.MissedPingMonitor != nil {
 		ae.MissedPingMonitor.Stop()
+	}
+	if ae.HeartbeatMonitor != nil {
+		ae.HeartbeatMonitor.Stop()
 	}
 
 	// Create a deadline for shutdown (give 30 seconds for graceful shutdown)

--- a/webapp/frontend/src/app/core/config/app.config.ts
+++ b/webapp/frontend/src/app/core/config/app.config.ts
@@ -100,6 +100,9 @@ export interface AppConfig {
         notify_on_missed_ping?: boolean
         missed_ping_timeout_minutes?: number
         missed_ping_check_interval_mins?: number
+        // Heartbeat notifications
+        heartbeat_enabled?: boolean
+        heartbeat_interval_hours?: number
     }
 
     // Server version (populated from API response, not stored in settings)
@@ -138,7 +141,9 @@ export const appConfig: AppConfig = {
         repeat_notifications: true,
         notify_on_missed_ping: false,
         missed_ping_timeout_minutes: 60,
-        missed_ping_check_interval_mins: 5
+        missed_ping_check_interval_mins: 5,
+        heartbeat_enabled: false,
+        heartbeat_interval_hours: 24
     }
 };
 

--- a/webapp/frontend/src/app/layout/common/dashboard-settings/dashboard-settings.component.html
+++ b/webapp/frontend/src/app/layout/common/dashboard-settings/dashboard-settings.component.html
@@ -147,6 +147,25 @@
             </mat-form-field>
         </div>
 
+        <div class="flex flex-col mt-5 gt-md:flex-row">
+            <mat-form-field class="flex-auto gt-xs:pr-3 gt-md:pr-3">
+                <mat-label>Heartbeat Notifications</mat-label>
+                <mat-select [(ngModel)]="heartbeatEnabled">
+                    <mat-option [value]="true">Enabled</mat-option>
+                    <mat-option [value]="false">Disabled</mat-option>
+                </mat-select>
+                <mat-hint>Periodic "all drives healthy" notification</mat-hint>
+            </mat-form-field>
+        </div>
+
+        <div class="flex flex-col mt-5 gt-md:flex-row" *ngIf="heartbeatEnabled">
+            <mat-form-field class="flex-auto gt-xs:pr-3 gt-md:pr-3">
+                <mat-label>Heartbeat Interval (hours)</mat-label>
+                <input matInput type="number" [(ngModel)]="heartbeatIntervalHours" min="1">
+                <mat-hint>Hours between heartbeat notifications (default: 24)</mat-hint>
+            </mat-form-field>
+        </div>
+
         <!-- SMART Attribute Overrides Section -->
         <mat-expansion-panel class="mt-5">
             <mat-expansion-panel-header>

--- a/webapp/frontend/src/app/layout/common/dashboard-settings/dashboard-settings.component.ts
+++ b/webapp/frontend/src/app/layout/common/dashboard-settings/dashboard-settings.component.ts
@@ -44,6 +44,10 @@ export class DashboardSettingsComponent implements OnInit {
     missedPingTimeoutMinutes: number;
     missedPingCheckIntervalMins: number;
 
+    // Heartbeat settings
+    heartbeatEnabled: boolean;
+    heartbeatIntervalHours: number;
+
     // Attribute overrides
     overrides: AttributeOverride[] = [];
     displayedColumns: string[] = ['protocol', 'attribute_id', 'action', 'source', 'actions'];
@@ -98,6 +102,10 @@ export class DashboardSettingsComponent implements OnInit {
                 this.notifyOnMissedPing = config.metrics.notify_on_missed_ping ?? false;
                 this.missedPingTimeoutMinutes = config.metrics.missed_ping_timeout_minutes ?? 60;
                 this.missedPingCheckIntervalMins = config.metrics.missed_ping_check_interval_mins ?? 5;
+
+                // Heartbeat settings
+                this.heartbeatEnabled = config.metrics.heartbeat_enabled ?? false;
+                this.heartbeatIntervalHours = config.metrics.heartbeat_interval_hours ?? 24;
 
             });
 
@@ -176,7 +184,9 @@ export class DashboardSettingsComponent implements OnInit {
                 repeat_notifications: this.repeatNotifications,
                 notify_on_missed_ping: this.notifyOnMissedPing,
                 missed_ping_timeout_minutes: this.missedPingTimeoutMinutes,
-                missed_ping_check_interval_mins: this.missedPingCheckIntervalMins
+                missed_ping_check_interval_mins: this.missedPingCheckIntervalMins,
+                heartbeat_enabled: this.heartbeatEnabled,
+                heartbeat_interval_hours: this.heartbeatIntervalHours
             }
         }
         this._configService.config = newSettings


### PR DESCRIPTION
## Summary

- Adds opt-in periodic "all clear" heartbeat notifications that confirm Scrutiny is running and all drives are healthy
- Useful for integration with uptime monitoring tools (Uptime Kuma, etc.) that need positive confirmation the system is operational
- Follows the existing MissedPingMonitor pattern exactly (background goroutine, settings-driven, dynamic reconfiguration)

Closes #188

## Changes

### Backend (7 files)
- **Settings model** - Added `heartbeat_enabled` and `heartbeat_interval_hours` fields
- **Database migration** (`m20260207000000`) - Inserts default settings (disabled, 24h interval)
- **HeartbeatMonitor** - New background goroutine that periodically checks device health and sends notifications when all drives are healthy
- **Notify package** - Added `Heartbeat` notification type with payload, subject, and message generation
- **Server wiring** - HeartbeatMonitor lifecycle (start/stop) integrated into AppEngine

### Frontend (3 files)
- **AppConfig** - Added heartbeat fields to TypeScript interface and defaults
- **Settings UI** - Enable/disable dropdown and interval input in dashboard settings

### Documentation (3 files)
- **README.md** - Added to feature list and Notifications section
- **TROUBLESHOOTING_NOTIFICATIONS.md** - Updated failure types for script notifications
- **example.scrutiny.yaml** - Documented heartbeat settings

## Behavior
- **Disabled by default** (opt-in via Settings UI or API)
- **Default interval**: 24 hours
- **Suppressed during failures**: If any monitored drive has `DeviceStatusFailedSmart` or `DeviceStatusFailedScrutiny`, the heartbeat is not sent
- **Excludes archived/muted devices** from the health check
- **No heartbeat if zero monitored devices** exist

## Test plan
- [x] 10 unit tests added (`heartbeat_monitor_test.go`) - all pass
- [x] All existing tests pass (missed ping, models, notify)
- [x] Backend compiles (scrutiny + collector binaries)
- [x] Docker omnibus image built and deployed to dev environment (Zeus)
- [x] Migration ran successfully on live container
- [x] Settings API returns heartbeat fields correctly
- [x] Settings toggle works via web UI (verified in container logs)
- [x] Heartbeat monitor starts with configured interval