### PR TITLE
fix(performance): add smartctl to perf container and configurable mount points (#274)

### DIFF
--- a/collector/pkg/config/config.go
+++ b/collector/pkg/config/config.go
@@ -64,6 +64,7 @@ func (c *configuration) Init() error {
 	c.SetDefault("performance.profile", "quick")
 	c.SetDefault("performance.allow_direct_device_io", false)
 	c.SetDefault("performance.temp_file_size", "256M")
+	c.SetDefault("performance.mount_points", map[string]string{})
 
 	c.SetDefault("allow_listed_devices", []string{})
 

--- a/collector/pkg/performance/collector.go
+++ b/collector/pkg/performance/collector.go
@@ -260,7 +260,11 @@ func (c *Collector) Benchmark(device *models.Device, profile string) (*models.Pe
 	c.logger.Infof("Benchmarking complete for %s (%.1fs)", device.DeviceName, result.TestDurationSec)
 
 	if result.SeqReadBwBytes == 0 && result.RandReadIOPS == 0 {
-		return nil, fmt.Errorf("all read benchmarks produced zero results for %s -- skipping (device may be inaccessible)", device.DeviceName)
+		hint := ""
+		if directIO {
+			hint = ". Hint: configure performance.mount_points in collector-performance.yaml to specify the filesystem mount point for this device, or ensure the container has sufficient capabilities for raw block device access"
+		}
+		return nil, fmt.Errorf("all read benchmarks produced zero results for %s -- skipping (device may be inaccessible%s)", device.DeviceName, hint)
 	}
 
 	return result, nil
@@ -320,6 +324,26 @@ func (c *Collector) resolveTargetPath(device *models.Device) (string, func(), bo
 		effectiveDevicePath = namespaceDev
 	}
 
+	// Check for explicitly configured mount point (by device name, then by WWN)
+	if configuredMount := c.lookupConfiguredMountPoint(device); configuredMount != "" {
+		if _, statErr := os.Stat(configuredMount); statErr != nil {
+			c.logger.Warnf("Configured mount point %s for device %s does not exist: %v -- ignoring", configuredMount, device.DeviceName, statErr)
+		} else {
+			requiredSize := c.getRequiredTestFileSize()
+			suitable, reason := isMountPointSuitable(configuredMount, requiredSize)
+			if !suitable {
+				c.logger.Warnf("Configured mount point %s for device %s is not suitable: %s -- ignoring", configuredMount, device.DeviceName, reason)
+			} else {
+				c.logger.Infof("Using configured mount point %s for device %s", configuredMount, device.DeviceName)
+				tempFile := fmt.Sprintf("%s/.scrutiny_perf_bench", configuredMount)
+				cleanup := func() {
+					os.Remove(tempFile)
+				}
+				return tempFile, cleanup, false, nil
+			}
+		}
+	}
+
 	// Explicit opt-in takes precedence (now uses namespace device for NVMe)
 	if c.config.GetBool("performance.allow_direct_device_io") {
 		c.logger.Infof("Direct device I/O enabled -- benchmarking %s (read-only, write tests skipped)", effectiveDevicePath)
@@ -347,6 +371,20 @@ func (c *Collector) resolveTargetPath(device *models.Device) (string, func(), bo
 	}
 
 	return tempFile, cleanup, false, nil
+}
+
+// lookupConfiguredMountPoint checks the config for an explicit mount point
+// override, first by device name (e.g., "sda") then by WWN.
+func (c *Collector) lookupConfiguredMountPoint(device *models.Device) string {
+	if mp := c.config.GetString("performance.mount_points." + device.DeviceName); mp != "" {
+		return mp
+	}
+	if device.WWN != "" {
+		if mp := c.config.GetString("performance.mount_points." + device.WWN); mp != "" {
+			return mp
+		}
+	}
+	return ""
 }
 
 // getRequiredTestFileSize returns the number of bytes needed for the benchmark
@@ -434,6 +472,11 @@ func (c *Collector) buildFioArgs(rwMode string, blockSize string, profile string
 		fmt.Sprintf("--filename=%s", targetPath),
 	}
 
+	// When targeting a raw block device, tell fio the file already exists
+	if strings.HasPrefix(targetPath, detect.DevicePrefix()) {
+		args = append(args, "--allow_file_create=0")
+	}
+
 	return args
 }
 
@@ -448,6 +491,10 @@ func (c *Collector) runFio(fioBin string, args []string) ([]byte, error) {
 
 	if err := cmd.Run(); err != nil {
 		return nil, fmt.Errorf("fio command failed: %w (stderr: %s)", err, stderr.String())
+	}
+
+	if stderrStr := strings.TrimSpace(stderr.String()); stderrStr != "" {
+		c.logger.Debugf("fio stderr (non-fatal): %s", stderrStr)
 	}
 
 	return stdout.Bytes(), nil

--- a/docker/Dockerfile.collector-performance
+++ b/docker/Dockerfile.collector-performance
@@ -18,8 +18,10 @@ FROM debian:trixie-slim AS runtime
 WORKDIR /opt/scrutiny
 ENV PATH="/opt/scrutiny/bin:${PATH}"
 
-RUN apt-get update && \
+RUN echo "deb http://deb.debian.org/debian trixie-backports main" > /etc/apt/sources.list.d/backports.list && \
+    apt-get update && \
     apt-get install -y cron ca-certificates tzdata fio && \
+    apt-get install -y -t trixie-backports smartmontools && \
     rm -rf /var/lib/apt/lists/* && \
     update-ca-certificates
 

--- a/docker/example.hubspoke.docker-compose.yml
+++ b/docker/example.hubspoke.docker-compose.yml
@@ -81,17 +81,24 @@ services:
   # Performance Benchmark Collector (optional - for fio-based drive benchmarking)
   # Runs fio benchmarks on drives and tracks throughput, IOPS, and latency over time.
   # Default schedule: Sunday 2 AM. Requires device access and mounted filesystems.
+  # For best results, volume-mount the host filesystem paths and configure mount_points
+  # so the collector benchmarks the actual filesystem rather than using raw device I/O.
   # collector-performance:
   #   restart: unless-stopped
   #   image: 'ghcr.io/starosdev/scrutiny:latest-collector-performance'
   #   volumes:
   #     - '/run/udev:/run/udev:ro'
+  #     - '/mnt/data:/mnt/data'        # Mount host filesystem for sda benchmarks
+  #     - '/mnt/backup:/mnt/backup'    # Mount host filesystem for sdb benchmarks
   #   environment:
   #     COLLECTOR_PERF_API_ENDPOINT: 'http://web:8080'
   #     COLLECTOR_PERF_HOST_ID: 'scrutiny-collector-hostname'
   #     COLLECTOR_PERF_CRON_SCHEDULE: '0 2 * * 0'  # Sunday at 2 AM
   #     COLLECTOR_PERF_RUN_STARTUP: 'false'
   #     COLLECTOR_PERF_PROFILE: 'quick'  # 'quick' (~60s/device) or 'comprehensive' (~300s/device)
+  #     # Map devices to their host mount points (avoids raw block device fallback):
+  #     COLLECTOR_PERFORMANCE_MOUNT_POINTS_SDA: '/mnt/data'
+  #     COLLECTOR_PERFORMANCE_MOUNT_POINTS_SDB: '/mnt/backup'
   #   depends_on:
   #     web:
   #       condition: service_healthy

--- a/example.collector-performance.yaml
+++ b/example.collector-performance.yaml
@@ -65,6 +65,13 @@ performance:
   profile: 'quick'            # 'quick' (~60s per device) or 'comprehensive' (~300s per device)
 #  allow_direct_device_io: false  # Benchmark raw block device (/dev/sdX) directly. Read-only (write tests skipped for safety).
 #  temp_file_size: '256M'     # Size of temp file for benchmarks (used in quick profile)
+#  mount_points:              # Explicit mount point overrides per device (useful in containers).
+#    sda: '/mnt/data'         # Key: device name (e.g., sda, nvme0n1)
+#    0x5000cca7aae69487: '/mnt/backup'  # Key: device WWN (stable across reboots)
+#  # In containers, volume-mount the host filesystem path into the container and map it here.
+#  # Example: docker run -v /mnt/data:/mnt/data --device=/dev/sda ...
+#  # The collector checks device name first, then WWN. If neither is configured,
+#  # it auto-detects via 'df' and falls back to direct device I/O if no mount is found.
 
 # Benchmark Profiles:
 #


### PR DESCRIPTION
## Summary

- Add `smartmontools` to `Dockerfile.collector-performance` from trixie-backports, fixing `smartctl: executable file not found in $PATH` error in standalone performance containers
- Add `performance.mount_points` config option allowing users to map devices to filesystem mount points by device name or WWN (useful in containers where devices are not mounted as real filesystems)
- Improve direct device I/O reliability by passing `--allow_file_create=0` to fio for block device targets
- Add diagnostic hints when benchmarks produce zero results, guiding users to configure mount points
- Log fio stderr output at debug level even on success for troubleshooting
- Update example config and docker-compose with mount_points documentation and volume mount guidance

## Linked Issues

Closes #274

## Test plan

- [x] `go build ./collector/cmd/collector-performance/` -- exit 0
- [x] `go vet ./collector/...` -- exit 0
- [x] `go test ./collector/...` -- all packages pass (10/10 performance, 15/15 config)
- [x] Dockerfile pattern matches existing `Dockerfile.collector` backports installation
- [ ] Docker image build (requires CI)
- [ ] End-to-end test with container and `--device` flag