### PR TITLE
Add spacing between host-id groups on dashboard

### DIFF
--- a/webapp/frontend/src/app/modules/dashboard/dashboard.component.html
+++ b/webapp/frontend/src/app/modules/dashboard/dashboard.component.html
@@ -81,7 +81,7 @@
 
         <!-- Device Groups -->
         @for (hostId of hostGroups | keyvalue; track hostId) {
-          <div class="flex flex-wrap w-full">
+          <div class="flex flex-wrap w-full mb-6">
             @if (hostId.key) {
               <div class="flex items-center ml-4 gap-3">
                 <h3 class="m-0">{{ hostId.key }}</h3>


### PR DESCRIPTION
## Summary
- Adds vertical spacing (`mb-6` / 1.5rem) between host-id group blocks on the dashboard so groups are visually separated

Closes #234

## Test plan
- [ ] Build frontend successfully
- [ ] Visually confirm spacing between host-id groups with multiple hosts
- [ ] Verify single-host setups still look correct