### PR TITLE
fix(ui): hide threshold for non-normalized ATA attributes

### DIFF
--- a/webapp/frontend/src/app/modules/detail/detail.component.html
+++ b/webapp/frontend/src/app/modules/detail/detail.component.html
@@ -476,7 +476,7 @@
                         <div class="truncate">Normalized</div>
                       </div>
                       <div class="w-1/4 items-center font-medium">{{attribute.value}}</div>
-                      <div class="w-1/4 items-center text-secondary">{{getAttributeWorst(attribute) || '--' }}/{{getAttributeThreshold(attribute)}}</div>
+                      <div class="w-1/4 items-center text-secondary">{{getAttributeWorst(attribute) || '--' }}/{{getAttributeThreshold(attribute) || '--'}}</div>
                       <div class="w-1/4 items-center text-secondary">--</div>
                     </div>
 

--- a/webapp/frontend/src/app/modules/detail/detail.component.ts
+++ b/webapp/frontend/src/app/modules/detail/detail.component.ts
@@ -278,12 +278,7 @@ export class DetailComponent implements OnInit, AfterViewInit, OnDestroy {
             if (!attributeMetadata || attributeMetadata.display_type === 'normalized') {
                 return attributeData.thresh
             } else {
-                // if(this.data.metadata[attribute_data.attribute_id].observed_thresholds){
-                //
-                // } else {
-                // }
-                // return ''
-                return attributeData.thresh
+                return ''
             }
         } else {
             return (attributeData.thresh === -1 ? '' : attributeData.thresh)


### PR DESCRIPTION
## Summary
- Fix SonarQube bug S3923: identical if/else branches in `getAttributeThreshold()` -- both returned `attributeData.thresh` regardless of display type
- For non-normalized (raw/transformed) ATA attributes, return empty string instead, matching the existing pattern in `getAttributeWorst()`
- Add `|| '--'` fallback in the detail card template to prevent a dangling slash in the worst/threshold display

Replaces #209 (rebased on updated master to pick up CI fix from #211).

## Test plan
- [ ] All frontend tests pass
- [ ] Verify threshold column is empty for raw/transformed ATA attributes in table view
- [ ] Verify detail card shows `--/--` instead of `--/[value]` for non-normalized attributes