### PR TITLE
Update ZFS monitoring instructions in documentation

### DIFF
--- a/docs/ZFS_POOL_MONITORING.md
+++ b/docs/ZFS_POOL_MONITORING.md
@@ -16,7 +16,7 @@ Scrutiny can monitor ZFS pool health alongside individual drive S.M.A.R.T metric
 
 ### Omnibus Image
 
-If you are using the omnibus image (`ghcr.io/starosdev/scrutiny:latest-omnibus`), add these environment variables to enable ZFS monitoring, and /dev/zfs to the disks:
+If you are using the omnibus image (`ghcr.io/starosdev/scrutiny:latest-omnibus`), add these environment variables and device mappings to enable ZFS monitoring:
 
 ```yaml
 version: '3.5'
@@ -30,7 +30,7 @@ services:
       COLLECTOR_ZFS_RUN_STARTUP: "true"
     devices:
       - /dev/sda:/dev/sda
-      - #rest of your disks
+      # ...rest of your disks
       - /dev/zfs:/dev/zfs
     # ... rest of your config
 ```
@@ -39,7 +39,7 @@ The ZFS collector binary and `zfsutils-linux` are already included in the omnibu
 
 ### Hub/Spoke Deployment
 
-For hub/spoke deployments, run the ZFS collector container on each host with ZFS pools:
+For hub/spoke deployments, run the ZFS collector container on each host with ZFS pools, and make sure to include the appropriate device mapping:
 
 ```yaml
 version: '2.4'
@@ -54,6 +54,8 @@ services:
       COLLECTOR_ZFS_API_ENDPOINT: 'http://web:8080'
       COLLECTOR_ZFS_HOST_ID: 'my-zfs-server'
       COLLECTOR_ZFS_RUN_STARTUP: 'true'
+    devices:
+      - /dev/zfs:/dev/zfs
     depends_on:
       web:
         condition: service_healthy


### PR DESCRIPTION
Added /dev/zfs to the disks configuration for ZFS monitoring in the omnibus image section.

## Summary

<!-- Brief description of what this PR does -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

N/A

## Changes Made

<!-- List the specific changes made in this PR -->

- updated the documentation to reflect that the /dev/zfs device needs to be present in device mappings
-
-

## Testing

ran through the existing documentation, and ran into this error:

docker exec scrutiny zpool list
/dev/zfs and /proc/self/mounts are required.

mounted the /dev/zfs device to the container, and noted that it was able to pick up my zfs pool afterwards

- [X] I have tested this locally
- [X] I have added/updated tests that prove my fix/feature works
- [X] All existing tests pass

## Checklist

- [ ] My code follows the project's code style
- [ ] I have performed a self-review of my code
- [ ] I have commented my code where necessary (particularly complex areas)
- [X] I have updated the documentation if needed
- [ ] My changes generate no new warnings
- [ ] No console.log, debug statements, or commented-out code

## Screenshots (if applicable)

N/A

## Additional Notes
N/A
