### PR TITLE
fix(web): add retry logic for database init to prevent Docker crash-loops

### DIFF
--- a/webapp/backend/pkg/database/scrutiny_repository.go
+++ b/webapp/backend/pkg/database/scrutiny_repository.go
@@ -319,7 +319,10 @@ func InfluxSetupComplete(influxEndpoint string, tlsConfig *tls.Config) (bool, er
 		return false, err
 	}
 
-    client := &http.Client{Transport: &http.Transport{TLSClientConfig: tlsConfig}}
+	client := &http.Client{
+		Transport: &http.Transport{TLSClientConfig: tlsConfig},
+		Timeout:   10 * time.Second,
+	}
 	res, err := client.Get(influxUri.String())
 	if err != nil {
 		return false, err


### PR DESCRIPTION
## Summary

- Replaces `panic()` in `RepositoryMiddleware` with a retry loop (30 attempts, 10s intervals = 5 min max) so the `-web` Docker image waits for InfluxDB to become available instead of crash-looping
- Adds 10-second HTTP client timeout to `InfluxSetupComplete()` to fail fast instead of hanging indefinitely
- Replaces remaining `panic()` with `log.Fatal` for clear diagnostic messages in `docker logs`

**Root cause:** The `-web` image starts `scrutiny start` directly with no InfluxDB readiness check. The omnibus image uses s6-overlay with a curl wait-loop, but the web image had nothing. When InfluxDB wasn't ready, `NewScrutinyRepository()` failed, `RepositoryMiddleware` called `panic()` during server `Setup()` (before Gin starts serving, so `gin.Recovery()` couldn't catch it), and the container crashed.

## Test plan

- [x] `go build ./webapp/backend/cmd/scrutiny/` passes
- [x] `go build ./collector/cmd/collector-metrics/` passes
- [x] `go build ./collector/cmd/collector-performance/` passes
- [x] `go vet` clean (pre-existing migration warnings only)
- [ ] Start web binary without InfluxDB running -- confirm retry log messages instead of panic stack trace
- [ ] Start web binary with InfluxDB running -- confirm normal startup

Closes #258