### PR TITLE
feat(workload): respect dashboard_display setting for device titles (#290)

### DIFF
--- a/webapp/backend/pkg/database/scrutiny_repository_workload.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_workload.go
@@ -30,6 +30,14 @@ func (sr *scrutinyRepository) GetWorkloadInsights(ctx context.Context, durationK
 		insights[devices[i].WWN] = &models.WorkloadInsight{
 			DeviceWWN:      devices[i].WWN,
 			DeviceProtocol: devices[i].DeviceProtocol,
+			DeviceName:     devices[i].DeviceName,
+			DeviceType:     devices[i].DeviceType,
+			ModelName:      devices[i].ModelName,
+			Label:          devices[i].Label,
+			DeviceLabel:    devices[i].DeviceLabel,
+			HostId:         devices[i].HostId,
+			DeviceSerialID: devices[i].DeviceSerialID,
+			DeviceUUID:     devices[i].DeviceUUID,
 			Intensity:      "unknown",
 		}
 		deviceProtocols[devices[i].WWN] = devices[i].DeviceProtocol

--- a/webapp/backend/pkg/models/workload_insight.go
+++ b/webapp/backend/pkg/models/workload_insight.go
@@ -11,6 +11,16 @@ type WorkloadInsight struct {
 	DeviceWWN      string `json:"device_wwn"`
 	DeviceProtocol string `json:"device_protocol"`
 
+	// Device display fields (for frontend device title rendering)
+	DeviceName     string `json:"device_name,omitempty"`
+	DeviceType     string `json:"device_type,omitempty"`
+	ModelName      string `json:"model_name,omitempty"`
+	Label          string `json:"label,omitempty"`
+	DeviceLabel    string `json:"device_label,omitempty"`
+	HostId         string `json:"host_id,omitempty"`
+	DeviceSerialID string `json:"device_serial_id,omitempty"`
+	DeviceUUID     string `json:"device_uuid,omitempty"`
+
 	// Classification: "heavy", "medium", "light", "idle", "unknown"
 	Intensity string `json:"intensity"`
 

--- a/webapp/frontend/src/app/core/models/workload-insight-model.ts
+++ b/webapp/frontend/src/app/core/models/workload-insight-model.ts
@@ -1,6 +1,17 @@
 export interface WorkloadInsightModel {
     device_wwn: string;
     device_protocol: string;
+
+    // Device display fields (populated from Device record)
+    device_name?: string;
+    device_type?: string;
+    model_name?: string;
+    label?: string;
+    device_label?: string;
+    host_id?: string;
+    device_serial_id?: string;
+    device_uuid?: string;
+
     data_points: number;
     time_span_hours: number;
     daily_write_bytes: number;

--- a/webapp/frontend/src/app/modules/workload/workload.component.html
+++ b/webapp/frontend/src/app/modules/workload/workload.component.html
@@ -35,7 +35,7 @@
               </div>
               @for (device of spikeDevices; track device.device_wwn) {
                 <div class="text-sm ml-8">
-                  {{ device.device_wwn }} &mdash; {{ device.spike.description }}
+                  {{ getDeviceDisplayTitle(device) }} &mdash; {{ device.spike.description }}
                 </div>
               }
             </div>
@@ -50,8 +50,10 @@
               <!-- Device column -->
               <ng-container matColumnDef="device_wwn">
                 <th mat-header-cell *matHeaderCellDef mat-sort-header>Device</th>
-                <td mat-cell *matCellDef="let row" class="cursor-pointer" (click)="navigateToDevice(row.device_wwn)">
-                  <span class="font-medium">{{ row.device_wwn }}</span>
+                <td mat-cell *matCellDef="let row" class="cursor-pointer"
+                    (click)="navigateToDevice(row.device_wwn)"
+                    [matTooltip]="row.device_wwn">
+                  <span class="font-medium">{{ getDeviceDisplayTitle(row) }}</span>
                 </td>
               </ng-container>
 

--- a/webapp/frontend/src/app/modules/workload/workload.component.ts
+++ b/webapp/frontend/src/app/modules/workload/workload.component.ts
@@ -140,6 +140,57 @@ export class WorkloadComponent implements OnInit, AfterViewInit, OnDestroy {
         return `${days} d`;
     }
 
+    getDeviceDisplayTitle(insight: WorkloadInsightModel): string {
+        const titleType = this.config?.dashboard_display || 'name';
+        const parts: string[] = [];
+
+        if (insight.host_id) {
+            parts.push(insight.host_id);
+        }
+
+        let identifier = '';
+        switch (titleType) {
+            case 'name':
+                identifier = this.buildNameTitle(insight);
+                break;
+            case 'serial_id':
+                identifier = insight.device_serial_id ? `/by-id/${insight.device_serial_id}` : '';
+                break;
+            case 'uuid':
+                identifier = insight.device_uuid ? `/by-uuid/${insight.device_uuid}` : '';
+                break;
+            case 'label':
+                if (insight.label) {
+                    identifier = insight.label;
+                } else if (insight.device_label) {
+                    identifier = `/by-label/${insight.device_label}`;
+                }
+                break;
+        }
+
+        // Fallback to name mode if the chosen mode yields nothing
+        if (!identifier) {
+            identifier = this.buildNameTitle(insight);
+        }
+
+        parts.push(identifier);
+        return parts.join(' - ');
+    }
+
+    private buildNameTitle(insight: WorkloadInsightModel): string {
+        const parts: string[] = [];
+        if (insight.device_name) {
+            parts.push(`/dev/${insight.device_name}`);
+        }
+        if (insight.device_type && insight.device_type !== 'scsi' && insight.device_type !== 'ata') {
+            parts.push(insight.device_type);
+        }
+        if (insight.model_name) {
+            parts.push(insight.model_name);
+        }
+        return parts.join(' - ') || insight.device_wwn;
+    }
+
     private refreshComponent(): void {
         const currentUrl = this.router.url;
         this.router.routeReuseStrategy.shouldReuseRoute = () => false;


### PR DESCRIPTION
## Summary

- Passes device identity fields (name, label, serial_id, uuid, host_id) through the workload API response so the frontend can render device titles using the same `dashboard_display` config setting used elsewhere in the app
- Adds WWN tooltip on hover for quick identification when a non-WWN display mode is active
- Spike alerts also respect the display setting

Closes #290

## Changes

| File | Change |
|------|--------|
| `webapp/backend/pkg/models/workload_insight.go` | Add 8 device display fields to `WorkloadInsight` struct |
| `webapp/backend/pkg/database/scrutiny_repository_workload.go` | Populate new fields from `Device` records (already fetched) |
| `webapp/frontend/src/app/core/models/workload-insight-model.ts` | Add 8 optional fields to match backend |
| `webapp/frontend/src/app/modules/workload/workload.component.ts` | Add `getDeviceDisplayTitle()` mirroring `DeviceTitlePipe` logic |
| `webapp/frontend/src/app/modules/workload/workload.component.html` | Use display titles + WWN tooltip |

## Test plan

- [ ] `go build ./webapp/backend/...` compiles
- [ ] `go test ./webapp/backend/...` passes
- [ ] `cd webapp/frontend && npm run build:prod` builds successfully
- [ ] Set `dashboard_display` to `label` -- workload tab shows custom labels
- [ ] Set `dashboard_display` to `name` -- workload tab shows `/dev/sdX - Model`
- [ ] Devices without a label fall back to name mode gracefully
- [ ] Hovering a device cell in the table shows the WWN in a tooltip
- [ ] Spike alerts show the display title instead of raw WWN