### PR TITLE
fix(smart): per-attribute devstat thresholds and blank raw_value display

### DIFF
--- a/webapp/backend/pkg/thresholds/ata_attribute_metadata.go
+++ b/webapp/backend/pkg/thresholds/ata_attribute_metadata.go
@@ -1692,6 +1692,7 @@ type AtaDeviceStatisticsMetadata struct {
 	Critical    bool   `json:"critical"`
 	Description string `json:"description"`
 	DisplayType string `json:"display_type"`
+	Threshold   int64  `json:"threshold"` // Fixed threshold for this attribute. 0 means no fixed threshold (use for error counts).
 }
 
 var AtaDeviceStatsMetadata = map[string]AtaDeviceStatisticsMetadata{
@@ -1702,6 +1703,7 @@ var AtaDeviceStatsMetadata = map[string]AtaDeviceStatisticsMetadata{
 		Critical:    true,
 		Description: "Contains a vendor specific estimate of the percentage of the device life used based on the actual device usage and the manufacturer's prediction of device life. A value of 100 indicates that the estimated endurance of the device has been consumed, but may not indicate a device failure.",
 		DisplayType: AtaSmartAttributeDisplayTypeRaw,
+		Threshold:   100,
 	},
 	// Page 1 (General Statistics)
 	"devstat_1_8": {

--- a/webapp/frontend/src/app/modules/detail/detail.component.html
+++ b/webapp/frontend/src/app/modules/detail/detail.component.html
@@ -534,7 +534,7 @@
                         <div class="flex-shrink-0 w-2 h-2 mr-3 rounded-full"></div>
                         <div class="truncate">Raw</div>
                       </div>
-                      <div class="w-1/4 items-center font-medium">{{attribute.raw_value}}</div>
+                      <div class="w-1/4 items-center font-medium">{{attribute.raw_value ?? attribute.value}}</div>
                       <div class="w-1/4 items-center text-secondary">--</div>
                       <div class="w-1/4 items-center text-secondary">--</div>
                     </div>


### PR DESCRIPTION
## Summary

- **Fixed incorrect FAILED status on error count devstat attributes** (Discussion #215). The hardcoded threshold of 100 was only appropriate for `devstat_7_8` (Percentage Used Endurance Indicator) but was applied to all critical devstat attributes. Error count attributes like `devstat_4_8` (Uncorrectable Errors) with value 452 were incorrectly marked as FAILED.
- **Introduced two-tier evaluation**: Tier 1 uses per-attribute metadata thresholds (only `devstat_7_8` has one at 100); Tier 2 warns on non-zero critical error counts without a fixed threshold. Warnings do NOT propagate to device-level failure.
- **Fixed blank raw_value in frontend expanded detail** for devstat attributes by adding `?? attribute.value` fallback.

## Changes

| File | Change |
|------|--------|
| `webapp/backend/pkg/thresholds/ata_attribute_metadata.go` | Added `Threshold` field to `AtaDeviceStatisticsMetadata`; set `Threshold: 100` for `devstat_7_8` |
| `webapp/backend/pkg/models/measurements/smart_ata_devstat_attribute.go` | Two-tier threshold logic replacing hardcoded default of 100 |
| `webapp/backend/pkg/models/measurements/smart_ata_devstat_attribute_test.go` | 6 new tests covering metadata threshold, error counts, and edge cases |
| `webapp/frontend/src/app/modules/detail/detail.component.html` | Added `?? attribute.value` fallback for raw_value display |

## Behavior Changes

| Scenario | Before | After |
|----------|--------|-------|
| `devstat_7_8` value=100 (percentage used) | FAIL | FAIL (unchanged, now via metadata threshold) |
| `devstat_4_8` value=452 (error count) | FAIL | WARN |
| `devstat_3_32` value=5 (reallocated sectors) | FAIL | WARN |
| `devstat_4_8` value=0 | PASS | PASS |
| Device with only devstat warnings | FAILED | NOT FAILED |
| Frontend expanded row for devstat | Blank raw value | Shows value |

## Test plan

- [x] All 78 backend tests pass (`go test ./...`)
- [x] Frontend builds cleanly (`npm run build:prod`)
- [ ] Manual verification with a drive reporting devstat_4_8 > 100

Closes #215