### PR TITLE
fix(collector): read-only benchmarks for direct device I/O

### DIFF
--- a/collector/pkg/performance/collector.go
+++ b/collector/pkg/performance/collector.go
@@ -176,6 +176,8 @@ func (c *Collector) Benchmark(device *models.Device, profile string) (*models.Pe
 		result.FioVersion = strings.TrimSpace(string(versionOut))
 	}
 
+	directIO := c.config.GetBool("performance.allow_direct_device_io")
+
 	startTime := time.Now()
 
 	// Sequential read test
@@ -189,14 +191,18 @@ func (c *Collector) Benchmark(device *models.Device, profile string) (*models.Pe
 		}
 	}
 
-	// Sequential write test
-	c.logger.Debugf("Running sequential write test on %s", device.DeviceName)
-	seqWriteOut, err := c.runFio(fioBin, c.buildFioArgs("write", "1M", profile, targetPath))
-	if err != nil {
-		c.logger.Warnf("Sequential write test failed for %s: %v", device.DeviceName, err)
+	// Sequential write test (skipped for raw block devices to prevent data loss)
+	if directIO {
+		c.logger.Infof("Skipping sequential write test on %s (direct device I/O -- writes disabled for safety)", device.DeviceName)
 	} else {
-		if fioResult, parseErr := models.ParseFioOutput(seqWriteOut); parseErr == nil && len(fioResult.Jobs) > 0 {
-			result.SeqWriteBwBytes, _, _, _, _, _ = models.ExtractWriteStats(&fioResult.Jobs[0])
+		c.logger.Debugf("Running sequential write test on %s", device.DeviceName)
+		seqWriteOut, seqWriteErr := c.runFio(fioBin, c.buildFioArgs("write", "1M", profile, targetPath))
+		if seqWriteErr != nil {
+			c.logger.Warnf("Sequential write test failed for %s: %v", device.DeviceName, seqWriteErr)
+		} else {
+			if fioResult, parseErr := models.ParseFioOutput(seqWriteOut); parseErr == nil && len(fioResult.Jobs) > 0 {
+				result.SeqWriteBwBytes, _, _, _, _, _ = models.ExtractWriteStats(&fioResult.Jobs[0])
+			}
 		}
 	}
 
@@ -211,25 +217,33 @@ func (c *Collector) Benchmark(device *models.Device, profile string) (*models.Pe
 		}
 	}
 
-	// Random write test (IOPS + latency)
-	c.logger.Debugf("Running random write test on %s", device.DeviceName)
-	randWriteOut, err := c.runFio(fioBin, c.buildFioArgs("randwrite", "4K", profile, targetPath))
-	if err != nil {
-		c.logger.Warnf("Random write test failed for %s: %v", device.DeviceName, err)
+	// Random write test (skipped for raw block devices to prevent data loss)
+	if directIO {
+		c.logger.Infof("Skipping random write test on %s (direct device I/O -- writes disabled for safety)", device.DeviceName)
 	} else {
-		if fioResult, parseErr := models.ParseFioOutput(randWriteOut); parseErr == nil && len(fioResult.Jobs) > 0 {
-			_, result.RandWriteIOPS, result.RandWriteLatAvgNs, result.RandWriteLatP50Ns, result.RandWriteLatP95Ns, result.RandWriteLatP99Ns = models.ExtractWriteStats(&fioResult.Jobs[0])
+		c.logger.Debugf("Running random write test on %s", device.DeviceName)
+		randWriteOut, randWriteErr := c.runFio(fioBin, c.buildFioArgs("randwrite", "4K", profile, targetPath))
+		if randWriteErr != nil {
+			c.logger.Warnf("Random write test failed for %s: %v", device.DeviceName, randWriteErr)
+		} else {
+			if fioResult, parseErr := models.ParseFioOutput(randWriteOut); parseErr == nil && len(fioResult.Jobs) > 0 {
+				_, result.RandWriteIOPS, result.RandWriteLatAvgNs, result.RandWriteLatP50Ns, result.RandWriteLatP95Ns, result.RandWriteLatP99Ns = models.ExtractWriteStats(&fioResult.Jobs[0])
+			}
 		}
 	}
 
-	// Mixed random R/W test (comprehensive profile only)
-	if profile == "comprehensive" {
+	// Mixed random R/W test (comprehensive profile only, skipped for raw block devices)
+	if directIO {
+		if profile == "comprehensive" {
+			c.logger.Infof("Skipping mixed R/W test on %s (direct device I/O -- writes disabled for safety)", device.DeviceName)
+		}
+	} else if profile == "comprehensive" {
 		c.logger.Debugf("Running mixed random R/W test on %s", device.DeviceName)
 		mixedArgs := c.buildFioArgs("randrw", "4K", profile, targetPath)
 		mixedArgs = append(mixedArgs, "--rwmixread=70")
-		mixedOut, err := c.runFio(fioBin, mixedArgs)
-		if err != nil {
-			c.logger.Warnf("Mixed R/W test failed for %s: %v", device.DeviceName, err)
+		mixedOut, mixedErr := c.runFio(fioBin, mixedArgs)
+		if mixedErr != nil {
+			c.logger.Warnf("Mixed R/W test failed for %s: %v", device.DeviceName, mixedErr)
 		} else if fioResult, err := models.ParseFioOutput(mixedOut); err == nil && len(fioResult.Jobs) > 0 {
 			result.MixedRwIOPS = fioResult.Jobs[0].Read.IOPS + fioResult.Jobs[0].Write.IOPS
 		}
@@ -273,7 +287,7 @@ func (c *Collector) resolveTargetPath(device *models.Device) (string, func(), er
 	fullDeviceName := fmt.Sprintf("%s%s", detect.DevicePrefix(), device.DeviceName)
 
 	if c.config.GetBool("performance.allow_direct_device_io") {
-		c.logger.Warnf("Direct device I/O enabled -- benchmarking raw device %s (writes are destructive!)", fullDeviceName)
+		c.logger.Infof("Direct device I/O enabled -- benchmarking raw device %s (read-only, write tests skipped)", fullDeviceName)
 		return fullDeviceName, nil, nil
 	}
 

--- a/example.collector-performance.yaml
+++ b/example.collector-performance.yaml
@@ -58,7 +58,7 @@ api:
 performance:
   enabled: true
   profile: 'quick'            # 'quick' (~60s per device) or 'comprehensive' (~300s per device)
-#  allow_direct_device_io: false  # Benchmark raw block device (/dev/sdX) directly. WARNING: writes are destructive!
+#  allow_direct_device_io: false  # Benchmark raw block device (/dev/sdX) directly. Read-only (write tests skipped for safety).
 #  temp_file_size: '256M'     # Size of temp file for benchmarks (used in quick profile)
 
 # Benchmark Profiles:

--- a/example.collector.yaml
+++ b/example.collector.yaml
@@ -131,7 +131,7 @@ devices:
 #performance:
 #  enabled: false             # Set to true to enable performance benchmarking
 #  profile: 'quick'           # 'quick' (~60s per device) or 'comprehensive' (~300s per device)
-#  allow_direct_device_io: false  # Benchmark raw block device (/dev/sdX) directly. WARNING: writes are destructive!
+#  allow_direct_device_io: false  # Benchmark raw block device (/dev/sdX) directly. Read-only (write tests skipped for safety).
 #  temp_file_size: '256M'     # Size of temp file for benchmarks (used in quick profile)
 
 #commands:


### PR DESCRIPTION
## Summary

- When `allow_direct_device_io` is enabled, skip all fio write tests (sequential write, random write, mixed rw) against raw block devices
- Only read benchmarks (`read`, `randread`) run against `/dev/sdX`, preventing data destruction
- Updated config comments and log messages to reflect the read-only behavior

## Context

PR #226 wired up `allow_direct_device_io` so fio targets raw block devices directly. However, the write tests (`--rw=write`, `--rw=randwrite`, `--rw=randrw`) destroy partition tables, superblocks, and filesystems when writing to `/dev/sdX`. The benchmark loop runs against **all** detected devices including the OS disk, and the only safeguard was a single log warning.

This fix eliminates the risk entirely by skipping write tests when targeting raw devices. Read benchmarks still provide accurate throughput and IOPS numbers -- the original goal of `allow_direct_device_io`.

Addresses feedback from @delacor on #226.

## Test plan

- [x] `go build ./collector/cmd/collector-performance/` passes
- [x] `go vet ./collector/...` passes
- [ ] With `allow_direct_device_io: false` (default), all benchmarks run unchanged
- [ ] With `allow_direct_device_io: true`, only read tests run; write tests log skip messages at INFO level