### PR TITLE
fix(settings): apply defaults for empty DB values to prevent blank UI

### DIFF
--- a/webapp/backend/pkg/database/scrutiny_repository_settings.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_settings.go
@@ -44,6 +44,11 @@ func (sr *scrutinyRepository) LoadSettings(ctx context.Context) (*models.Setting
 	if err != nil {
 		return nil, err
 	}
+
+	// Fill in any missing or empty settings with known-good defaults.
+	// This handles DB entries with empty string values and missing entries alike.
+	settings.ApplyDefaults()
+
 	return &settings, nil
 }
 

--- a/webapp/backend/pkg/models/settings.go
+++ b/webapp/backend/pkg/models/settings.go
@@ -50,3 +50,48 @@ type Settings struct {
 		ReportPDFPath        string `json:"report_pdf_path" mapstructure:"report_pdf_path"`
 	} `json:"metrics" mapstructure:"metrics"`
 }
+
+// defaultStr sets *p to def if *p is empty.
+func defaultStr(p *string, def string) {
+	if *p == "" {
+		*p = def
+	}
+}
+
+// defaultInt sets *p to def if *p is zero.
+func defaultInt(p *int, def int) {
+	if *p == 0 {
+		*p = def
+	}
+}
+
+// ApplyDefaults fills in zero-value fields with known-good defaults.
+// This prevents the API from returning empty strings that break the frontend
+// (e.g. theme="" produces invalid CSS class "treo-theme-", layout="" matches
+// no template case). Called after loading settings from the database.
+func (s *Settings) ApplyDefaults() {
+	// Top-level string settings
+	defaultStr(&s.Theme, "system")
+	defaultStr(&s.Layout, "material")
+	defaultStr(&s.DashboardDisplay, "name")
+	defaultStr(&s.DashboardSort, "status")
+	defaultStr(&s.TemperatureUnit, "celsius")
+	defaultStr(&s.LineStroke, "smooth")
+	defaultStr(&s.PoweredOnHoursUnit, "humanize")
+
+	// Metrics: numeric fields where 0 is not a valid value.
+	// Note: StatusFilterAttributes defaults to 0 (All), which is the zero value, so no check needed.
+	defaultInt(&s.Metrics.NotifyLevel, 2)            // MetricsNotifyLevelFail
+	defaultInt(&s.Metrics.StatusThreshold, 3)         // MetricsStatusThresholdBoth
+	defaultInt(&s.Metrics.MissedPingTimeoutMinutes, 60)
+	defaultInt(&s.Metrics.MissedPingCheckIntervalMins, 5)
+	defaultInt(&s.Metrics.HeartbeatIntervalHours, 24)
+
+	// Metrics: scheduled report defaults
+	defaultStr(&s.Metrics.ReportDailyTime, "08:00")
+	defaultInt(&s.Metrics.ReportWeeklyDay, 1)  // Monday
+	defaultStr(&s.Metrics.ReportWeeklyTime, "08:00")
+	defaultInt(&s.Metrics.ReportMonthlyDay, 1) // 1st of the month
+	defaultStr(&s.Metrics.ReportMonthlyTime, "08:00")
+	defaultStr(&s.Metrics.ReportPDFPath, "/opt/scrutiny/reports")
+}

