### PR TITLE
fix(smart): handle manufacturer-specific Power-On Hours encoding

### DIFF
--- a/webapp/backend/pkg/models/measurements/smart_ata_attribute_test.go
+++ b/webapp/backend/pkg/models/measurements/smart_ata_attribute_test.go
@@ -8,6 +8,56 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Power-On Hours (Attribute 9) Transform Tests
+
+func TestAttribute9Transform_StandardHours(t *testing.T) {
+	transform := thresholds.AtaMetadata[9].Transform
+	require.NotNil(t, transform)
+	result := transform(100, 1730, "1730")
+	require.Equal(t, int64(1730), result)
+}
+
+func TestAttribute9Transform_ZeroHours(t *testing.T) {
+	transform := thresholds.AtaMetadata[9].Transform
+	result := transform(100, 0, "0")
+	require.Equal(t, int64(0), result)
+}
+
+func TestAttribute9Transform_PackedValue(t *testing.T) {
+	// From smart-sat.json: rawValue=167031278144165 (0x97ea00000aa5), actual hours=2725
+	transform := thresholds.AtaMetadata[9].Transform
+	result := transform(97, 167031278144165, "2725 (151 234 0)")
+	require.Equal(t, int64(2725), result)
+}
+
+func TestAttribute9Transform_PackedValueLargeHours(t *testing.T) {
+	// Packed format where upper bytes contain flags, lower 32 bits = 10800 hours
+	transform := thresholds.AtaMetadata[9].Transform
+	result := transform(85, 0x001E00002A30, "10800")
+	require.Equal(t, int64(10800), result)
+}
+
+func TestAttribute9Transform_HoursMinutesSecondsFormat(t *testing.T) {
+	// smartctl h+m+s format
+	transform := thresholds.AtaMetadata[9].Transform
+	result := transform(97, 1730, "1730h+05m+02.453s")
+	require.Equal(t, int64(1730), result)
+}
+
+func TestAttribute9Transform_ParenthesisHoursFormat(t *testing.T) {
+	// smartctl minutes-converted format
+	transform := thresholds.AtaMetadata[9].Transform
+	result := transform(90, 103800, "103800 (1730 hours)")
+	require.Equal(t, int64(1730), result)
+}
+
+func TestAttribute9Transform_LargeStandardValue(t *testing.T) {
+	// Old drive with 100,000+ hours (within 32-bit range, not packed)
+	transform := thresholds.AtaMetadata[9].Transform
+	result := transform(50, 100000, "100000")
+	require.Equal(t, int64(100000), result)
+}
+
 func TestValidateThreshold_NonZeroAnnualFailureRate_Unchanged(t *testing.T) {
 	sa := SmartAtaAttribute{RawValue: 5}
 	metadata := thresholds.AtaAttributeMetadata{

--- a/webapp/backend/pkg/models/measurements/smart_test.go
+++ b/webapp/backend/pkg/models/measurements/smart_test.go
@@ -350,6 +350,9 @@ func TestFromCollectorSmartInfo(t *testing.T) {
 	require.Equal(t, int64(163210330144), smartMdl.Attributes["194"].(*measurements.SmartAtaAttribute).RawValue)
 	require.Equal(t, int64(32), smartMdl.Attributes["194"].(*measurements.SmartAtaAttribute).TransformedValue)
 
+	//check that power-on hours was correctly transformed
+	require.Equal(t, int64(1730), smartMdl.Attributes["9"].(*measurements.SmartAtaAttribute).TransformedValue)
+
 	//ensure that Scrutiny warning for a non critical attribute does not set device status to failed.
 	require.Equal(t, pkg.AttributeStatusWarningScrutiny, smartMdl.Attributes["3"].GetStatus())
 

--- a/webapp/backend/pkg/thresholds/ata_attribute_metadata.go
+++ b/webapp/backend/pkg/thresholds/ata_attribute_metadata.go
@@ -258,10 +258,49 @@ var AtaMetadata = map[int]AtaAttributeMetadata{
 
 		ID:          9,
 		DisplayName: "Power-On Hours",
-		DisplayType: AtaSmartAttributeDisplayTypeNormalized,
+		DisplayType: AtaSmartAttributeDisplayTypeTransformed,
 		Ideal:       "",
 		Critical:    false,
 		Description: "Count of hours in power-on state. The raw value of this attribute shows total count of hours (or minutes, or seconds, depending on manufacturer) in power-on state. By default, the total expected lifetime of a hard disk in perfect condition is defined as 5 years (running every day and night on all days). This is equal to 1825 days in 24/7 mode or 43800 hours. On some pre-2005 drives, this raw value may advance erratically and/or \"wrap around\" (reset to zero periodically).",
+		Transform: func(normValue int64, rawValue int64, rawString string) int64 {
+			// smartctl "h+m+s" format (e.g., "1730h+05m+02.453s")
+			if strings.Contains(rawString, "h+") {
+				hIdx := strings.Index(rawString, "h+")
+				if hIdx > 0 {
+					hours, err := strconv.ParseInt(rawString[:hIdx], 10, 64)
+					if err == nil {
+						return hours
+					}
+				}
+			}
+
+			// smartctl parsed format with parenthetical hours
+			// e.g., "103800 (1730 hours)" when smartctl detects minutes encoding
+			if strings.Contains(rawString, "hours)") {
+				parenStart := strings.Index(rawString, "(")
+				if parenStart >= 0 {
+					inner := rawString[parenStart+1:]
+					spaceIdx := strings.Index(inner, " ")
+					if spaceIdx > 0 {
+						hours, err := strconv.ParseInt(inner[:spaceIdx], 10, 64)
+						if err == nil {
+							return hours
+						}
+					}
+				}
+			}
+
+			// Packed 48-bit raw value with extra data in upper bytes.
+			// Some manufacturers store additional data (e.g., temperature, flags) in
+			// the upper bytes. The actual power-on hours are in the lower 32 bits.
+			if rawValue > 0xFFFFFFFF {
+				return rawValue & 0xFFFFFFFF
+			}
+
+			// Standard: raw value is already in hours
+			return rawValue
+		},
+		TransformValueUnit: "hours",
 	},
 	10: {
 		ID:          10,


### PR DESCRIPTION
## Summary

- Added `Transform` function to SMART attribute 9 (Power-On Hours) to correctly extract hours from manufacturer-specific encodings
- Changed `DisplayType` from `normalized` to `transformed` so the UI shows actual power-on hours instead of a meaningless 0-255 normalized value
- Handles three encoding variants: smartctl `h+m+s` format, parenthetical hours format, and packed 48-bit raw values

## Test plan

- [x] 7 unit tests covering all transform cases (standard, zero, packed, h+m+s, parenthetical, large values)
- [x] Integration test asserting `TransformedValue == 1730` from `smart-ata.json`
- [x] All 50 measurements package tests pass
- [x] Deployed to dev container on zeus - verified transform works with real drive data (ST4000DM004: `raw_string: "59412h+11m+25.482s"` -> `transformed_value: 59412`)

Closes #191