### PR TITLE
fix(smart): persist model name for SAS/SCSI drives

### DIFF
--- a/webapp/backend/pkg/database/scrutiny_repository_device.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_device.go
@@ -22,7 +22,7 @@ import (
 func (sr *scrutinyRepository) RegisterDevice(ctx context.Context, dev models.Device) error {
 	if err := sr.gormClient.WithContext(ctx).Clauses(clause.OnConflict{
 		Columns:   []clause.Column{{Name: "wwn"}},
-		DoUpdates: clause.AssignmentColumns([]string{"host_id", "device_name", "device_type", "device_uuid", "device_serial_id", "device_label", "collector_version"}),
+		DoUpdates: clause.AssignmentColumns([]string{"host_id", "device_name", "device_type", "device_uuid", "device_serial_id", "device_label", "collector_version", "model_name", "manufacturer"}),
 	}).Create(&dev).Error; err != nil {
 		return err
 	}

--- a/webapp/backend/pkg/models/device.go
+++ b/webapp/backend/pkg/models/device.go
@@ -167,6 +167,7 @@ func (dv *Device) IsNvme() bool {
 // This function is called every time the collector sends SMART data to the API.
 // It can be used to update device data that can change over time.
 func (dv *Device) UpdateFromCollectorSmartInfo(info collector.SmartInfo) error {
+	dv.ModelName = info.ModelName
 	dv.Firmware = info.FirmwareVersion
 	dv.DeviceProtocol = info.Device.Protocol
 

--- a/webapp/backend/pkg/models/device_test.go
+++ b/webapp/backend/pkg/models/device_test.go
@@ -1,0 +1,53 @@
+package models
+
+import (
+	"testing"
+
+	"github.com/analogj/scrutiny/webapp/backend/pkg/models/collector"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpdateFromCollectorSmartInfo_ShouldPopulateModelName(t *testing.T) {
+	// setup
+	device := Device{
+		WWN:        "0x5000cca252c859cc",
+		DeviceName: "sdg",
+	}
+	smartInfo := collector.SmartInfo{
+		ModelName:       "SEAGATE ST4000NM0043",
+		FirmwareVersion: "0004",
+	}
+	smartInfo.Device.Protocol = "SCSI"
+	smartInfo.SmartStatus.Passed = true
+
+	// test
+	err := device.UpdateFromCollectorSmartInfo(smartInfo)
+
+	// assert
+	require.NoError(t, err)
+	require.Equal(t, "SEAGATE ST4000NM0043", device.ModelName)
+	require.Equal(t, "0004", device.Firmware)
+	require.Equal(t, "SCSI", device.DeviceProtocol)
+}
+
+func TestUpdateFromCollectorSmartInfo_ShouldPopulateModelNameForAta(t *testing.T) {
+	// setup
+	device := Device{
+		WWN:        "0x5000cca264eb01d7",
+		DeviceName: "sda",
+	}
+	smartInfo := collector.SmartInfo{
+		ModelName:       "WDC WD140EDFZ-11A0VA0",
+		FirmwareVersion: "81.00A81",
+	}
+	smartInfo.Device.Protocol = "ATA"
+	smartInfo.SmartStatus.Passed = true
+
+	// test
+	err := device.UpdateFromCollectorSmartInfo(smartInfo)
+
+	// assert
+	require.NoError(t, err)
+	require.Equal(t, "WDC WD140EDFZ-11A0VA0", device.ModelName)
+	require.Equal(t, "ATA", device.DeviceProtocol)
+}


### PR DESCRIPTION
## Summary

- Add `model_name` and `manufacturer` to `RegisterDevice()` UPSERT `DoUpdates` clause so re-registrations persist these fields
- Add `ModelName` update in `UpdateFromCollectorSmartInfo()` so SMART data uploads also keep model name current
- Add unit tests for `UpdateFromCollectorSmartInfo` covering both SCSI and ATA devices

Fixes #190

## Root Cause

SAS/SCSI drives displayed as `/dev/sdaX -` without model names because:
1. `RegisterDevice()` UPSERT did not include `model_name` in its update columns, so re-registrations never updated it
2. `UpdateFromCollectorSmartInfo()` did not populate `ModelName` from collector data

The collector and frontend were already correct - this was purely a backend persistence gap.

## Test plan

- [x] `go build ./webapp/backend/...` compiles
- [x] `go build ./collector/...` compiles
- [x] `go test ./webapp/backend/pkg/models/...` passes (46/46 tests)
- [x] Built omnibus image, deployed to zeus dev, verified all devices now show model names via `/api/summary`