--- a/webapp/backend/pkg/models/settings_test.go
+++ b/webapp/backend/pkg/models/settings_test.go
@@ -1,0 +1,111 @@
+package models
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplyDefaults_AllZeroValues(t *testing.T) {
+	s := Settings{}
+	s.ApplyDefaults()
+
+	// Top-level string settings
+	require.Equal(t, "system", s.Theme)
+	require.Equal(t, "material", s.Layout)
+	require.Equal(t, "name", s.DashboardDisplay)
+	require.Equal(t, "status", s.DashboardSort)
+	require.Equal(t, "celsius", s.TemperatureUnit)
+	require.Equal(t, "smooth", s.LineStroke)
+	require.Equal(t, "humanize", s.PoweredOnHoursUnit)
+
+	// Metrics numeric defaults
+	require.Equal(t, 2, s.Metrics.NotifyLevel)
+	require.Equal(t, 0, s.Metrics.StatusFilterAttributes) // 0 = All, valid default
+	require.Equal(t, 3, s.Metrics.StatusThreshold)
+	require.Equal(t, 60, s.Metrics.MissedPingTimeoutMinutes)
+	require.Equal(t, 5, s.Metrics.MissedPingCheckIntervalMins)
+	require.Equal(t, 24, s.Metrics.HeartbeatIntervalHours)
+
+	// Metrics scheduled report defaults
+	require.Equal(t, "08:00", s.Metrics.ReportDailyTime)
+	require.Equal(t, 1, s.Metrics.ReportWeeklyDay)
+	require.Equal(t, "08:00", s.Metrics.ReportWeeklyTime)
+	require.Equal(t, 1, s.Metrics.ReportMonthlyDay)
+	require.Equal(t, "08:00", s.Metrics.ReportMonthlyTime)
+	require.Equal(t, "/opt/scrutiny/reports", s.Metrics.ReportPDFPath)
+
+	// Bool fields should remain false (valid default)
+	require.False(t, s.FileSizeSIUnits)
+	require.False(t, s.Collector.RetrieveSCTHistory)
+	require.False(t, s.Metrics.RepeatNotifications)
+	require.False(t, s.Metrics.NotifyOnMissedPing)
+	require.False(t, s.Metrics.HeartbeatEnabled)
+	require.False(t, s.Metrics.ReportEnabled)
+	require.False(t, s.Metrics.ReportDailyEnabled)
+	require.False(t, s.Metrics.ReportWeeklyEnabled)
+	require.False(t, s.Metrics.ReportMonthlyEnabled)
+	require.False(t, s.Metrics.ReportPDFEnabled)
+}
+
+func TestApplyDefaults_PreservesExistingValues(t *testing.T) {
+	s := Settings{
+		Theme:              "dark",
+		Layout:             "empty",
+		DashboardDisplay:   "serial_id",
+		DashboardSort:      "title",
+		TemperatureUnit:    "fahrenheit",
+		LineStroke:         "straight",
+		PoweredOnHoursUnit: "device_hours",
+	}
+	s.Metrics.NotifyLevel = 1
+	s.Metrics.StatusThreshold = 1
+	s.Metrics.MissedPingTimeoutMinutes = 30
+	s.Metrics.MissedPingCheckIntervalMins = 10
+	s.Metrics.HeartbeatIntervalHours = 12
+	s.Metrics.ReportDailyTime = "03:00"
+	s.Metrics.ReportWeeklyDay = 5
+	s.Metrics.ReportWeeklyTime = "09:00"
+	s.Metrics.ReportMonthlyDay = 15
+	s.Metrics.ReportMonthlyTime = "10:00"
+	s.Metrics.ReportPDFPath = "/custom/path"
+
+	s.ApplyDefaults()
+
+	// All user-set values preserved
+	require.Equal(t, "dark", s.Theme)
+	require.Equal(t, "empty", s.Layout)
+	require.Equal(t, "serial_id", s.DashboardDisplay)
+	require.Equal(t, "title", s.DashboardSort)
+	require.Equal(t, "fahrenheit", s.TemperatureUnit)
+	require.Equal(t, "straight", s.LineStroke)
+	require.Equal(t, "device_hours", s.PoweredOnHoursUnit)
+	require.Equal(t, 1, s.Metrics.NotifyLevel)
+	require.Equal(t, 1, s.Metrics.StatusThreshold)
+	require.Equal(t, 30, s.Metrics.MissedPingTimeoutMinutes)
+	require.Equal(t, 10, s.Metrics.MissedPingCheckIntervalMins)
+	require.Equal(t, 12, s.Metrics.HeartbeatIntervalHours)
+	require.Equal(t, "03:00", s.Metrics.ReportDailyTime)
+	require.Equal(t, 5, s.Metrics.ReportWeeklyDay)
+	require.Equal(t, "09:00", s.Metrics.ReportWeeklyTime)
+	require.Equal(t, 15, s.Metrics.ReportMonthlyDay)
+	require.Equal(t, "10:00", s.Metrics.ReportMonthlyTime)
+	require.Equal(t, "/custom/path", s.Metrics.ReportPDFPath)
+}
+
+func TestApplyDefaults_PartiallyPopulated(t *testing.T) {
+	s := Settings{
+		Theme:  "dark",
+		Layout: "", // empty - should get defaulted
+	}
+	s.Metrics.NotifyLevel = 1 // set
+	// StatusThreshold left at 0 - should get defaulted
+
+	s.ApplyDefaults()
+
+	require.Equal(t, "dark", s.Theme)              // preserved
+	require.Equal(t, "material", s.Layout)          // defaulted
+	require.Equal(t, "name", s.DashboardDisplay)    // defaulted
+	require.Equal(t, 1, s.Metrics.NotifyLevel)      // preserved
+	require.Equal(t, 3, s.Metrics.StatusThreshold)  // defaulted
+}


### PR DESCRIPTION
## Summary

- When the database has empty string values for settings (e.g. `theme=""`, `layout=""`), the backend returned them as-is and the frontend used them directly, producing a blank white page
- Root cause: `treo-theme-` (empty suffix) matches no CSS rules; `layout=""` matches neither `@if (layout === 'empty')` nor `@if (layout === 'material')` in the template
- Also broke the corruption cycle where saving any single setting would overwrite all DB rows with empty values
- **Backend**: Added `ApplyDefaults()` method to `Settings` model, called in `LoadSettings()` after unmarshal. Replaces empty strings and zero-value ints with known-good defaults matching the DB migration seeds
- **Frontend**: Added `_mergeWithDefaults()` to `ScrutinyConfigService` that deep-merges API settings over local defaults, treating `""`, `null`, and `undefined` as "missing"

## Test plan

- [x] `go test ./webapp/backend/pkg/models/...` passes (3 new tests: all-zero, preserves-existing, partially-populated)
- [ ] Rebuild dev container on Zeus and verify dashboard renders without manual settings save
- [ ] Verify prod still works with existing saved settings (no overrides)