### PR TITLE
fix(collector): wire up allow_direct_device_io for perf benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,6 +497,7 @@ The performance collector checks `COLLECTOR_PERF_` prefixed variables first, the
 | `api.endpoint` | `COLLECTOR_PERF_API_ENDPOINT` or `COLLECTOR_API_ENDPOINT` | `http://localhost:8080` |
 | `performance.profile` | `COLLECTOR_PERF_PROFILE` | `quick` |
 | `performance.enabled` | `COLLECTOR_PERFORMANCE_ENABLED` | `false` |
+| `performance.allow_direct_device_io` | `COLLECTOR_PERFORMANCE_ALLOW_DIRECT_DEVICE_IO` | `false` |
 | `performance.temp_file_size` | `COLLECTOR_PERFORMANCE_TEMP_FILE_SIZE` | `256M` |
 | `commands.performance_fio_bin` | `COLLECTOR_COMMANDS_PERFORMANCE_FIO_BIN` | `fio` |
 | `log.level` | `COLLECTOR_LOG_LEVEL` | `INFO` |

--- a/collector/pkg/performance/collector.go
+++ b/collector/pkg/performance/collector.go
@@ -270,9 +270,12 @@ func (c *Collector) Publish(wwn string, result *models.PerformanceResult) error 
 // resolveTargetPath determines the fio target file path for benchmarking.
 // Returns the path, a cleanup function (if a temp file was created), and any error.
 func (c *Collector) resolveTargetPath(device *models.Device) (string, func(), error) {
-	// For safety, we always use a temp file on the device's filesystem.
-	// Direct device I/O is not supported in this version to prevent data loss.
 	fullDeviceName := fmt.Sprintf("%s%s", detect.DevicePrefix(), device.DeviceName)
+
+	if c.config.GetBool("performance.allow_direct_device_io") {
+		c.logger.Warnf("Direct device I/O enabled -- benchmarking raw device %s (writes are destructive!)", fullDeviceName)
+		return fullDeviceName, nil, nil
+	}
 
 	// Try to find mount point for the device
 	mountPoint, err := findMountPoint(fullDeviceName)

--- a/example.collector-performance.yaml
+++ b/example.collector-performance.yaml
@@ -58,6 +58,7 @@ api:
 performance:
   enabled: true
   profile: 'quick'            # 'quick' (~60s per device) or 'comprehensive' (~300s per device)
+#  allow_direct_device_io: false  # Benchmark raw block device (/dev/sdX) directly. WARNING: writes are destructive!
 #  temp_file_size: '256M'     # Size of temp file for benchmarks (used in quick profile)
 
 # Benchmark Profiles:

--- a/example.collector.yaml
+++ b/example.collector.yaml
@@ -131,7 +131,7 @@ devices:
 #performance:
 #  enabled: false             # Set to true to enable performance benchmarking
 #  profile: 'quick'           # 'quick' (~60s per device) or 'comprehensive' (~300s per device)
-#  allow_direct_device_io: false  # WARNING: not yet supported, reserved for future use
+#  allow_direct_device_io: false  # Benchmark raw block device (/dev/sdX) directly. WARNING: writes are destructive!
 #  temp_file_size: '256M'     # Size of temp file for benchmarks (used in quick profile)
 
 #commands:


### PR DESCRIPTION
## Summary

- Wires up the existing `performance.allow_direct_device_io` config option in `resolveTargetPath()` so fio benchmarks target the raw block device (`/dev/sdX`) directly when enabled
- Updates config comments and docs to reflect the option is now functional

Closes #219

## Context

The performance collector wrote its fio temp file to `/dev/.scrutiny_perf_bench` -- the container's devtmpfs -- regardless of which device was being tested. This caused identical (cached) read results across all devices and "No space left on device" errors for all write tests.

When `allow_direct_device_io: true`, fio now receives `--filename=/dev/sdb` (the actual block device) instead of a temp file on tmpfs. The default remains `false` (unchanged behavior).

## Test plan

- [ ] `go build ./collector/cmd/collector-performance/` passes
- [ ] `go vet ./collector/...` passes
- [ ] `go test ./collector/...` passes
- [ ] With `allow_direct_device_io: false` (default), behavior is unchanged
- [ ] With `allow_direct_device_io: true`, fio targets raw block device paths