### PR TITLE
fix(zfs): address Reddit user feedback - scrub parsing, resolver errors, dark theme, vdev spacing

### DIFF
--- a/collector/pkg/zfs/detect/detect_test.go
+++ b/collector/pkg/zfs/detect/detect_test.go
@@ -1,0 +1,323 @@
+package detect
+
+import (
+	"testing"
+	"time"
+
+	"github.com/analogj/scrutiny/collector/pkg/zfs/models"
+	"github.com/sirupsen/logrus"
+)
+
+func newTestDetect() *Detect {
+	logger := logrus.New()
+	return &Detect{
+		Logger: logrus.NewEntry(logger),
+	}
+}
+
+// --- parseZFSBytes tests ---
+
+func TestParseZFSBytes(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected int64
+	}{
+		{"0B", 0},
+		{"0", 0},
+		{"", 0},
+		{"512B", 512},
+		{"1K", 1024},
+		{"1.5K", 1536},
+		{"2M", 2 * 1024 * 1024},
+		{"2.3M", 2411724},
+		{"1G", 1024 * 1024 * 1024},
+		{"1T", 1024 * 1024 * 1024 * 1024},
+		{"1P", 1024 * 1024 * 1024 * 1024 * 1024},
+		{"invalid", 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := parseZFSBytes(tt.input)
+			if result != tt.expected {
+				t.Errorf("parseZFSBytes(%q) = %d, want %d", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+// --- parseScrubStatus tests ---
+
+func TestParseScrubStatus_ScrubFinishedShortDuration(t *testing.T) {
+	d := newTestDetect()
+	pool := &models.ZFSPool{}
+
+	output := `  pool: tank
+ state: ONLINE
+  scan: scrub repaired 0B in 00:10:30 with 0 errors on Sun Jan  5 00:34:31 2026
+config:
+
+	NAME        STATE     READ WRITE CKSUM
+	tank        ONLINE       0     0     0
+`
+	d.parseScrubStatus(pool, output)
+
+	if pool.ScrubState != models.ZFSScrubStateFinished {
+		t.Errorf("expected ScrubState=finished, got %q", pool.ScrubState)
+	}
+	if pool.ScrubIssuedBytes != 0 {
+		t.Errorf("expected ScrubIssuedBytes=0, got %d", pool.ScrubIssuedBytes)
+	}
+	if pool.ScrubErrorsCount != 0 {
+		t.Errorf("expected ScrubErrorsCount=0, got %d", pool.ScrubErrorsCount)
+	}
+	if pool.ScrubPercentComplete != 100.0 {
+		t.Errorf("expected ScrubPercentComplete=100, got %f", pool.ScrubPercentComplete)
+	}
+	if pool.ScrubEndTime == nil {
+		t.Fatal("expected ScrubEndTime to be set")
+	}
+	expectedDate := time.Date(2026, time.January, 5, 0, 34, 31, 0, time.UTC)
+	if !pool.ScrubEndTime.Equal(expectedDate) {
+		t.Errorf("expected ScrubEndTime=%v, got %v", expectedDate, *pool.ScrubEndTime)
+	}
+}
+
+func TestParseScrubStatus_ScrubFinishedMultiDayDuration(t *testing.T) {
+	d := newTestDetect()
+	pool := &models.ZFSPool{}
+
+	output := `  pool: tank
+ state: ONLINE
+  scan: scrub repaired 0B in 1 days 00:12:08 with 0 errors on Mon Jan 12 00:36:38 2026
+config:
+
+	NAME        STATE     READ WRITE CKSUM
+	tank        ONLINE       0     0     0
+`
+	d.parseScrubStatus(pool, output)
+
+	if pool.ScrubState != models.ZFSScrubStateFinished {
+		t.Errorf("expected ScrubState=finished, got %q", pool.ScrubState)
+	}
+	if pool.ScrubErrorsCount != 0 {
+		t.Errorf("expected ScrubErrorsCount=0, got %d", pool.ScrubErrorsCount)
+	}
+	if pool.ScrubEndTime == nil {
+		t.Fatal("expected ScrubEndTime to be set")
+	}
+	expectedDate := time.Date(2026, time.January, 12, 0, 36, 38, 0, time.UTC)
+	if !pool.ScrubEndTime.Equal(expectedDate) {
+		t.Errorf("expected ScrubEndTime=%v, got %v", expectedDate, *pool.ScrubEndTime)
+	}
+}
+
+func TestParseScrubStatus_ScrubFinishedWithRepairs(t *testing.T) {
+	d := newTestDetect()
+	pool := &models.ZFSPool{}
+
+	output := `  pool: tank
+ state: ONLINE
+  scan: scrub repaired 1.5K in 00:10:30 with 2 errors on Sun Jan  5 00:34:31 2026
+config:
+
+	NAME        STATE     READ WRITE CKSUM
+	tank        ONLINE       0     0     0
+`
+	d.parseScrubStatus(pool, output)
+
+	if pool.ScrubState != models.ZFSScrubStateFinished {
+		t.Errorf("expected ScrubState=finished, got %q", pool.ScrubState)
+	}
+	if pool.ScrubIssuedBytes != 1536 {
+		t.Errorf("expected ScrubIssuedBytes=1536, got %d", pool.ScrubIssuedBytes)
+	}
+	if pool.ScrubErrorsCount != 2 {
+		t.Errorf("expected ScrubErrorsCount=2, got %d", pool.ScrubErrorsCount)
+	}
+}
+
+func TestParseScrubStatus_ScrubInProgress(t *testing.T) {
+	d := newTestDetect()
+	pool := &models.ZFSPool{}
+
+	output := `  pool: tank
+ state: ONLINE
+  scan: scrub in progress since Sun Jan  5 00:24:01 2026
+	tank        ONLINE       0     0     0
+	  mirror-0  ONLINE       0     0     0
+	42.5% done, 0 days 00:05:12 to go
+`
+	d.parseScrubStatus(pool, output)
+
+	if pool.ScrubState != models.ZFSScrubStateScanning {
+		t.Errorf("expected ScrubState=scanning, got %q", pool.ScrubState)
+	}
+	if pool.ScrubStartTime == nil {
+		t.Fatal("expected ScrubStartTime to be set")
+	}
+	if pool.ScrubPercentComplete != 42.5 {
+		t.Errorf("expected ScrubPercentComplete=42.5, got %f", pool.ScrubPercentComplete)
+	}
+}
+
+func TestParseScrubStatus_ScrubCanceled(t *testing.T) {
+	d := newTestDetect()
+	pool := &models.ZFSPool{}
+
+	output := `  pool: tank
+ state: ONLINE
+  scan: scrub canceled on Sun Jan  5 00:30:00 2026
+config:
+
+	NAME        STATE     READ WRITE CKSUM
+	tank        ONLINE       0     0     0
+`
+	d.parseScrubStatus(pool, output)
+
+	if pool.ScrubState != models.ZFSScrubStateCanceled {
+		t.Errorf("expected ScrubState=canceled, got %q", pool.ScrubState)
+	}
+	if pool.ScrubEndTime == nil {
+		t.Fatal("expected ScrubEndTime to be set")
+	}
+}
+
+func TestParseScrubStatus_NoneRequested(t *testing.T) {
+	d := newTestDetect()
+	pool := &models.ZFSPool{}
+
+	output := `  pool: tank
+ state: ONLINE
+  scan: none requested
+config:
+
+	NAME        STATE     READ WRITE CKSUM
+	tank        ONLINE       0     0     0
+`
+	d.parseScrubStatus(pool, output)
+
+	if pool.ScrubState != "" {
+		t.Errorf("expected ScrubState to be empty, got %q", pool.ScrubState)
+	}
+}
+
+func TestParseScrubStatus_ResilverFinished(t *testing.T) {
+	d := newTestDetect()
+	pool := &models.ZFSPool{}
+
+	output := `  pool: tank
+ state: ONLINE
+  scan: resilver repaired 1.5K in 00:05:30 with 0 errors on Tue Jan  6 12:00:00 2026
+config:
+
+	NAME        STATE     READ WRITE CKSUM
+	tank        ONLINE       0     0     0
+`
+	d.parseScrubStatus(pool, output)
+
+	if pool.ScrubState != models.ZFSScrubStateFinished {
+		t.Errorf("expected ScrubState=finished, got %q", pool.ScrubState)
+	}
+	if pool.ScrubIssuedBytes != 1536 {
+		t.Errorf("expected ScrubIssuedBytes=1536, got %d", pool.ScrubIssuedBytes)
+	}
+	if pool.ScrubEndTime == nil {
+		t.Fatal("expected ScrubEndTime to be set")
+	}
+}
+
+func TestParseScrubStatus_ResilverInProgress(t *testing.T) {
+	d := newTestDetect()
+	pool := &models.ZFSPool{}
+
+	output := `  pool: tank
+ state: DEGRADED
+  scan: resilver in progress since Tue Jan  6 11:54:30 2026
+	tank        DEGRADED     0     0     0
+	  mirror-0  DEGRADED     0     0     0
+	15.3% done, 0 days 00:02:45 to go
+`
+	d.parseScrubStatus(pool, output)
+
+	if pool.ScrubState != models.ZFSScrubStateScanning {
+		t.Errorf("expected ScrubState=scanning, got %q", pool.ScrubState)
+	}
+	if pool.ScrubStartTime == nil {
+		t.Fatal("expected ScrubStartTime to be set")
+	}
+	if pool.ScrubPercentComplete != 15.3 {
+		t.Errorf("expected ScrubPercentComplete=15.3, got %f", pool.ScrubPercentComplete)
+	}
+}
+
+func TestParseScrubStatus_ResilverCanceled(t *testing.T) {
+	d := newTestDetect()
+	pool := &models.ZFSPool{}
+
+	output := `  pool: tank
+ state: ONLINE
+  scan: resilver canceled on Tue Jan  6 12:30:00 2026
+config:
+
+	NAME        STATE     READ WRITE CKSUM
+	tank        ONLINE       0     0     0
+`
+	d.parseScrubStatus(pool, output)
+
+	if pool.ScrubState != models.ZFSScrubStateCanceled {
+		t.Errorf("expected ScrubState=canceled, got %q", pool.ScrubState)
+	}
+}
+
+// --- parseZFSDate tests ---
+
+func TestParseZFSDate(t *testing.T) {
+	d := newTestDetect()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected time.Time
+		wantErr  bool
+	}{
+		{
+			name:     "single digit day with double space",
+			input:    "Sun Jan  5 00:34:31 2026",
+			expected: time.Date(2026, time.January, 5, 0, 34, 31, 0, time.UTC),
+		},
+		{
+			name:     "double digit day",
+			input:    "Mon Jan 12 00:36:38 2026",
+			expected: time.Date(2026, time.January, 12, 0, 36, 38, 0, time.UTC),
+		},
+		{
+			name:     "different month",
+			input:    "Tue Feb 14 10:15:30 2026",
+			expected: time.Date(2026, time.February, 14, 10, 15, 30, 0, time.UTC),
+		},
+		{
+			name:    "invalid date",
+			input:   "not a date",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := d.parseZFSDate(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !result.Equal(tt.expected) {
+				t.Errorf("parseZFSDate(%q) = %v, want %v", tt.input, result, tt.expected)
+			}
+		})
+	}
+}

--- a/webapp/frontend/src/app/layout/common/zfs-pool-card/zfs-pool-card.component.html
+++ b/webapp/frontend/src/app/layout/common/zfs-pool-card/zfs-pool-card.component.html
@@ -12,19 +12,19 @@
   <div class="absolute bottom-0 right-0 w-24 h-24 -m-6">
     @if (getPoolStatus(poolSummary) == 'passed') {
       <mat-icon
-        class="icon-size-96 opacity-12 text-green"
+        class="icon-size-96 opacity-12 text-green-600 dark:text-green-400"
         [svgIcon]="'heroicons_outline:check-circle'"
       ></mat-icon>
     }
     @if (getPoolStatus(poolSummary) == 'failed') {
       <mat-icon
-        class="icon-size-96 opacity-12 text-red"
+        class="icon-size-96 opacity-12 text-red-600 dark:text-red-400"
         [svgIcon]="'heroicons_outline:exclamation-circle'"
       ></mat-icon>
     }
     @if (getPoolStatus(poolSummary) == 'unknown') {
       <mat-icon
-        class="icon-size-96 opacity-12 text-yellow"
+        class="icon-size-96 opacity-12 text-yellow-600 dark:text-yellow-400"
         [svgIcon]="'heroicons_outline:question-mark-circle'"
       ></mat-icon>
     }
@@ -176,6 +176,11 @@
       <div class="mt-2 font-medium text-3xl leading-none">
         {{ getScrubStatusText(poolSummary) }}
       </div>
+      @if (poolSummary.scrub_state === 'finished' && poolSummary.scrub_issued_bytes > 0) {
+        <div class="mt-1 text-xs text-yellow-600 dark:text-yellow-400">
+          {{ poolSummary.scrub_issued_bytes | fileSize:config?.file_size_si_units }} repaired
+        </div>
+      }
     </div>
 
     <!-- Errors -->
@@ -184,7 +189,7 @@
         <div class="font-semibold text-xs text-hint uppercase tracking-wider">
           Errors
         </div>
-        <div class="mt-2 font-medium text-3xl leading-none text-red">
+        <div class="mt-2 font-medium text-3xl leading-none text-red-600 dark:text-red-400">
           {{ getTotalErrors(poolSummary) }}
         </div>
       </div>

--- a/webapp/frontend/src/app/layout/common/zfs-pool-card/zfs-pool-card.component.ts
+++ b/webapp/frontend/src/app/layout/common/zfs-pool-card/zfs-pool-card.component.ts
@@ -52,14 +52,14 @@ export class ZFSPoolCardComponent implements OnInit {
     getStatusColorClass(status: ZFSPoolStatus): string {
         switch (status) {
             case 'ONLINE':
-                return 'text-green';
+                return 'text-green-600 dark:text-green-400';
             case 'DEGRADED':
-                return 'text-yellow';
+                return 'text-yellow-600 dark:text-yellow-400';
             case 'FAULTED':
             case 'UNAVAIL':
             case 'OFFLINE':
             case 'REMOVED':
-                return 'text-red';
+                return 'text-red-600 dark:text-red-400';
             default:
                 return '';
         }
@@ -68,14 +68,14 @@ export class ZFSPoolCardComponent implements OnInit {
     classPoolLastUpdatedOn(pool: ZFSPoolModel): string {
         const poolStatus = this.getPoolStatus(pool);
         if (poolStatus === 'failed') {
-            return 'text-red';
+            return 'text-red-600 dark:text-red-400';
         } else if (poolStatus === 'passed') {
             if (dayjs().subtract(14, 'day').isBefore(dayjs(pool.updated_at))) {
-                return 'text-green';
+                return 'text-green-600 dark:text-green-400';
             } else if (dayjs().subtract(1, 'month').isBefore(dayjs(pool.updated_at))) {
-                return 'text-yellow';
+                return 'text-yellow-600 dark:text-yellow-400';
             } else {
-                return 'text-red';
+                return 'text-red-600 dark:text-red-400';
             }
         } else {
             return '';
@@ -105,8 +105,13 @@ export class ZFSPoolCardComponent implements OnInit {
                 return 'Never';
             case 'scanning':
                 return `In Progress (${pool.scrub_percent_complete}%)`;
-            case 'finished':
-                return dayjs(pool.scrub_end_time).fromNow();
+            case 'finished': {
+                const timeAgo = dayjs(pool.scrub_end_time).fromNow();
+                if (pool.scrub_issued_bytes > 0) {
+                    return `${timeAgo} (repaired)`;
+                }
+                return timeAgo;
+            }
             case 'canceled':
                 return 'Canceled';
             default:

--- a/webapp/frontend/src/app/modules/detail/detail.resolvers.ts
+++ b/webapp/frontend/src/app/modules/detail/detail.resolvers.ts
@@ -1,6 +1,7 @@
 import {Injectable} from '@angular/core';
-import { ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
-import {Observable} from 'rxjs';
+import { ActivatedRouteSnapshot, Router, RouterStateSnapshot } from '@angular/router';
+import {Observable, of} from 'rxjs';
+import {catchError} from 'rxjs/operators';
 import {DetailService} from 'app/modules/detail/detail.service';
 import {DeviceDetailsResponseWrapper} from 'app/core/models/device-details-response-wrapper';
 
@@ -8,13 +9,9 @@ import {DeviceDetailsResponseWrapper} from 'app/core/models/device-details-respo
     providedIn: 'root'
 })
 export class DetailResolver  {
-    /**
-     * Constructor
-     *
-     * @param {FinanceService} _detailService
-     */
     constructor(
-        private _detailService: DetailService
+        private _detailService: DetailService,
+        private _router: Router
     )
     {
     }
@@ -23,13 +20,13 @@ export class DetailResolver  {
     // @ Public methods
     // -----------------------------------------------------------------------------------------------------
 
-    /**
-     * Resolver
-     *
-     * @param route
-     * @param state
-     */
     resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<DeviceDetailsResponseWrapper> {
-        return this._detailService.getData(route.params.wwn);
+        return this._detailService.getData(route.params.wwn).pipe(
+            catchError((error) => {
+                console.error('Failed to load device details:', error);
+                this._router.navigate(['/']);
+                return of(null);
+            })
+        );
     }
 }

--- a/webapp/frontend/src/app/modules/zfs-pool-detail/zfs-pool-detail.component.html
+++ b/webapp/frontend/src/app/modules/zfs-pool-detail/zfs-pool-detail.component.html
@@ -75,18 +75,23 @@
             <div class="font-bold text-3xl text-hint">Never</div>
           }
           @case ('scanning') {
-            <div class="font-bold text-3xl text-yellow">In Progress</div>
+            <div class="font-bold text-3xl text-yellow-600 dark:text-yellow-400">In Progress</div>
             <div class="text-sm text-hint mt-2">{{ pool.scrub_percent_complete }}% complete</div>
           }
           @case ('finished') {
-            <div class="font-bold text-3xl text-green">Completed</div>
+            <div class="font-bold text-3xl text-green-600 dark:text-green-400">Completed</div>
             <div class="text-sm text-hint mt-2">{{ pool.scrub_end_time | date:'MMM dd, yyyy HH:mm' }}</div>
             @if (pool.scrub_errors_count > 0) {
-              <div class="text-sm text-red mt-1">{{ pool.scrub_errors_count }} errors found</div>
+              <div class="text-sm text-red-600 dark:text-red-400 mt-1">{{ pool.scrub_errors_count }} errors found</div>
+            }
+            @if (pool.scrub_issued_bytes > 0) {
+              <div class="text-sm text-yellow-600 dark:text-yellow-400 mt-1">
+                {{ pool.scrub_issued_bytes | fileSize:config?.file_size_si_units }} repaired
+              </div>
             }
           }
           @case ('canceled') {
-            <div class="font-bold text-3xl text-yellow">Canceled</div>
+            <div class="font-bold text-3xl text-yellow-600 dark:text-yellow-400">Canceled</div>
           }
         }
       </treo-card>
@@ -95,19 +100,19 @@
     <!-- Error Summary -->
     @if (pool.total_read_errors > 0 || pool.total_write_errors > 0 || pool.total_checksum_errors > 0) {
       <treo-card class="p-6 mb-8">
-        <div class="font-semibold text-lg text-red mb-4">Error Summary</div>
+        <div class="font-semibold text-lg text-red-600 dark:text-red-400 mb-4">Error Summary</div>
         <div class="grid grid-cols-3 gap-4">
           <div>
             <div class="font-semibold text-xs text-hint uppercase tracking-wider">Read Errors</div>
-            <div class="font-bold text-2xl text-red">{{ pool.total_read_errors }}</div>
+            <div class="font-bold text-2xl text-red-600 dark:text-red-400">{{ pool.total_read_errors }}</div>
           </div>
           <div>
             <div class="font-semibold text-xs text-hint uppercase tracking-wider">Write Errors</div>
-            <div class="font-bold text-2xl text-red">{{ pool.total_write_errors }}</div>
+            <div class="font-bold text-2xl text-red-600 dark:text-red-400">{{ pool.total_write_errors }}</div>
           </div>
           <div>
             <div class="font-semibold text-xs text-hint uppercase tracking-wider">Checksum Errors</div>
-            <div class="font-bold text-2xl text-red">{{ pool.total_checksum_errors }}</div>
+            <div class="font-bold text-2xl text-red-600 dark:text-red-400">{{ pool.total_checksum_errors }}</div>
           </div>
         </div>
       </treo-card>
@@ -118,7 +123,10 @@
       <div class="font-semibold text-lg mb-4">Virtual Device Tree</div>
       @if (pool.vdevs && pool.vdevs.length > 0) {
         <div class="vdev-tree">
-          @for (vdev of pool.vdevs; track vdev.id) {
+          @for (vdev of pool.vdevs; track vdev.id; let i = $index) {
+            @if (i > 0) {
+              <mat-divider class="my-2"></mat-divider>
+            }
             <ng-container *ngTemplateOutlet="vdevNode; context: { vdev: vdev, depth: 0 }"></ng-container>
           }
         </div>
@@ -156,8 +164,8 @@
 <!-- Vdev Node Template -->
 <ng-template #vdevNode let-vdev="vdev" let-depth="depth">
   <div
-    class="vdev-item flex items-center py-2 px-4 rounded hover:bg-hover"
-    [style.padding-left.px]="depth * 24 + 16">
+    class="vdev-item flex items-center py-3 px-4 rounded hover:bg-hover"
+    [style.padding-left.px]="depth * 32 + 16">
     <mat-icon
       class="icon-size-20 mr-3"
       [svgIcon]="getVdevIcon(vdev.type)">
@@ -176,7 +184,7 @@
         <div class="text-xs text-hint">{{ vdev.path }}</div>
       }
       @if (hasErrors(vdev)) {
-        <div class="text-xs text-red mt-1">
+        <div class="text-xs text-red-600 dark:text-red-400 mt-1">
           R: {{ vdev.read_errors }} / W: {{ vdev.write_errors }} / C: {{ vdev.checksum_errors }}
         </div>
       }

--- a/webapp/frontend/src/app/modules/zfs-pool-detail/zfs-pool-detail.component.scss
+++ b/webapp/frontend/src/app/modules/zfs-pool-detail/zfs-pool-detail.component.scss
@@ -10,5 +10,10 @@
                 border-left-color: var(--primary-color, #667eea);
             }
         }
+
+        mat-divider {
+            margin-left: 16px;
+            margin-right: 16px;
+        }
     }
 }

--- a/webapp/frontend/src/app/modules/zfs-pool-detail/zfs-pool-detail.component.ts
+++ b/webapp/frontend/src/app/modules/zfs-pool-detail/zfs-pool-detail.component.ts
@@ -1,5 +1,6 @@
 import {
     ChangeDetectionStrategy,
+    ChangeDetectorRef,
     Component,
     OnDestroy,
     OnInit,
@@ -34,6 +35,7 @@ export class ZFSPoolDetailComponent implements OnInit, OnDestroy {
     constructor(
         private _zfsPoolDetailService: ZFSPoolDetailService,
         private _configService: ScrutinyConfigService,
+        private _changeDetectorRef: ChangeDetectorRef,
         private router: Router,
     ) {
         this._unsubscribeAll = new Subject();
@@ -45,6 +47,7 @@ export class ZFSPoolDetailComponent implements OnInit, OnDestroy {
             .pipe(takeUntil(this._unsubscribeAll))
             .subscribe((config: AppConfig) => {
                 this.config = config;
+                this._changeDetectorRef.markForCheck();
             });
 
         // Get the data
@@ -55,6 +58,7 @@ export class ZFSPoolDetailComponent implements OnInit, OnDestroy {
                     this.pool = data.data.pool;
                     this.metricsHistory = data.data.metrics_history;
                     this._prepareChartData();
+                    this._changeDetectorRef.markForCheck();
                 }
             });
     }
@@ -145,14 +149,14 @@ export class ZFSPoolDetailComponent implements OnInit, OnDestroy {
     getStatusColorClass(status: ZFSPoolStatus): string {
         switch (status) {
             case 'ONLINE':
-                return 'text-green';
+                return 'text-green-600 dark:text-green-400';
             case 'DEGRADED':
-                return 'text-yellow';
+                return 'text-yellow-600 dark:text-yellow-400';
             case 'FAULTED':
             case 'UNAVAIL':
             case 'OFFLINE':
             case 'REMOVED':
-                return 'text-red';
+                return 'text-red-600 dark:text-red-400';
             default:
                 return '';
         }
@@ -183,14 +187,14 @@ export class ZFSPoolDetailComponent implements OnInit, OnDestroy {
     getVdevStatusClass(status: string): string {
         switch (status) {
             case 'ONLINE':
-                return 'text-green';
+                return 'text-green-600 dark:text-green-400';
             case 'DEGRADED':
-                return 'text-yellow';
+                return 'text-yellow-600 dark:text-yellow-400';
             case 'FAULTED':
             case 'UNAVAIL':
             case 'OFFLINE':
             case 'REMOVED':
-                return 'text-red';
+                return 'text-red-600 dark:text-red-400';
             default:
                 return '';
         }

--- a/webapp/frontend/src/app/modules/zfs-pool-detail/zfs-pool-detail.resolvers.ts
+++ b/webapp/frontend/src/app/modules/zfs-pool-detail/zfs-pool-detail.resolvers.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
-import { ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
-import { Observable } from 'rxjs';
+import { ActivatedRouteSnapshot, Router, RouterStateSnapshot } from '@angular/router';
+import { Observable, of } from 'rxjs';
+import { catchError } from 'rxjs/operators';
 import { ZFSPoolDetailService } from 'app/modules/zfs-pool-detail/zfs-pool-detail.service';
 import { ZFSPoolDetailsResponseWrapper } from 'app/core/models/zfs-pool-summary-model';
 
@@ -9,11 +10,18 @@ import { ZFSPoolDetailsResponseWrapper } from 'app/core/models/zfs-pool-summary-
 })
 export class ZFSPoolDetailResolver {
     constructor(
-        private _zfsPoolDetailService: ZFSPoolDetailService
+        private _zfsPoolDetailService: ZFSPoolDetailService,
+        private _router: Router
     ) {
     }
 
     resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<ZFSPoolDetailsResponseWrapper> {
-        return this._zfsPoolDetailService.getData(route.params.guid);
+        return this._zfsPoolDetailService.getData(route.params.guid).pipe(
+            catchError((error) => {
+                console.error('Failed to load ZFS pool details:', error);
+                this._router.navigate(['/zfs-pools']);
+                return of(null);
+            })
+        );
     }
 }


### PR DESCRIPTION
## Summary

- **Bug 1**: Fix ZFS scrub regex to handle multi-day durations (`1 days 00:12:08`) and add resilver operation support via `(?:scrub|resilver)` alternation
- **Bug 2**: Add `catchError` to device detail and ZFS pool detail route resolvers to prevent silent navigation failures on API errors
- **Bug 3**: Fix ZFS pool capacity chart not rendering by injecting `ChangeDetectorRef` and calling `markForCheck()` in the OnPush component
- **UI Fix 1**: Replace bare `text-red`/`text-green`/`text-yellow` with `dark:` Tailwind variants for readable colors on dark theme
- **UI Fix 2**: Add `mat-divider` separators between vdev groups and increase padding/indentation in the vdev tree
- **Feature**: Populate `ScrubIssuedBytes` from scrub output via new `parseZFSBytes()` helper and display repair indicator in pool card and detail views

## Test plan

- [x] 16 new Go unit tests for `parseZFSBytes`, `parseScrubStatus` (scrub + resilver variants), and `parseZFSDate`
- [x] Go build passes (detect, web server, collector)
- [x] Angular production build succeeds
- [ ] Manual: navigate to device with bad WWN -> redirects to dashboard
- [ ] Manual: load ZFS pool detail -> capacity chart renders
- [ ] Manual: toggle dark theme -> red/green/yellow text readable
- [ ] Manual: verify vdev tree dividers and spacing with multiple vdev groups
- [ ] Manual: verify scrub repair indicator when `scrub_issued_bytes > 0`

Closes #212