### PR TITLE
fix(docker): add missing cap_add to performance collector examples (#283)

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,6 +355,8 @@ The performance collector is available as a separate Docker image:
 
 ```bash
 docker run --restart unless-stopped \
+  --cap-add SYS_RAWIO \
+  --cap-add SYS_ADMIN \
   --device=/dev/sda \
   --device=/dev/sdb \
   -e COLLECTOR_PERF_API_ENDPOINT=http://SCRUTINY_WEB_IPADDRESS:8080 \
@@ -714,6 +716,8 @@ Example:
 
 ```bash
 docker run --restart unless-stopped \
+  --cap-add SYS_RAWIO \
+  --cap-add SYS_ADMIN \
   --device=/dev/sda \
   --device=/dev/sdb \
   -e COLLECTOR_PERF_API_ENDPOINT=http://scrutiny-web:8080 \

--- a/docker/example.hubspoke.docker-compose.yml
+++ b/docker/example.hubspoke.docker-compose.yml
@@ -92,6 +92,9 @@ services:
   # collector-performance:
   #   restart: unless-stopped
   #   image: 'ghcr.io/starosdev/scrutiny:latest-collector-performance'
+  #   cap_add:
+  #     - SYS_RAWIO
+  #     - SYS_ADMIN  # Required for NVMe and USB/SAT devices
   #   volumes:
   #     - '/run/udev:/run/udev:ro'
   #     - '/mnt/data:/mnt/data'        # Mount host filesystem for sda benchmarks


### PR DESCRIPTION
## Summary

- Add `cap_add: SYS_RAWIO` and `SYS_ADMIN` to the performance collector docker-compose example
- Add `--cap-add SYS_RAWIO` and `--cap-add SYS_ADMIN` to both performance collector `docker run` examples in the README
- These capabilities were already present in the regular collector and omnibus examples but missing from the performance collector, causing `smartctl` to fail with exit status 2 on USB/SAT devices

## Linked Issues

Closes #283

## Test plan

- [x] Verified all `collector-performance` docker examples now include capabilities
- [x] Confirmed parity with regular collector capability configuration