### PR TITLE
fix(ci): replace packagr container with actions/setup-go

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,6 @@ jobs:
   test-backend:
     name: Test Backend
     runs-on: ubuntu-latest
-    container: ghcr.io/packagrio/packagr:latest-golang
     # Service containers to run with `build` (Required for end-to-end testing)
     services:
       influxdb:
@@ -43,13 +42,12 @@ jobs:
     env:
       STATIC: true
     steps:
-      - name: Git
-        run: |
-          apt-get update && apt-get install -y software-properties-common
-          add-apt-repository ppa:git-core/ppa && apt-get update && apt-get install -y git
-          git --version
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
       - name: Test Backend
         run: |
           make binary-clean binary-test-coverage
@@ -96,7 +94,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24.0'
+          go-version-file: go.mod
       - name: Sync vendor
         run: go mod vendor
       - name: golangci-lint
@@ -133,7 +131,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24.0'
+          go-version-file: go.mod
       - name: Build Binaries
         run: |
           make binary-clean binary-all


### PR DESCRIPTION
## Summary

- Replace `ghcr.io/packagrio/packagr:latest-golang` container (stuck at Go 1.24.4) with `actions/setup-go` using `go-version-file: go.mod`
- The shoutrrr fork update in #207 bumped `go.mod` to `go 1.24.6`, causing `test-backend` to fail with: `go.mod requires go >= 1.24.6 (running go 1.24.4; GOTOOLCHAIN=local)`
- Also updated `lint-backend` and `build` jobs from hardcoded `go-version: '1.24.0'` to `go-version-file: go.mod` for consistency

## Test plan

- [ ] CI passes on this PR (test-backend job specifically)