### PR TITLE
feat(frontend): improve archived disk display (#218)

### DIFF
--- a/webapp/frontend/src/app/layout/common/dashboard-device/dashboard-device.component.html
+++ b/webapp/frontend/src/app/layout/common/dashboard-device/dashboard-device.component.html
@@ -1,17 +1,20 @@
 <div
   [ngClass]="{
     'border-green':
+      !deviceSummary.device.archived &&
       deviceStatusForModelWithThreshold(
         deviceSummary.device,
         !!deviceSummary.smart,
         config.metrics.status_threshold
       ) == 'passed',
     'border-red':
+      !deviceSummary.device.archived &&
       deviceStatusForModelWithThreshold(
         deviceSummary.device,
         !!deviceSummary.smart,
         config.metrics.status_threshold
       ) == 'failed',
+    'border-gray': deviceSummary.device.archived,
     'text-disabled': deviceSummary.device.archived
   }"
   class="relative flex flex-col flex-auto p-6 pr-3 pb-3 bg-card rounded border-l-4 shadow-md overflow-hidden"

--- a/webapp/frontend/src/app/layout/common/zfs-pool-card/zfs-pool-card.component.html
+++ b/webapp/frontend/src/app/layout/common/zfs-pool-card/zfs-pool-card.component.html
@@ -1,8 +1,9 @@
 <div
   [ngClass]="{
-    'border-green': getPoolStatus(poolSummary) == 'passed',
-    'border-red': getPoolStatus(poolSummary) == 'failed',
-    'border-yellow': getPoolStatus(poolSummary) == 'unknown',
+    'border-green': !poolSummary.archived && getPoolStatus(poolSummary) == 'passed',
+    'border-red': !poolSummary.archived && getPoolStatus(poolSummary) == 'failed',
+    'border-yellow': !poolSummary.archived && getPoolStatus(poolSummary) == 'unknown',
+    'border-gray': poolSummary.archived,
     'text-disabled': poolSummary.archived
   }"
   class="relative flex flex-col flex-auto p-6 pr-3 pb-3 bg-card rounded border-l-4 shadow-md overflow-hidden"

--- a/webapp/frontend/src/app/modules/dashboard/dashboard.component.html
+++ b/webapp/frontend/src/app/modules/dashboard/dashboard.component.html
@@ -109,7 +109,7 @@
                 );
                 track deviceSummary
               ) {
-                @if (showArchived || !$any(deviceSummary).device.archived) {
+                @if (showArchived ? $any(deviceSummary).device.archived : !$any(deviceSummary).device.archived) {
                   <app-dashboard-device
                     class="flex gt-sm:w-1/2 min-w-80 p-4"
                     [deviceSummary]="deviceSummary"

--- a/webapp/frontend/src/app/modules/zfs-pools/zfs-pools.component.html
+++ b/webapp/frontend/src/app/modules/zfs-pools/zfs-pools.component.html
@@ -56,7 +56,7 @@
 
             <div class="flex flex-wrap w-full">
               @for (poolSummary of poolSummariesForHostGroup(hostId.value); track poolSummary) {
-                @if (showArchived || !poolSummary.archived) {
+                @if (showArchived ? poolSummary.archived : !poolSummary.archived) {
                   <app-zfs-pool-card
                     class="flex gt-sm:w-1/2 min-w-80 p-4"
                     [poolSummary]="poolSummary"


### PR DESCRIPTION
## Summary

- **Archived toggle is now a true filter**: Toggle ON shows only archived items, toggle OFF shows only active items (previously ON showed everything mixed together)
- **Gray left border for archived cards**: Archived devices/pools get a neutral gray border instead of the green/red/yellow status border, making them visually distinct
- Applied consistently to both the device dashboard and ZFS pools dashboard

Closes #218

## Test plan

- [ ] Toggle OFF (default): only non-archived devices shown with green/red borders
- [ ] Toggle ON: only archived devices shown with gray borders and 0.8 opacity
- [ ] Archive a device: card disappears from default view, appears in archived view
- [ ] Unarchive a device: card disappears from archived view, returns to default view
- [ ] Verify same behavior on ZFS pools page
- [ ] Verify dark mode appearance