### PR TITLE
fix(scsi): correct SCSI temperature attribute handling (#291)

### DIFF
--- a/webapp/backend/pkg/models/measurements/smart.go
+++ b/webapp/backend/pkg/models/measurements/smart.go
@@ -385,7 +385,7 @@ func (sm *Smart) ProcessNvmeSmartInfo(cfg config.Interface, nvmeSmartHealthInfor
 // generate SmartScsiAttribute entries from Scrutiny Collector Smart data.
 func (sm *Smart) ProcessScsiSmartInfo(cfg config.Interface, defectGrownList int64, scsiErrorCounterLog collector.ScsiErrorCounterLog, temperature map[string]collector.ScsiTemperatureData) {
 	sm.Attributes = map[string]SmartAttribute{
-		"temperature": (&SmartNvmeAttribute{AttributeId: "temperature", Value: getScsiTemperature(temperature), Threshold: -1}).PopulateAttributeStatus(),
+		"temperature": (&SmartScsiAttribute{AttributeId: "temperature", Value: sm.Temp, Threshold: -1}).PopulateAttributeStatus(),
 
 		"scsi_grown_defect_list":                     (&SmartScsiAttribute{AttributeId: "scsi_grown_defect_list", Value: defectGrownList, Threshold: 0}).PopulateAttributeStatus(),
 		"read_errors_corrected_by_eccfast":           (&SmartScsiAttribute{AttributeId: "read_errors_corrected_by_eccfast", Value: scsiErrorCounterLog.Read.ErrorsCorrectedByEccfast, Threshold: -1}).PopulateAttributeStatus(),
@@ -439,15 +439,6 @@ func (sm *Smart) ProcessScsiSmartInfo(cfg config.Interface, defectGrownList int6
 			sm.Status = pkg.DeviceStatusSet(sm.Status, pkg.DeviceStatusFailedScrutiny)
 		}
 	}
-}
-
-func getScsiTemperature(s map[string]collector.ScsiTemperatureData) int64 {
-	temp, ok := s["temperature_1"]
-	if !ok {
-		return 0
-	}
-
-	return temp.Current
 }
 
 // processAtaSmartInfoWithOverrides generates SmartAtaAttribute entries using pre-merged overrides.
@@ -784,7 +775,7 @@ func (sm *Smart) recalculateDeviceStatus() {
 // processScsiSmartInfoWithOverrides generates SmartScsiAttribute entries using pre-merged overrides.
 func (sm *Smart) processScsiSmartInfoWithOverrides(cfg config.Interface, defectGrownList int64, scsiErrorCounterLog collector.ScsiErrorCounterLog, temperature map[string]collector.ScsiTemperatureData, mergedOverrides []overrides.AttributeOverride) {
 	sm.Attributes = map[string]SmartAttribute{
-		"temperature": (&SmartNvmeAttribute{AttributeId: "temperature", Value: getScsiTemperature(temperature), Threshold: -1}).PopulateAttributeStatus(),
+		"temperature": (&SmartScsiAttribute{AttributeId: "temperature", Value: sm.Temp, Threshold: -1}).PopulateAttributeStatus(),
 
 		"scsi_grown_defect_list":                     (&SmartScsiAttribute{AttributeId: "scsi_grown_defect_list", Value: defectGrownList, Threshold: 0}).PopulateAttributeStatus(),
 		"read_errors_corrected_by_eccfast":           (&SmartScsiAttribute{AttributeId: "read_errors_corrected_by_eccfast", Value: scsiErrorCounterLog.Read.ErrorsCorrectedByEccfast, Threshold: -1}).PopulateAttributeStatus(),

--- a/webapp/backend/pkg/models/measurements/smart_test.go
+++ b/webapp/backend/pkg/models/measurements/smart_test.go
@@ -643,6 +643,70 @@ func TestFromCollectorSmartInfo_Scsi_SAS_EnvironmentalReports(t *testing.T) {
 	require.Equal(t, int64(38), smartMdl.Temp, "Temperature should be parsed from scsi_environmental_reports when standard temperature is 0")
 }
 
+// TestFromCollectorSmartInfo_Scsi_TemperatureAttributeType verifies that the SCSI
+// temperature attribute is correctly typed as SmartScsiAttribute (not SmartNvmeAttribute)
+// and uses the corrected temperature value. Fixes GitHub issue #291.
+func TestFromCollectorSmartInfo_Scsi_TemperatureAttributeType(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	fakeConfig := mock_config.NewMockInterface(mockCtrl)
+	fakeConfig.EXPECT().GetIntSlice("failures.transient.ata").Return([]int{195}).AnyTimes()
+	fakeConfig.EXPECT().Get("smart.attribute_overrides").Return(nil).AnyTimes()
+
+	smartDataFile, err := os.Open("../testdata/smart-scsi.json")
+	require.NoError(t, err)
+	defer smartDataFile.Close()
+
+	var smartJson collector.SmartInfo
+	smartDataBytes, err := ioutil.ReadAll(smartDataFile)
+	require.NoError(t, err)
+	err = json.Unmarshal(smartDataBytes, &smartJson)
+	require.NoError(t, err)
+
+	smartMdl := measurements.Smart{}
+	err = smartMdl.FromCollectorSmartInfo(fakeConfig, "WWN-test", smartJson)
+	require.NoError(t, err)
+
+	// Temperature attribute must be SmartScsiAttribute, not SmartNvmeAttribute
+	tempAttr, ok := smartMdl.Attributes["temperature"].(*measurements.SmartScsiAttribute)
+	require.True(t, ok, "SCSI temperature attribute should be *SmartScsiAttribute, got %T", smartMdl.Attributes["temperature"])
+	require.Equal(t, int64(34), tempAttr.Value, "Temperature attribute should use corrected temperature value")
+	require.Equal(t, int64(34), smartMdl.Temp, "Smart.Temp should match temperature attribute value")
+}
+
+// TestFromCollectorSmartInfo_Scsi_TemperatureAttributeType_EnvReports verifies that
+// when the standard temperature field is 0, the temperature attribute correctly uses
+// the fallback value from scsi_environmental_reports. Fixes GitHub issue #291.
+func TestFromCollectorSmartInfo_Scsi_TemperatureAttributeType_EnvReports(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	fakeConfig := mock_config.NewMockInterface(mockCtrl)
+	fakeConfig.EXPECT().GetIntSlice("failures.transient.ata").Return([]int{195}).AnyTimes()
+	fakeConfig.EXPECT().Get("smart.attribute_overrides").Return(nil).AnyTimes()
+
+	smartDataFile, err := os.Open("../testdata/smart-scsi-sas-env-temp.json")
+	require.NoError(t, err)
+	defer smartDataFile.Close()
+
+	var smartJson collector.SmartInfo
+	smartDataBytes, err := ioutil.ReadAll(smartDataFile)
+	require.NoError(t, err)
+	err = json.Unmarshal(smartDataBytes, &smartJson)
+	require.NoError(t, err)
+
+	smartMdl := measurements.Smart{}
+	err = smartMdl.FromCollectorSmartInfo(fakeConfig, "WWN-test", smartJson)
+	require.NoError(t, err)
+
+	// Temperature attribute must be SmartScsiAttribute
+	tempAttr, ok := smartMdl.Attributes["temperature"].(*measurements.SmartScsiAttribute)
+	require.True(t, ok, "SCSI temperature attribute should be *SmartScsiAttribute, got %T", smartMdl.Attributes["temperature"])
+
+	// Standard temp is 0 in this test data; should fall back to env reports (38)
+	require.Equal(t, int64(38), tempAttr.Value, "Temperature attribute should use fallback from scsi_environmental_reports")
+	require.Equal(t, int64(38), smartMdl.Temp, "Smart.Temp should match temperature attribute value")
+}
+
 // TestFromCollectorSmartInfo_ATA_DeviceStatistics tests that ATA Device Statistics
 // from GP Log 0x04 are correctly parsed, including enterprise SSD metrics like
 // "Percentage Used Endurance Indicator" (devstat_7_8). Fixes GitHub issue #7 (SCR-11).

--- a/webapp/backend/pkg/thresholds/scsi_attribute_metadata.go
+++ b/webapp/backend/pkg/thresholds/scsi_attribute_metadata.go
@@ -117,4 +117,12 @@ var ScsiMetadata = map[string]ScsiAttributeMetadata{
 		Critical:    true,
 		Description: " This parameter code specifies the counter that contains the total number of blocks for which an uncorrected data error has occurred.",
 	},
+	"temperature": {
+		ID:          "temperature",
+		DisplayName: "Temperature",
+		DisplayType: "",
+		Ideal:       "",
+		Critical:    false,
+		Description: "Current drive temperature in Celsius.",
+	},
 }


### PR DESCRIPTION
## Summary

- Fix SCSI temperature attribute to use the correct attribute type, resolving missing temperature and SMART data on SAS SSDs (#291)

## Linked Issues

Closes #291

## Test plan

- [x] Unit tests added for SCSI temperature attribute handling
- [x] All backend tests pass
- [x] CI checks passed on PR #296