### PR TITLE
fix(docker): update Makefile tags and docs to reference Starosdev/scrutiny

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,29 +150,29 @@ binary-frontend-test-coverage:
 ########################################################################################################################
 # Docker
 # NOTE: these docker make targets are only used for local development (not used by Github Actions/CI)
-# NOTE: docker-web and docker-omnibus require `make binary-frontend` or frontend.tar.gz content in /dist before executing.
+# NOTE: docker-web and docker-omnibus build the frontend internally via multi-stage Docker builds.
 ########################################################################################################################
 .PHONY: docker-collector
 docker-collector:
 	@echo "building collector docker image"
-	docker build $(DOCKER_TARGETARCH_BUILD_ARG) -f docker/Dockerfile.collector -t analogj/scrutiny-dev:collector .
+	docker build $(DOCKER_TARGETARCH_BUILD_ARG) -f docker/Dockerfile.collector -t ghcr.io/starosdev/scrutiny-dev:collector .
 
 .PHONY: docker-collector-zfs
 docker-collector-zfs:
 	@echo "building ZFS collector docker image"
-	docker build $(DOCKER_TARGETARCH_BUILD_ARG) -f docker/Dockerfile.collector-zfs -t analogj/scrutiny-dev:collector-zfs .
+	docker build $(DOCKER_TARGETARCH_BUILD_ARG) -f docker/Dockerfile.collector-zfs -t ghcr.io/starosdev/scrutiny-dev:collector-zfs .
 
 .PHONY: docker-collector-performance
 docker-collector-performance:
 	@echo "building performance collector docker image"
-	docker build $(DOCKER_TARGETARCH_BUILD_ARG) -f docker/Dockerfile.collector-performance -t analogj/scrutiny-dev:collector-performance .
+	docker build $(DOCKER_TARGETARCH_BUILD_ARG) -f docker/Dockerfile.collector-performance -t ghcr.io/starosdev/scrutiny-dev:collector-performance .
 
 .PHONY: docker-web
 docker-web:
 	@echo "building web docker image"
-	docker build $(DOCKER_TARGETARCH_BUILD_ARG) -f docker/Dockerfile.web -t analogj/scrutiny-dev:web .
+	docker build $(DOCKER_TARGETARCH_BUILD_ARG) -f docker/Dockerfile.web -t ghcr.io/starosdev/scrutiny-dev:web .
 
 .PHONY: docker-omnibus
 docker-omnibus:
 	@echo "building omnibus docker image"
-	docker build $(DOCKER_TARGETARCH_BUILD_ARG) -f docker/Dockerfile -t analogj/scrutiny-dev:omnibus .
+	docker build $(DOCKER_TARGETARCH_BUILD_ARG) -f docker/Dockerfile -t ghcr.io/starosdev/scrutiny-dev:omnibus .

--- a/docs/INSTALL_HUB_SPOKE.md
+++ b/docs/INSTALL_HUB_SPOKE.md
@@ -126,7 +126,7 @@ chmod +x /opt/scrutiny/bin/scrutiny-collector-metrics-linux-amd64 && \
 ls -lha /opt/scrutiny/bin
 ```
 
-<p class="callout warning">When downloading Github Release Assests, make sure that you have the correct version. The provided example is with Release v0.5.0. [The release list can be found here.](https://github.com/analogj/scrutiny/releases) </p>
+<p class="callout warning">When downloading Github Release Assests, make sure that you have the correct version. The provided example is with Release v0.5.0. [The release list can be found here.](https://github.com/Starosdev/scrutiny/releases) </p>
 
 Once the Collector is installed, you can run it with the following command. Make sure to add the correct address and
 port of your Hub as `--api-endpoint`.

--- a/docs/INSTALL_MANUAL.md
+++ b/docs/INSTALL_MANUAL.md
@@ -68,7 +68,7 @@ web:
 
 ### Download Files
 
-Next, we'll download the Scrutiny API binary and frontend files from the [latest Github release](https://github.com/analogj/scrutiny/releases).
+Next, we'll download the Scrutiny API binary and frontend files from the [latest Github release](https://github.com/Starosdev/scrutiny/releases).
 The files you need to download are named:
 
 - **scrutiny-web-linux-amd64** - save this file to `/opt/scrutiny/bin`
@@ -133,7 +133,7 @@ mkdir -p /opt/scrutiny/bin
 
 ### Download Files
 
-Next, we'll download the Scrutiny collector binary from the [latest Github release](https://github.com/analogj/scrutiny/releases).
+Next, we'll download the Scrutiny collector binary from the [latest Github release](https://github.com/Starosdev/scrutiny/releases).
 The file you need to download is named:
 
 - **scrutiny-collector-metrics-linux-amd64** - save this file to `/opt/scrutiny/bin`

--- a/docs/INSTALL_PFSENSE.md
+++ b/docs/INSTALL_PFSENSE.md
@@ -25,7 +25,7 @@ mkdir -p /opt/scrutiny/bin
 
 ### Download Files
 
-Next, we'll download the Scrutiny collector binary from the [latest Github release](https://github.com/analogj/scrutiny/releases).
+Next, we'll download the Scrutiny collector binary from the [latest Github release](https://github.com/Starosdev/scrutiny/releases).
 
 > NOTE: Ensure you have the latest version in the below command
 


### PR DESCRIPTION
## Summary

- Update all 5 Makefile Docker targets from `analogj/scrutiny-dev` to `ghcr.io/starosdev/scrutiny-dev`
- Fix misleading comment about `binary-frontend` dependency (handled internally by multi-stage Docker builds)
- Update stale `analogj/scrutiny` release links in 3 install docs (INSTALL_PFSENSE, INSTALL_HUB_SPOKE, INSTALL_MANUAL)

## Linked Issues

N/A - housekeeping task

## Test plan

- [x] `grep analogj Makefile` -- only `GO_WORKSPACE` internal path remains
- [x] `make -n docker-web` -- confirms `ghcr.io/starosdev/scrutiny-dev:web` tag
- [x] `grep -r "analogj/scrutiny" docs/` -- no results
- [x] All 5 docker targets verified via dry-run