### PR TITLE
docs: update outdated documentation across repository (#304)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ Depending on the functionality you are adding, you may need to setup a developme
 
 # Modifying the Scrutiny Backend Server (API)
 
-1. install the [Go runtime](https://go.dev/doc/install) (v1.20+)
+1. install the [Go runtime](https://go.dev/doc/install) (v1.25+)
 2. download the `scrutiny-web-frontend.tar.gz` for
    the [latest release](https://github.com/Starosdev/scrutiny/releases/latest). Extract to a folder named `dist`
 3. create a `scrutiny.yaml` config file
@@ -96,7 +96,7 @@ The frontend is written in Angular. If you're working on the frontend and can us
 If you're developing a feature that requires changes to the backend and the frontend, or a frontend feature that requires real data,
 you'll need to follow the steps below:
 
-1. install the [Go runtime](https://go.dev/doc/install) (v1.20+)
+1. install the [Go runtime](https://go.dev/doc/install) (v1.25+)
 2. install [NodeJS](https://nodejs.org/en/download/)
 3. create a `scrutiny.yaml` config file
     ```yaml
@@ -130,7 +130,7 @@ you'll need to follow the steps below:
     cd webapp/frontend
     npm install --legacy-peer-deps
     npm run build:prod -- --watch --output-path=../../dist
-    # Note: if you do not add `--prod` flag, app will display mocked data for api calls.
+    # Note: `build:prod` uses the production configuration. Without it, app will display mocked data for api calls.
     ```
 6. start the scrutiny web server
     ```bash

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Full credit for the original vision and architecture goes to [AnalogJ](https://g
 | | Original | This Fork |
 |---|---|---|
 | **Latest Version** | v0.8.1 (Apr 2024) | [![GitHub release](https://img.shields.io/github/v/release/Starosdev/scrutiny?label=&style=flat-square)](https://github.com/Starosdev/scrutiny/releases) |
-| **Frontend** | Angular 13 | Modern Angular |
+| **Frontend** | Angular 13 | Angular 21 |
 | **Status** | Minimal updates | Actively maintained |
 | **Community PRs** | Many pending | Merged |
 

--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -49,8 +49,8 @@ Last updated: 2026-01-08
 
 ### Go Version
 
-- **Current**: 1.20
-- **Recommended**: 1.23+ (latest stable)
+- **Current**: 1.25
+- **Recommended**: Current
 
 ### Direct Dependencies
 

--- a/docs/INSTALL_HUB_SPOKE.md
+++ b/docs/INSTALL_HUB_SPOKE.md
@@ -1,5 +1,5 @@
 >
-See [docker/example.hubspoke.docker-compose.yml](https://github.com/AnalogJ/scrutiny/blob/master/docker/example.hubspoke.docker-compose.yml)
+See [docker/example.hubspoke.docker-compose.yml](https://github.com/Starosdev/scrutiny/blob/master/docker/example.hubspoke.docker-compose.yml)
 for a docker-compose file.
 
 > The following guide was contributed by @TinJoy59 in #417
@@ -37,14 +37,14 @@ is triggered every 30min to collect data on the drives. The data is sent to the 
 The Hub consists of Scrutiny Web - a web interface for viewing the SMART data. And InfluxDB, where the smartmon data is
 stored.
 
-[🔗This is the official Hub-Spoke layout in docker-compose.](https://github.com/AnalogJ/scrutiny/blob/master/docker/example.hubspoke.docker-compose.yml)
+[🔗This is the official Hub-Spoke layout in docker-compose.](https://github.com/Starosdev/scrutiny/blob/master/docker/example.hubspoke.docker-compose.yml)
 We are going to reuse parts of it. The ENV variables provide the necessary configuration for the initial setup, both for
 InfluxDB and Scrutiny.
 
 If you are working with and existing InfluxDB instance, you can forgo all the `INIT` variables as they already exist.
 
 The official Scrutiny documentation has a
-sample [scrutiny.yaml ](https://github.com/AnalogJ/scrutiny/blob/master/example.scrutiny.yaml)file that normally
+sample [scrutiny.yaml ](https://github.com/Starosdev/scrutiny/blob/master/example.scrutiny.yaml)file that normally
 contains the connection and notification details but I always find it easier to configure as much as possible in the
 docker-compose.
 
@@ -109,7 +109,7 @@ empty because no metrics have been collected yet.
 
 A spoke consists of the Scrutiny Collector binary that is run on a set interval via crontab and sends the data to the
 Hub. The official
-documentation [describes the manual setup of the Collector](https://github.com/AnalogJ/scrutiny/blob/master/docs/INSTALL_MANUAL.md#collector)
+documentation [describes the manual setup of the Collector](https://github.com/Starosdev/scrutiny/blob/master/docs/INSTALL_MANUAL.md#collector)
 - dependencies and step by step commands. I have a shortened version that does the same thing but in one line of code.
 
 ```bash
@@ -121,7 +121,7 @@ apt install smartmontools -y
 # 3. Make it exacutable
 # 4. List the contents of the library for confirmation
 mkdir -p /opt/scrutiny/bin && \
-curl -L https://github.com/AnalogJ/scrutiny/releases/download/v0.8.1/scrutiny-collector-metrics-linux-amd64 > /opt/scrutiny/bin/scrutiny-collector-metrics-linux-amd64 && \
+curl -L https://github.com/Starosdev/scrutiny/releases/latest/download/scrutiny-collector-metrics-linux-amd64 > /opt/scrutiny/bin/scrutiny-collector-metrics-linux-amd64 && \
 chmod +x /opt/scrutiny/bin/scrutiny-collector-metrics-linux-amd64 && \
 ls -lha /opt/scrutiny/bin
 ```
@@ -149,14 +149,14 @@ crontab -e
 
 The Collector has its own independent config file that lives in `/opt/scrutiny/config/collector.yaml` but I did not find
 a need to modify
-it. [A default collector.yaml can be found in the official documentation.](https://github.com/AnalogJ/scrutiny/blob/master/example.collector.yaml)
+it. [A default collector.yaml can be found in the official documentation.](https://github.com/Starosdev/scrutiny/blob/master/example.collector.yaml)
 
 ## Setting up a Spoke ***with*** Docker
 
 ![drawing-3-1671744277](https://user-images.githubusercontent.com/86809766/209230176-87c9e55a-4e3e-4f5f-9609-335d41529f3d.png)
 
 Setting up a remote Spoke in Docker requires you to split
-the [official Hub-Spoke layout docker-compose.yml](https://github.com/AnalogJ/scrutiny/blob/master/docker/example.hubspoke.docker-compose.yml)
+the [official Hub-Spoke layout docker-compose.yml](https://github.com/Starosdev/scrutiny/blob/master/docker/example.hubspoke.docker-compose.yml)
 . In the following docker-compose you need to provide the `${API_ENDPOINT}`, in my case `http://192.168.0.100:8080`.
 Also all drives that you wish to monitor need to be presented to the container under `devices`.
 

--- a/docs/INSTALL_MANUAL.md
+++ b/docs/INSTALL_MANUAL.md
@@ -1,6 +1,6 @@
 # Manual Install
 
-While the easiest way to get started with [Scrutiny is using Docker](https://github.com/AnalogJ/scrutiny#docker),
+While the easiest way to get started with [Scrutiny is using Docker](https://github.com/Starosdev/scrutiny#docker),
 it is possible to run it manually without much work. You can even mix and match, using Docker for one component and
 a manual installation for the other. There's also [an installer](INSTALL_ANSIBLE.md) which automates this manual installation procedure.
 

--- a/docs/INSTALL_MANUAL_WINDOWS.md
+++ b/docs/INSTALL_MANUAL_WINDOWS.md
@@ -5,18 +5,18 @@ This guide is specifically for people who are on a Windows machine using [WSL](h
 Scrutiny is made up of three components: an influxdb Database, a collector and a webapp/api. Docker will be used for
 the influxdb and webapp/API, the collector component will be facilitated by [Windows Task Scheduler](https://learn.microsoft.com/en-us/windows/win32/taskschd/task-scheduler-start-page).
 
-> **NOTE:** If you are **NOT** using WSL with docker, then the easiest way to get started with [Scrutiny is the omnibus Docker image](https://github.com/AnalogJ/scrutiny#docker).
+> **NOTE:** If you are **NOT** using WSL with docker, then the easiest way to get started with [Scrutiny is the omnibus Docker image](https://github.com/Starosdev/scrutiny#docker).
 
 ## InfluxDB and Webapp/API (Docker)
 
-1. Copy the [example.hubspoke.docker-compose.yml](https://github.com/AnalogJ/scrutiny/blob/master/docker/example.hubspoke.docker-compose.yml) 
+1. Copy the [example.hubspoke.docker-compose.yml](https://github.com/Starosdev/scrutiny/blob/master/docker/example.hubspoke.docker-compose.yml) 
 file and delete the collector section near the bottom of the file.
 2. Run `docker-compose up -d` to verify that the DB and webapp are working correctly and once its completed, your webapp
 should be up and running but the dashboard will be empty (default location is `localhost:8080`)
 
 ## Collector (Windows Task Scheduler)
 
-1. Download the latest `scrutiny-collector-metrics-windows-amd64.exe` from the [releases page](https://github.com/AnalogJ/scrutiny/releases) (under assets)
+1. Download the latest `scrutiny-collector-metrics-windows-amd64.exe` from the [releases page](https://github.com/Starosdev/scrutiny/releases) (under assets)
 2. On your windows host, open [Windows Task Scheduler](https://www.wikihow.com/Open-Task-Scheduler-in-Windows-10) as **Administrator**
    1. In the **Start Menu** (Windows key), type `Task Scheduler` and then right click `Run as Administrator` to open
 3. On the status bar (under the `action` tab), click `Create Task...`
@@ -40,7 +40,7 @@ should be up and running but the dashboard will be empty (default location is `l
          > **NOTE:** 
          > * Make sure that you put the correct port number (as specified in the docker-compose file) for the webapp (default is `8080`)
          > * The `--config` param is optional and is not needed if you just want to use the default collector config, see 
-      [example.collector.yaml](https://github.com/AnalogJ/scrutiny/blob/master/example.collector.yaml) for more info on the collector config.
+      [example.collector.yaml](https://github.com/Starosdev/scrutiny/blob/master/example.collector.yaml) for more info on the collector config.
       3. In the **Start in (optional)** field, put: FOLDER_PATH_TO_YOUR `scrutiny-collector-metrics-windows-amd64.exe` file
           > **NOTE:** Must be exact and do not include `scrutiny-collector-metrics-windows-amd64.exe` in the path
       4. Click Ok when finished

--- a/docs/INSTALL_NAS.md
+++ b/docs/INSTALL_NAS.md
@@ -1,1 +1,0 @@
-package docs

--- a/docs/INSTALL_PFSENSE.md
+++ b/docs/INSTALL_PFSENSE.md
@@ -1,6 +1,6 @@
 # pfsense Install
 
-This bascially follows the [Manual collector instructions](https://github.com/AnalogJ/scrutiny/blob/master/docs/INSTALL_MANUAL.md#collector) and assumes you are running a hub and spoke deployment and already have the web app setup.
+This bascially follows the [Manual collector instructions](https://github.com/Starosdev/scrutiny/blob/master/docs/INSTALL_MANUAL.md#collector) and assumes you are running a hub and spoke deployment and already have the web app setup.
 
 
 ### Dependencies
@@ -30,7 +30,7 @@ Next, we'll download the Scrutiny collector binary from the [latest Github relea
 > NOTE: Ensure you have the latest version in the below command
 
 ```
-fetch -o /opt/scrutiny/bin https://github.com/AnalogJ/scrutiny/releases/download/vX.X.X/scrutiny-collector-metrics-freebsd-amd64
+fetch -o /opt/scrutiny/bin https://github.com/Starosdev/scrutiny/releases/download/vX.X.X/scrutiny-collector-metrics-freebsd-amd64
 ```
 
 

--- a/docs/INSTALL_SYNOLOGY_COLLECTOR.md
+++ b/docs/INSTALL_SYNOLOGY_COLLECTOR.md
@@ -37,7 +37,7 @@ mkdir -p /volume1/\@Entware/scrutiny/conf
 
 **6. Download the collector binary for your architecture and make it executable**
 
-`wget https://github.com/AnalogJ/scrutiny/releases/download/v0.4.12/scrutiny-collector-metrics-linux-arm64`
+`wget https://github.com/Starosdev/scrutiny/releases/download/v0.4.12/scrutiny-collector-metrics-linux-arm64`
 
 `chmod +x /volume1/\@Entware/scrutiny/bin/scrutiny-collector-metrics-linux-arm64`
 
@@ -45,7 +45,7 @@ mkdir -p /volume1/\@Entware/scrutiny/conf
 
 ```
 cd /volume1/\@Entware/scrutiny/conf
-wget https://raw.githubusercontent.com/AnalogJ/scrutiny/master/example.collector.yaml
+wget https://raw.githubusercontent.com/Starosdev/scrutiny/master/example.collector.yaml
 mv example.collector.yaml collector.yaml
 ```
 

--- a/docs/TESTERS.md
+++ b/docs/TESTERS.md
@@ -4,7 +4,7 @@ Scrutiny supports many operating systems, CPU architectures and runtime environm
 difficult to test. 
 Thankfully the following users have been gracious enough to test/validate Scrutiny works on their system.
 
-> NOTE: If you're interested in volunteering to test Scrutiny beta builds on your system, please [open an issue](https://github.com/AnalogJ/scrutiny/issues). 
+> NOTE: If you're interested in volunteering to test Scrutiny beta builds on your system, please [open an issue](https://github.com/Starosdev/scrutiny/issues). 
 
 | Architecture Name | Binaries | Docker |
 | --- | --- | --- |

--- a/docs/TROUBLESHOOTING_DEVICE_COLLECTOR.md
+++ b/docs/TROUBLESHOOTING_DEVICE_COLLECTOR.md
@@ -71,7 +71,7 @@ If the output is the same, your devices will be processed by Scrutiny.
 In some cases `--scan` does not correctly detect the device type, returning [incomplete SMART data](https://github.com/AnalogJ/scrutiny/issues/45).
 Scrutiny will supports overriding the detected device type via the config file.
 
-[example.collector.yaml](https://github.com/AnalogJ/scrutiny/blob/master/example.collector.yaml)
+[example.collector.yaml](https://github.com/Starosdev/scrutiny/blob/master/example.collector.yaml)
 
 ### RAID Controllers (Megaraid/3ware/HBA/Adaptec/HPE/etc)
 Smartctl has support for a large number of [RAID controllers](https://www.smartmontools.org/wiki/Supported_RAID-Controllers), however this 
@@ -277,7 +277,7 @@ If this is effecting your drives, you'll need to do the following:
 
 1. Upgrade to v0.4.13+
 2. Reset your drive status using the SQLite script
-   in [#device-failed-but-smart--scrutiny-passed](https://github.com/AnalogJ/scrutiny/blob/master/docs/TROUBLESHOOTING_DEVICE_COLLECTOR.md#device-failed-but-smart--scrutiny-passed)
+   in [#device-failed-but-smart--scrutiny-passed](https://github.com/Starosdev/scrutiny/blob/master/docs/TROUBLESHOOTING_DEVICE_COLLECTOR.md#device-failed-but-smart--scrutiny-passed)
 3. Wait for (or manually start) the collector.
 
 If you'd like to learn more about how the Seagate Ironwolf SMART attributes work under the hood, and how they differ
@@ -309,9 +309,9 @@ The host-id is passed from the collector to the web-api when SMART device data i
 the host-id:
 
 - using the collector config
-  file: [master/example.collector.yaml#L19-L22](https://github.com/AnalogJ/scrutiny/blob/master/example.collector.yaml?rgh-link-date=2022-05-25T15%3A08%3A56Z#L19-L22)
+  file: [master/example.collector.yaml#L19-L22](https://github.com/Starosdev/scrutiny/blob/master/example.collector.yaml#L19-L22)
 - using the `--host-id` collector CLI
-  argument: [master/collector/cmd/collector-metrics/collector-metrics.go#L180-L185](https://github.com/AnalogJ/scrutiny/blob/master/collector/cmd/collector-metrics/collector-metrics.go?rgh-link-date=2022-05-25T15%3A08%3A56Z#L180-L185)
+  argument: [master/collector/cmd/collector-metrics/collector-metrics.go#L180-L185](https://github.com/Starosdev/scrutiny/blob/master/collector/cmd/collector-metrics/collector-metrics.go#L180-L185)
 - using the `COLLECTOR_HOST_ID` environmental variable.
 
 See the [docs/INSTALL_HUB_SPOKE.md](/docs/INSTALL_HUB_SPOKE.md) guide for more information.

--- a/docs/TROUBLESHOOTING_DOCKER.md
+++ b/docs/TROUBLESHOOTING_DOCKER.md
@@ -3,7 +3,7 @@
 > TL;DR; The `master-omnibus` and `latest` tags are almost semantically identical, as I follow a `golden master` 
 development process. However if you want to ensure you're only using the latest release, you can change to `latest`
 
-The CI script used to orchestrate the docker image builds can be found here: https://github.com/AnalogJ/scrutiny/blob/master/.github/workflows/docker-build.yaml#L166-L184
+The CI script used to orchestrate the docker image builds can be found here: https://github.com/Starosdev/scrutiny/blob/master/.github/workflows/docker-build.yaml#L166-L184
 
 In general Scrutiny follows a `golden master` development process, which means that the `master` branch is not directly updated (unless its for documentation changes), 
 instead development is done in a feature branch, or committed to the `beta` branch. 

--- a/docs/TROUBLESHOOTING_INFLUXDB.md
+++ b/docs/TROUBLESHOOTING_INFLUXDB.md
@@ -116,8 +116,8 @@ this usually related to either:
 
 Here's a couple of confirmed working docker-compose files that you may want to look at:
 
-- https://github.com/AnalogJ/scrutiny/blob/master/docker/example.hubspoke.docker-compose.yml
-- https://github.com/AnalogJ/scrutiny/blob/master/docker/example.omnibus.docker-compose.yml
+- https://github.com/Starosdev/scrutiny/blob/master/docker/example.hubspoke.docker-compose.yml
+- https://github.com/Starosdev/scrutiny/blob/master/docker/example.omnibus.docker-compose.yml
 
 ## Bring your own InfluxDB
 
@@ -424,7 +424,7 @@ done, you can start the Scrutiny server
 ## Customize InfluxDB Admin Username & Password
 
 The full set of InfluxDB configuration options are available
-in [code](https://github.com/AnalogJ/scrutiny/blob/master/webapp/backend/pkg/config/config.go?rgh-link-date=2023-01-19T16%3A23%3A40Z#L49-L51)
+in [code](https://github.com/Starosdev/scrutiny/blob/master/webapp/backend/pkg/config/config.go#L49-L51)
 .
 
 During first startup Scrutiny will connect to the unprotected InfluxDB server, start the setup process (via API) using a

--- a/docs/TROUBLESHOOTING_NOTIFICATIONS.md
+++ b/docs/TROUBLESHOOTING_NOTIFICATIONS.md
@@ -1,6 +1,6 @@
 # Notifications
 
-As documented in [example.scrutiny.yaml](https://github.com/AnalogJ/scrutiny/blob/master/example.scrutiny.yaml#L59-L75)
+As documented in [example.scrutiny.yaml](https://github.com/Starosdev/scrutiny/blob/master/example.scrutiny.yaml#L59-L75)
 there are multiple ways to configure notifications for Scrutiny.
 
 Under the hood we use a library called [Shoutrrr](https://github.com/nicholas-fedor/shoutrrr) to send our notifications, and you should use their documentation if you run into

--- a/webapp/frontend/README.md
+++ b/webapp/frontend/README.md
@@ -1,25 +1,32 @@
-# Treo - Admin template and Starter project for Angular
+# Scrutiny Frontend
+
+Angular 21 application for the Scrutiny Hard Drive Health Dashboard.
 
 ## Development server
 
-Run `ng serve` for a dev server. Navigate to `http://localhost:4200/`. The app will automatically reload if you change any of the source files.
+```bash
+npm install --legacy-peer-deps
+npm run start -- --serve-path="/web/" --port 4200
+```
 
-## Code scaffolding
-
-Run `ng generate component component-name` to generate a new component. You can also use `ng generate directive|pipe|service|class|guard|interface|enum|module`.
+Navigate to `http://localhost:4200/web/`. The app will automatically reload on source file changes.
 
 ## Build
 
-Run `ng build` to build the project. The build artifacts will be stored in the `dist/` directory. Use the `--prod` flag for a production build.
+```bash
+npm run build:prod -- --output-path=../../dist
+```
 
 ## Running unit tests
 
-Run `ng test` to execute the unit tests via [Karma](https://karma-runner.github.io).
+```bash
+npm test -- --watch=false                             # Run tests once
+npm test -- --watch=false --browsers=ChromeHeadless   # Headless CI mode
+npx ng test --watch=false --code-coverage             # Run with coverage
+```
 
-## Running end-to-end tests
+## Linting
 
-Run `ng e2e` to execute the end-to-end tests via [Protractor](http://www.protractortest.org/).
-
-## Further help
-
-To get more help on the Angular CLI use `ng help` or go check out the [Angular CLI README](https://github.com/angular/angular-cli/blob/master/README.md).
+```bash
+npm run lint
+```


### PR DESCRIPTION
## Summary

- Update Go version references from 1.20 to 1.25 in CONTRIBUTING.md and DEPENDENCIES.md
- Update Angular version from "Modern Angular" to "Angular 21" in README.md comparison table
- Rewrite webapp/frontend/README.md with Scrutiny-specific content (was generic Treo template with deprecated Protractor and --prod flag references)
- Update AnalogJ/scrutiny code/file/release links to Starosdev/scrutiny across 10 documentation files (issue discussion links kept for historical context)
- Delete docs/INSTALL_NAS.md stub file (13 bytes, invalid content; SUPPORTED_NAS_OS.md serves as NAS install hub)
- Update deprecated --prod flag reference in CONTRIBUTING.md

## Linked Issues

Closes #304

## Test plan

- [x] Verified no stale Go version references remain (only CHANGELOG.md historical entries and DEPENDENCIES.md shoutrrr note)
- [x] Verified no stale Angular 13 references remain (only README.md original-project column and CHANGELOG.md)
- [x] Verified only AnalogJ issue discussion links remain in docs/ (all code/file/release links updated)
- [x] Verified PLANNING.md deleted (untracked, local only) and docs/INSTALL_NAS.md deleted
- [x] Verified webapp/frontend/README.md reads correctly with Scrutiny-specific content