### PR TITLE
feat(collector): add config-driven device labels (#301)

### DIFF
--- a/collector/pkg/detect/detect.go
+++ b/collector/pkg/detect/detect.go
@@ -181,6 +181,7 @@ func (d *Detect) TransformDetectedDevices(detectedDeviceConns models.Scan) []mod
 						CollectorVersion: version.VERSION,
 						DeviceType:       overrideDeviceType,
 						DeviceName:       strings.TrimPrefix(overrideDeviceFile, DevicePrefix()),
+						Label:            overrideDevice.Label,
 					})
 				}
 			} else {
@@ -206,6 +207,7 @@ func (d *Detect) TransformDetectedDevices(detectedDeviceConns models.Scan) []mod
 					CollectorVersion: version.VERSION,
 					DeviceType:       deviceType,
 					DeviceName:       strings.TrimPrefix(overrideDeviceFile, DevicePrefix()),
+					Label:            overrideDevice.Label,
 				})
 			}
 

--- a/collector/pkg/detect/detect_test.go
+++ b/collector/pkg/detect/detect_test.go
@@ -409,3 +409,103 @@ func TestDetect_SmartCtlInfo(t *testing.T) {
 		assert.Equal(t, someCapacity, someDevice.Capacity)
 	})
 }
+
+func TestDetect_TransformDetectedDevices_LabelWithDeviceType(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	fakeConfig := mock_config.NewMockInterface(mockCtrl)
+	fakeConfig.EXPECT().GetString("host.id").AnyTimes().Return("")
+	fakeConfig.EXPECT().GetDeviceOverrides().AnyTimes().Return([]models.ScanOverride{
+		{Device: "/dev/sda", DeviceType: []string{"sat"}, Label: "NAS Pool - Disk 1"},
+	})
+	fakeConfig.EXPECT().IsAllowlistedDevice(gomock.Any()).AnyTimes().Return(true)
+
+	detectedDevices := models.Scan{
+		Devices: []models.ScanDevice{
+			{Name: "/dev/sda", InfoName: "/dev/sda", Protocol: "ata", Type: "ata"},
+		},
+	}
+
+	d := detect.Detect{Config: fakeConfig}
+	transformedDevices := d.TransformDetectedDevices(detectedDevices)
+
+	require.Equal(t, 1, len(transformedDevices))
+	require.Equal(t, "sat", transformedDevices[0].DeviceType)
+	require.Equal(t, "NAS Pool - Disk 1", transformedDevices[0].Label)
+}
+
+func TestDetect_TransformDetectedDevices_LabelWithoutDeviceType(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	fakeConfig := mock_config.NewMockInterface(mockCtrl)
+	fakeConfig.EXPECT().GetString("host.id").AnyTimes().Return("")
+	fakeConfig.EXPECT().GetDeviceOverrides().AnyTimes().Return([]models.ScanOverride{
+		{Device: "/dev/sda", Label: "Backup Drive"},
+	})
+	fakeConfig.EXPECT().IsAllowlistedDevice(gomock.Any()).AnyTimes().Return(true)
+
+	detectedDevices := models.Scan{
+		Devices: []models.ScanDevice{
+			{Name: "/dev/sda", InfoName: "/dev/sda", Protocol: "ata", Type: "scsi"},
+		},
+	}
+
+	d := detect.Detect{Config: fakeConfig}
+	transformedDevices := d.TransformDetectedDevices(detectedDevices)
+
+	require.Equal(t, 1, len(transformedDevices))
+	require.Equal(t, "scsi", transformedDevices[0].DeviceType)
+	require.Equal(t, "Backup Drive", transformedDevices[0].Label)
+}
+
+func TestDetect_TransformDetectedDevices_NoLabel(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	fakeConfig := mock_config.NewMockInterface(mockCtrl)
+	fakeConfig.EXPECT().GetString("host.id").AnyTimes().Return("")
+	fakeConfig.EXPECT().GetDeviceOverrides().AnyTimes().Return([]models.ScanOverride{
+		{Device: "/dev/sda", DeviceType: []string{"sat"}},
+	})
+	fakeConfig.EXPECT().IsAllowlistedDevice(gomock.Any()).AnyTimes().Return(true)
+
+	detectedDevices := models.Scan{
+		Devices: []models.ScanDevice{
+			{Name: "/dev/sda", InfoName: "/dev/sda", Protocol: "ata", Type: "ata"},
+		},
+	}
+
+	d := detect.Detect{Config: fakeConfig}
+	transformedDevices := d.TransformDetectedDevices(detectedDevices)
+
+	require.Equal(t, 1, len(transformedDevices))
+	require.Equal(t, "", transformedDevices[0].Label)
+}
+
+func TestDetect_TransformDetectedDevices_RaidWithLabel(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	fakeConfig := mock_config.NewMockInterface(mockCtrl)
+	fakeConfig.EXPECT().GetString("host.id").AnyTimes().Return("")
+	fakeConfig.EXPECT().GetDeviceOverrides().AnyTimes().Return([]models.ScanOverride{
+		{
+			Device:     "/dev/bus/0",
+			DeviceType: []string{"megaraid,14", "megaraid,15", "megaraid,18"},
+			Label:      "RAID Controller A",
+		},
+	})
+	fakeConfig.EXPECT().IsAllowlistedDevice(gomock.Any()).AnyTimes().Return(true)
+
+	detectedDevices := models.Scan{
+		Devices: []models.ScanDevice{
+			{Name: "/dev/bus/0", InfoName: "/dev/bus/0", Protocol: "scsi", Type: "scsi"},
+		},
+	}
+
+	d := detect.Detect{Config: fakeConfig}
+	transformedDevices := d.TransformDetectedDevices(detectedDevices)
+
+	require.Equal(t, 3, len(transformedDevices))
+	for _, dev := range transformedDevices {
+		require.Equal(t, "RAID Controller A", dev.Label)
+	}
+}

