### PR TITLE
fix(thresholds): improve devstat status reason messages (#275)

### DIFF
--- a/webapp/backend/pkg/models/measurements/smart_ata_devstat_attribute.go
+++ b/webapp/backend/pkg/models/measurements/smart_ata_devstat_attribute.go
@@ -92,7 +92,8 @@ func (sa *SmartAtaDeviceStatAttribute) PopulateAttributeStatus() *SmartAtaDevice
 	// Some drives report corrupted/encoded values that shouldn't be interpreted literally
 	if metadata.Ideal == thresholds.ObservedThresholdIdealLow && sa.Value > MaxReasonableFailureCount {
 		sa.Status = pkg.AttributeStatusSet(sa.Status, pkg.AttributeStatusInvalidValue)
-		sa.StatusReason = "Value exceeds reasonable maximum, likely corrupted data"
+		sa.StatusReason = fmt.Sprintf("%s value %d exceeds reasonable maximum (%d), likely corrupted data",
+			metadata.DisplayName, sa.Value, MaxReasonableFailureCount)
 		return sa
 	}
 
@@ -106,15 +107,15 @@ func (sa *SmartAtaDeviceStatAttribute) PopulateAttributeStatus() *SmartAtaDevice
 		// Tier 1: Fixed threshold available (e.g., devstat_7_8 percentage used = 100)
 		if metadata.Ideal == thresholds.ObservedThresholdIdealLow && sa.Value >= threshold {
 			sa.Status = pkg.AttributeStatusSet(sa.Status, pkg.AttributeStatusFailedScrutiny)
-			sa.StatusReason = "Device statistic exceeds recommended threshold"
+			sa.StatusReason = fmt.Sprintf("%s value %d exceeds threshold %d", metadata.DisplayName, sa.Value, threshold)
 		} else if metadata.Ideal == thresholds.ObservedThresholdIdealHigh && sa.Value <= threshold {
 			sa.Status = pkg.AttributeStatusSet(sa.Status, pkg.AttributeStatusFailedScrutiny)
-			sa.StatusReason = "Device statistic below recommended threshold"
+			sa.StatusReason = fmt.Sprintf("%s value %d is below threshold %d", metadata.DisplayName, sa.Value, threshold)
 		}
 	} else if metadata.Critical && metadata.Ideal == thresholds.ObservedThresholdIdealLow && sa.Value > 0 {
 		// Tier 2: No fixed threshold, but critical error count is non-zero
 		sa.Status = pkg.AttributeStatusSet(sa.Status, pkg.AttributeStatusWarningScrutiny)
-		sa.StatusReason = "Critical device statistic has non-zero error count"
+		sa.StatusReason = fmt.Sprintf("%s has non-zero error count: value %d", metadata.DisplayName, sa.Value)
 	}
 
 	return sa

--- a/webapp/backend/pkg/models/measurements/smart_ata_devstat_attribute_test.go
+++ b/webapp/backend/pkg/models/measurements/smart_ata_devstat_attribute_test.go
@@ -98,7 +98,9 @@ func TestSmartAtaDeviceStatAttribute_PopulateAttributeStatus_AtThreshold(t *test
 	attr.PopulateAttributeStatus()
 
 	require.True(t, pkg.AttributeStatusHas(attr.Status, pkg.AttributeStatusFailedScrutiny))
-	require.NotEmpty(t, attr.StatusReason)
+	require.Contains(t, attr.StatusReason, "Percentage Used Endurance Indicator")
+	require.Contains(t, attr.StatusReason, "100")
+	require.Contains(t, attr.StatusReason, "exceeds threshold")
 }
 
 func TestSmartAtaDeviceStatAttribute_PopulateAttributeStatus_AboveThreshold(t *testing.T) {
@@ -270,4 +272,20 @@ func TestSmartAtaDeviceStatAttribute_PopulateAttributeStatus_MechanicalFailures_
 	attr.PopulateAttributeStatus()
 
 	require.Equal(t, pkg.AttributeStatusPassed, attr.Status)
+}
+
+func TestSmartAtaDeviceStatAttribute_PopulateAttributeStatus_Discussion239(t *testing.T) {
+	// Discussion #239: Transcend TS240GMTS420S reports devstat_7_8 = 118
+	// StatusReason should clearly identify the attribute, value, and threshold
+	attr := SmartAtaDeviceStatAttribute{
+		AttributeId: "devstat_7_8",
+		Value:       118,
+	}
+
+	attr.PopulateAttributeStatus()
+
+	require.True(t, pkg.AttributeStatusHas(attr.Status, pkg.AttributeStatusFailedScrutiny))
+	require.Contains(t, attr.StatusReason, "Percentage Used Endurance Indicator")
+	require.Contains(t, attr.StatusReason, "118")
+	require.Contains(t, attr.StatusReason, "100")
 }


### PR DESCRIPTION
## Summary

- Replace generic devstat status reason strings with descriptive messages that include the attribute name, current value, and threshold
- Adds regression test for Discussion #239 scenario (Transcend SSD reporting devstat_7_8 = 118)
- Users now see e.g. "Percentage Used Endurance Indicator value 118 exceeds threshold 100" instead of "Device statistic exceeds recommended threshold"

## Linked Issues

Closes #275

## Test plan

- [x] All 82 measurements tests pass (`go test -v -count=1 ./webapp/backend/pkg/models/measurements/...`)
- [x] `go vet` clean
- [x] New regression test covers Discussion #239 scenario (value 118, threshold 100)
- [x] Verified existing test assertions still pass with new message format
- [x] Cherry-picked cleanly onto master and re-verified