--- a/collector/pkg/models/scan_override.go
+++ b/collector/pkg/models/scan_override.go
@@ -4,6 +4,7 @@ type ScanOverride struct {
 	Device     string   `mapstructure:"device"`
 	DeviceType []string `mapstructure:"type"`
 	Ignore     bool     `mapstructure:"ignore"`
+	Label      string   `mapstructure:"label"`
 	Commands   struct {
 		MetricsInfoArgs  string `mapstructure:"metrics_info_args"`
 		MetricsSmartArgs string `mapstructure:"metrics_smart_args"`

--- a/example.collector.yaml
+++ b/example.collector.yaml
@@ -83,6 +83,18 @@ devices:
 #      - 3ware,4
 #      - 3ware,5
 #
+#  # example for setting a custom label for a device.
+#  # This label will be applied on every collector run, making it ideal
+#  # for environments where disks may be swapped (the label follows the slot/path).
+#  # Config labels take precedence over labels set in the web UI.
+#  - device: /dev/sda
+#    label: 'NAS Pool - Disk 1'
+#
+#  # example combining label with type override
+#  - device: /dev/sdb
+#    type: 'sat'
+#    label: 'Backup Drive'
+#
 #  # example to show how to override the smartctl command args (per device), see below for how to override these globally.
 #  - device: /dev/sda
 #    commands:

--- a/webapp/backend/pkg/database/scrutiny_repository_device.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_device.go
@@ -20,9 +20,22 @@ import (
 // insert device into DB (and update specified columns if device is already registered)
 // update device fields that may change: (DeviceType, HostID)
 func (sr *scrutinyRepository) RegisterDevice(ctx context.Context, dev models.Device) error {
+	updateColumns := []string{
+		"host_id", "device_name", "device_type", "device_uuid",
+		"device_serial_id", "device_label", "collector_version",
+		"model_name", "manufacturer",
+	}
+
+	// Only update the custom label if the collector explicitly provides one.
+	// This preserves labels set via the web UI when no config label is specified,
+	// while allowing config-set labels to take precedence on every collector run.
+	if len(dev.Label) > 0 {
+		updateColumns = append(updateColumns, "label")
+	}
+
 	if err := sr.gormClient.WithContext(ctx).Clauses(clause.OnConflict{
 		Columns:   []clause.Column{{Name: "wwn"}},
-		DoUpdates: clause.AssignmentColumns([]string{"host_id", "device_name", "device_type", "device_uuid", "device_serial_id", "device_label", "collector_version", "model_name", "manufacturer"}),
+		DoUpdates: clause.AssignmentColumns(updateColumns),
 	}).Create(&dev).Error; err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

- Add `label` field to collector config device overrides, allowing users to set custom device labels in `collector.yaml`
- Labels from config are applied on every collector run, making them ideal for environments where disks are swapped between slots
- Config labels take precedence over UI-set labels when specified; when no config label is set, existing UI labels are preserved
- Conditional upsert in `RegisterDevice()` ensures labels are only overwritten when explicitly provided

## Linked Issues

Closes #301

## Test plan

- [x] Unit tests: 4 new tests for label propagation (with DeviceType, without DeviceType, no label, RAID with label)
- [x] All 16 detect tests pass (`go test -v -count=1 ./collector/pkg/detect/...`)
- [x] Build compiles (`go build ./collector/...` and `go build ./webapp/backend/...`)
- [ ] Integration test: register device with label, re-register without label (preserves existing), re-register with new label (overwrites)
- [ ] Manual: verify label appears in dashboard with `dashboard_display: label`