### PR TITLE
feat(notifications): add cooldown, quiet hours, rate limiting, and per-device overrides (#255)

### DIFF
--- a/webapp/backend/pkg/database/interface.go
+++ b/webapp/backend/pkg/database/interface.go
@@ -41,6 +41,7 @@ type DeviceRepo interface {
 	UpdateDeviceLabel(ctx context.Context, wwn string, label string) error
 	UpdateDeviceSmartDisplayMode(ctx context.Context, wwn string, mode string) error
 	UpdateDeviceHasForcedFailure(ctx context.Context, wwn string, hasForcedFailure bool) error
+	UpdateDeviceMissedPingTimeout(ctx context.Context, wwn string, timeoutMinutes int) error
 	DeleteDevice(ctx context.Context, wwn string) error
 	// RecalculateDeviceStatusFromHistory re-evaluates device status from stored SMART data
 	// with current overrides applied. Used when overrides are added/modified/deleted.

--- a/webapp/backend/pkg/database/migrations/m20260301000000/device.go
+++ b/webapp/backend/pkg/database/migrations/m20260301000000/device.go
@@ -1,0 +1,38 @@
+package m20260301000000
+
+import (
+	"github.com/analogj/scrutiny/webapp/backend/pkg"
+	"time"
+)
+
+type Device struct {
+	CreatedAt                 time.Time
+	UpdatedAt                 time.Time
+	DeletedAt                 *time.Time
+	FormFactor                string           `json:"form_factor"`
+	DeviceType                string           `json:"device_type"`
+	DeviceUUID                string           `json:"device_uuid"`
+	DeviceSerialID            string           `json:"device_serial_id"`
+	DeviceLabel               string           `json:"device_label"`
+	Manufacturer              string           `json:"manufacturer"`
+	ModelName                 string           `json:"model_name"`
+	InterfaceType             string           `json:"interface_type"`
+	InterfaceSpeed            string           `json:"interface_speed"`
+	SerialNumber              string           `json:"serial_number"`
+	Firmware                  string           `json:"firmware"`
+	WWN                       string           `json:"wwn" gorm:"primary_key"`
+	DeviceProtocol            string           `json:"device_protocol"`
+	DeviceName                string           `json:"device_name"`
+	Label                     string           `json:"label"`
+	HostId                    string           `json:"host_id"`
+	CollectorVersion          string           `json:"collector_version"`
+	SmartDisplayMode          string           `json:"smart_display_mode" gorm:"default:'scrutiny'"`
+	Capacity                  int64            `json:"capacity"`
+	RotationSpeed             int              `json:"rotational_speed"`
+	MissedPingTimeoutOverride int              `json:"missed_ping_timeout_override" gorm:"default:0"`
+	DeviceStatus              pkg.DeviceStatus `json:"device_status"`
+	Archived                  bool             `json:"archived"`
+	Muted                     bool             `json:"muted"`
+	SmartSupport              bool             `json:"smart_support"`
+	HasForcedFailure          bool             `json:"has_forced_failure" gorm:"default:false"`
+}

--- a/webapp/backend/pkg/database/mock/mock_database.go
+++ b/webapp/backend/pkg/database/mock/mock_database.go
@@ -625,6 +625,20 @@ func (mr *MockDeviceRepoMockRecorder) UpdateDeviceHasForcedFailure(ctx, wwn, has
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDeviceHasForcedFailure", reflect.TypeOf((*MockDeviceRepo)(nil).UpdateDeviceHasForcedFailure), ctx, wwn, hasForcedFailure)
 }
 
+// UpdateDeviceMissedPingTimeout mocks base method.
+func (m *MockDeviceRepo) UpdateDeviceMissedPingTimeout(ctx context.Context, wwn string, timeoutMinutes int) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateDeviceMissedPingTimeout", ctx, wwn, timeoutMinutes)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateDeviceMissedPingTimeout indicates an expected call of UpdateDeviceMissedPingTimeout.
+func (mr *MockDeviceRepoMockRecorder) UpdateDeviceMissedPingTimeout(ctx, wwn, timeoutMinutes interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDeviceMissedPingTimeout", reflect.TypeOf((*MockDeviceRepo)(nil).UpdateDeviceMissedPingTimeout), ctx, wwn, timeoutMinutes)
+}
+
 // UpdateDeviceLabel mocks base method.
 func (m *MockDeviceRepo) UpdateDeviceLabel(ctx context.Context, wwn, label string) error {
 	m.ctrl.T.Helper()

--- a/webapp/backend/pkg/database/scrutiny_repository_device.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_device.go
@@ -246,6 +246,16 @@ func (sr *scrutinyRepository) UpdateDeviceHasForcedFailure(ctx context.Context, 
 	return sr.gormClient.WithContext(ctx).Model(&models.Device{}).Where("wwn = ?", wwn).Update("has_forced_failure", hasForcedFailure).Error
 }
 
+// Update Device Missed Ping Timeout Override (0 = use global setting)
+func (sr *scrutinyRepository) UpdateDeviceMissedPingTimeout(ctx context.Context, wwn string, timeoutMinutes int) error {
+	var device models.Device
+	if err := sr.gormClient.WithContext(ctx).Where("wwn = ?", wwn).First(&device).Error; err != nil {
+		return fmt.Errorf("could not get device from DB: %v", err)
+	}
+
+	return sr.gormClient.Model(&device).Where("wwn = ?", wwn).Update("missed_ping_timeout_override", timeoutMinutes).Error
+}
+
 func (sr *scrutinyRepository) DeleteDevice(ctx context.Context, wwn string) error {
 	// Validate WWN format before using in delete predicate (defense-in-depth, DeleteAPI doesn't support params)
 	if err := validation.ValidateWWN(wwn); err != nil {

--- a/webapp/backend/pkg/database/scrutiny_repository_migrations.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_migrations.go
@@ -22,6 +22,7 @@ import (
 	"github.com/analogj/scrutiny/webapp/backend/pkg/database/migrations/m20260202000000"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/database/migrations/m20260225000000"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/database/migrations/m20260226000000"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/database/migrations/m20260301000000"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/models"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/models/collector"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/models/measurements"
@@ -635,6 +636,44 @@ func (sr *scrutinyRepository) Migrate(ctx context.Context) error {
 			ID: "m20260226000000", // add notify_urls table for UI-configurable notification endpoints
 			Migrate: func(tx *gorm.DB) error {
 				return tx.AutoMigrate(&m20260226000000.NotifyUrl{})
+			},
+		},
+		{
+			ID: "m20260301000000", // add notification cooldown, quiet hours, and per-device timeout override
+			Migrate: func(tx *gorm.DB) error {
+				// Add missed_ping_timeout_override column to devices table
+				if err := tx.AutoMigrate(m20260301000000.Device{}); err != nil {
+					return err
+				}
+
+				// Add notification cooldown, rate limiting, and quiet hours settings
+				var defaultSettings = []m20220716214900.Setting{
+					{
+						SettingKeyName:        "metrics.missed_ping_cooldown_minutes",
+						SettingKeyDescription: "Minutes between repeated missed ping notifications for the same device (0 = use timeout value)",
+						SettingDataType:       "numeric",
+						SettingValueNumeric:   0,
+					},
+					{
+						SettingKeyName:        "metrics.notification_rate_limit",
+						SettingKeyDescription: "Maximum notifications per hour across all types (0 = unlimited)",
+						SettingDataType:       "numeric",
+						SettingValueNumeric:   0,
+					},
+					{
+						SettingKeyName:        "metrics.notification_quiet_start",
+						SettingKeyDescription: "Time to stop sending notifications in HH:MM 24h format (empty = disabled)",
+						SettingDataType:       "string",
+						SettingValueString:    "",
+					},
+					{
+						SettingKeyName:        "metrics.notification_quiet_end",
+						SettingKeyDescription: "Time to resume sending notifications in HH:MM 24h format (empty = disabled)",
+						SettingDataType:       "string",
+						SettingValueString:    "",
+					},
+				}
+				return tx.Create(&defaultSettings).Error
 			},
 		},
 	})

--- a/webapp/backend/pkg/models/device.go
+++ b/webapp/backend/pkg/models/device.go
@@ -48,7 +48,8 @@ type Device struct {
 
 	// Data set by Scrutiny
 	DeviceStatus     pkg.DeviceStatus `json:"device_status"`
-	HasForcedFailure bool             `json:"has_forced_failure" gorm:"default:false"` // True when override with action=force_status, status=failed is applied
+	HasForcedFailure          bool             `json:"has_forced_failure" gorm:"default:false"` // True when override with action=force_status, status=failed is applied
+	MissedPingTimeoutOverride int              `json:"missed_ping_timeout_override" gorm:"default:0"` // Per-device override for missed ping timeout (0 = use global)
 }
 
 func (dv *Device) IsAta() bool {

--- a/webapp/backend/pkg/models/settings.go
+++ b/webapp/backend/pkg/models/settings.go
@@ -32,6 +32,14 @@ type Settings struct {
 		MissedPingTimeoutMinutes    int  `json:"missed_ping_timeout_minutes" mapstructure:"missed_ping_timeout_minutes"`
 		MissedPingCheckIntervalMins int  `json:"missed_ping_check_interval_mins" mapstructure:"missed_ping_check_interval_mins"`
 
+		// Notification cooldown / rate limiting
+		MissedPingCooldownMinutes int `json:"missed_ping_cooldown_minutes" mapstructure:"missed_ping_cooldown_minutes"`
+		NotificationRateLimit     int `json:"notification_rate_limit" mapstructure:"notification_rate_limit"`
+
+		// Quiet hours
+		NotificationQuietStart string `json:"notification_quiet_start" mapstructure:"notification_quiet_start"`
+		NotificationQuietEnd   string `json:"notification_quiet_end" mapstructure:"notification_quiet_end"`
+
 		// Heartbeat notification settings
 		HeartbeatEnabled       bool `json:"heartbeat_enabled" mapstructure:"heartbeat_enabled"`
 		HeartbeatIntervalHours int  `json:"heartbeat_interval_hours" mapstructure:"heartbeat_interval_hours"`

--- a/webapp/backend/pkg/notify/gate.go
+++ b/webapp/backend/pkg/notify/gate.go
@@ -1,0 +1,218 @@
+package notify
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/analogj/scrutiny/webapp/backend/pkg/models"
+	"github.com/sirupsen/logrus"
+)
+
+// NotificationGate centralizes rate limiting, cooldown, and quiet hours logic.
+// All notification dispatch should pass through Gate.TrySend() instead of
+// directly calling Notify.Send().
+type NotificationGate struct {
+	logger         logrus.FieldLogger
+	sentTimestamps []time.Time          // sliding window for rate limiting
+	quietQueue     []QueuedNotification // queued during quiet hours
+	mu             sync.Mutex
+}
+
+// QueuedNotification holds a notification that was deferred during quiet hours.
+type QueuedNotification struct {
+	QueuedAt time.Time
+	Subject  string
+	Message  string
+}
+
+// NewNotificationGate creates a new gate instance. Should be created once
+// in AppEngine and shared across all notification paths.
+func NewNotificationGate(logger logrus.FieldLogger) *NotificationGate {
+	return &NotificationGate{
+		logger: logger,
+	}
+}
+
+// TrySend checks rate limiting and quiet hours before dispatching a notification.
+// If quiet hours are active, the notification summary is queued for digest delivery.
+// If rate limit is exceeded, the notification is dropped (logged).
+// If bypassQuietHours is true, quiet hours are ignored (used for heartbeats).
+// Returns true if sent or queued, false if dropped.
+func (g *NotificationGate) TrySend(n *Notify, settings *models.Settings, bypassQuietHours bool) bool {
+	if !bypassQuietHours && g.isQuietHours(settings) {
+		subject := n.Payload.Subject
+		message := n.Payload.Message
+		g.mu.Lock()
+		g.quietQueue = append(g.quietQueue, QueuedNotification{
+			Subject:  subject,
+			Message:  message,
+			QueuedAt: time.Now(),
+		})
+		g.mu.Unlock()
+		g.logger.Infof("Notification queued during quiet hours: %s", subject)
+		return true
+	}
+
+	if g.isRateLimited(settings) {
+		g.logger.Warnf("Notification dropped due to rate limit (%d/hour): %s",
+			settings.Metrics.NotificationRateLimit, n.Payload.Subject)
+		return false
+	}
+
+	if err := n.Send(); err != nil {
+		g.logger.Warnf("Failed to send notification: %v", err)
+		return false
+	}
+
+	g.recordSent()
+	return true
+}
+
+// FlushQuietQueue checks if quiet hours have ended and sends a digest of all
+// queued notifications. Should be called periodically (e.g., at the start of
+// each missed ping check cycle).
+func (g *NotificationGate) FlushQuietQueue(n *Notify, settings *models.Settings) {
+	if g.isQuietHours(settings) {
+		return
+	}
+
+	g.mu.Lock()
+	if len(g.quietQueue) == 0 {
+		g.mu.Unlock()
+		return
+	}
+	queued := make([]QueuedNotification, len(g.quietQueue))
+	copy(queued, g.quietQueue)
+	g.quietQueue = nil
+	g.mu.Unlock()
+
+	subject := fmt.Sprintf("Scrutiny: %d notification(s) during quiet hours", len(queued))
+	var parts []string
+	parts = append(parts,
+		fmt.Sprintf("The following %d notification(s) were queued during quiet hours:", len(queued)),
+		"",
+	)
+	for _, q := range queued {
+		parts = append(parts, fmt.Sprintf("  [%s] %s", q.QueuedAt.Format("15:04"), q.Subject))
+		if q.Message != "" {
+			// Include first line of message for context
+			lines := strings.SplitN(q.Message, "\n", 2)
+			parts = append(parts, fmt.Sprintf("    %s", lines[0]))
+		}
+		parts = append(parts, "")
+	}
+
+	n.Payload = Payload{
+		FailureType: NotifyFailureTypeMissedPing,
+		Subject:     subject,
+		Message:     strings.Join(parts, "\n"),
+	}
+
+	if g.isRateLimited(settings) {
+		g.logger.Warnf("Quiet hours digest dropped due to rate limit")
+		return
+	}
+
+	if err := n.Send(); err != nil {
+		g.logger.Warnf("Failed to send quiet hours digest: %v", err)
+		return
+	}
+	g.recordSent()
+	g.logger.Infof("Sent quiet hours digest with %d queued notification(s)", len(queued))
+}
+
+// isQuietHours checks if the current time falls within the configured quiet window.
+// Returns false if quiet hours are not configured (empty strings).
+func (g *NotificationGate) isQuietHours(settings *models.Settings) bool {
+	startStr := settings.Metrics.NotificationQuietStart
+	endStr := settings.Metrics.NotificationQuietEnd
+
+	if startStr == "" || endStr == "" {
+		return false
+	}
+
+	start, err := parseTimeOfDay(startStr)
+	if err != nil {
+		g.logger.Warnf("Invalid notification_quiet_start '%s': %v", startStr, err)
+		return false
+	}
+	end, err := parseTimeOfDay(endStr)
+	if err != nil {
+		g.logger.Warnf("Invalid notification_quiet_end '%s': %v", endStr, err)
+		return false
+	}
+
+	now := time.Now()
+	nowMinutes := now.Hour()*60 + now.Minute()
+
+	if start <= end {
+		// Same-day window (e.g., 08:00-17:00)
+		return nowMinutes >= start && nowMinutes < end
+	}
+	// Overnight window (e.g., 22:00-07:00)
+	return nowMinutes >= start || nowMinutes < end
+}
+
+// isRateLimited checks if sending another notification would exceed the hourly limit.
+// Returns false if rate limiting is disabled (limit == 0).
+func (g *NotificationGate) isRateLimited(settings *models.Settings) bool {
+	limit := settings.Metrics.NotificationRateLimit
+	if limit <= 0 {
+		return false
+	}
+
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	g.pruneOldTimestamps()
+	return len(g.sentTimestamps) >= limit
+}
+
+// recordSent adds the current time to the sliding window.
+func (g *NotificationGate) recordSent() {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.sentTimestamps = append(g.sentTimestamps, time.Now())
+}
+
+// pruneOldTimestamps removes entries older than 1 hour from the sliding window.
+// Must be called with g.mu held.
+func (g *NotificationGate) pruneOldTimestamps() {
+	cutoff := time.Now().Add(-1 * time.Hour)
+	n := 0
+	for _, ts := range g.sentTimestamps {
+		if ts.After(cutoff) {
+			g.sentTimestamps[n] = ts
+			n++
+		}
+	}
+	g.sentTimestamps = g.sentTimestamps[:n]
+}
+
+// parseTimeOfDay parses a "HH:MM" string and returns total minutes since midnight.
+func parseTimeOfDay(s string) (int, error) {
+	parts := strings.SplitN(s, ":", 2)
+	if len(parts) != 2 {
+		return 0, fmt.Errorf("expected HH:MM format, got %q", s)
+	}
+	var hour, min int
+	if _, err := fmt.Sscanf(parts[0], "%d", &hour); err != nil {
+		return 0, fmt.Errorf("invalid hour: %w", err)
+	}
+	if _, err := fmt.Sscanf(parts[1], "%d", &min); err != nil {
+		return 0, fmt.Errorf("invalid minute: %w", err)
+	}
+	if hour < 0 || hour > 23 || min < 0 || min > 59 {
+		return 0, fmt.Errorf("time out of range: %02d:%02d", hour, min)
+	}
+	return hour*60 + min, nil
+}
+
+// QueueLength returns the number of notifications currently queued during quiet hours.
+func (g *NotificationGate) QueueLength() int {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return len(g.quietQueue)
+}

--- a/webapp/backend/pkg/notify/gate_test.go
+++ b/webapp/backend/pkg/notify/gate_test.go
@@ -1,0 +1,222 @@
+package notify
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/analogj/scrutiny/webapp/backend/pkg/models"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseTimeOfDay_Valid(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input    string
+		expected int
+	}{
+		{"00:00", 0},
+		{"07:30", 450},
+		{"12:00", 720},
+		{"22:00", 1320},
+		{"23:59", 1439},
+	}
+
+	for _, tc := range tests {
+		result, err := parseTimeOfDay(tc.input)
+		require.NoError(t, err, "input: %s", tc.input)
+		require.Equal(t, tc.expected, result, "input: %s", tc.input)
+	}
+}
+
+func TestParseTimeOfDay_Invalid(t *testing.T) {
+	t.Parallel()
+
+	inputs := []string{"", "abc", "25:00", "12:60", "12", "-1:00"}
+	for _, input := range inputs {
+		_, err := parseTimeOfDay(input)
+		require.Error(t, err, "input: %s", input)
+	}
+}
+
+func TestGate_NoLimits_SendsImmediately(t *testing.T) {
+	t.Parallel()
+
+	gate := NewNotificationGate(logrus.NewEntry(logrus.StandardLogger()))
+	settings := &models.Settings{}
+	settings.Metrics.NotificationRateLimit = 0
+	settings.Metrics.NotificationQuietStart = ""
+	settings.Metrics.NotificationQuietEnd = ""
+
+	// Verify isQuietHours returns false when not configured
+	require.False(t, gate.isQuietHours(settings))
+
+	// Verify isRateLimited returns false when limit is 0
+	require.False(t, gate.isRateLimited(settings))
+}
+
+func TestGate_RateLimit_DropsWhenExceeded(t *testing.T) {
+	t.Parallel()
+
+	gate := NewNotificationGate(logrus.NewEntry(logrus.StandardLogger()))
+	settings := &models.Settings{}
+	settings.Metrics.NotificationRateLimit = 2
+
+	// Simulate 2 sent notifications
+	gate.mu.Lock()
+	gate.sentTimestamps = []time.Time{
+		time.Now().Add(-30 * time.Minute),
+		time.Now().Add(-10 * time.Minute),
+	}
+	gate.mu.Unlock()
+
+	require.True(t, gate.isRateLimited(settings))
+}
+
+func TestGate_RateLimit_SlidingWindowExpiry(t *testing.T) {
+	t.Parallel()
+
+	gate := NewNotificationGate(logrus.NewEntry(logrus.StandardLogger()))
+	settings := &models.Settings{}
+	settings.Metrics.NotificationRateLimit = 2
+
+	// Simulate 2 sent notifications, both older than 1 hour
+	gate.mu.Lock()
+	gate.sentTimestamps = []time.Time{
+		time.Now().Add(-2 * time.Hour),
+		time.Now().Add(-90 * time.Minute),
+	}
+	gate.mu.Unlock()
+
+	// Old timestamps should be pruned, so not rate limited
+	require.False(t, gate.isRateLimited(settings))
+}
+
+func TestGate_QuietHours_SameDayWindow(t *testing.T) {
+	t.Parallel()
+
+	gate := NewNotificationGate(logrus.NewEntry(logrus.StandardLogger()))
+
+	now := time.Now()
+	currentMinutes := now.Hour()*60 + now.Minute()
+
+	// Set quiet hours around the current time (current - 30min to current + 30min)
+	startMin := currentMinutes - 30
+	if startMin < 0 {
+		startMin += 1440
+	}
+	endMin := currentMinutes + 30
+	if endMin >= 1440 {
+		endMin -= 1440
+	}
+
+	settings := &models.Settings{}
+	settings.Metrics.NotificationQuietStart = minutesToHHMM(startMin)
+	settings.Metrics.NotificationQuietEnd = minutesToHHMM(endMin)
+
+	// Same-day window only works when start < end
+	if startMin < endMin {
+		require.True(t, gate.isQuietHours(settings))
+	}
+}
+
+func TestGate_QuietHours_OvernightSpan(t *testing.T) {
+	t.Parallel()
+
+	gate := NewNotificationGate(logrus.NewEntry(logrus.StandardLogger()))
+
+	now := time.Now()
+	currentMinutes := now.Hour()*60 + now.Minute()
+
+	// Overnight window: start after current time + 60 to end before current time - 60
+	// This means current time is NOT in quiet hours
+	startAfter := currentMinutes + 60
+	if startAfter >= 1440 {
+		startAfter -= 1440
+	}
+	endBefore := currentMinutes - 60
+	if endBefore < 0 {
+		endBefore += 1440
+	}
+
+	settings := &models.Settings{}
+	settings.Metrics.NotificationQuietStart = minutesToHHMM(startAfter)
+	settings.Metrics.NotificationQuietEnd = minutesToHHMM(endBefore)
+
+	// In overnight mode (start > end), quiet if now >= start OR now < end
+	// Since we set start = now+60 and end = now-60, now is NOT in quiet
+	if startAfter > endBefore {
+		require.False(t, gate.isQuietHours(settings))
+	}
+}
+
+func TestGate_QuietHours_Disabled(t *testing.T) {
+	t.Parallel()
+
+	gate := NewNotificationGate(logrus.NewEntry(logrus.StandardLogger()))
+
+	// Empty strings = disabled
+	settings := &models.Settings{}
+	settings.Metrics.NotificationQuietStart = ""
+	settings.Metrics.NotificationQuietEnd = ""
+	require.False(t, gate.isQuietHours(settings))
+
+	// Only start set = disabled
+	settings.Metrics.NotificationQuietStart = "22:00"
+	settings.Metrics.NotificationQuietEnd = ""
+	require.False(t, gate.isQuietHours(settings))
+
+	// Only end set = disabled
+	settings.Metrics.NotificationQuietStart = ""
+	settings.Metrics.NotificationQuietEnd = "07:00"
+	require.False(t, gate.isQuietHours(settings))
+}
+
+func TestGate_QueueLength(t *testing.T) {
+	t.Parallel()
+
+	gate := NewNotificationGate(logrus.NewEntry(logrus.StandardLogger()))
+	require.Equal(t, 0, gate.QueueLength())
+
+	gate.mu.Lock()
+	gate.quietQueue = append(gate.quietQueue, QueuedNotification{
+		Subject:  "Test",
+		Message:  "Message",
+		QueuedAt: time.Now(),
+	})
+	gate.mu.Unlock()
+
+	require.Equal(t, 1, gate.QueueLength())
+}
+
+func TestGate_PruneOldTimestamps(t *testing.T) {
+	t.Parallel()
+
+	gate := NewNotificationGate(logrus.NewEntry(logrus.StandardLogger()))
+
+	gate.mu.Lock()
+	gate.sentTimestamps = []time.Time{
+		time.Now().Add(-2 * time.Hour),   // should be pruned
+		time.Now().Add(-90 * time.Minute), // should be pruned
+		time.Now().Add(-30 * time.Minute), // should be kept
+		time.Now().Add(-5 * time.Minute),  // should be kept
+	}
+	gate.pruneOldTimestamps()
+	require.Equal(t, 2, len(gate.sentTimestamps))
+	gate.mu.Unlock()
+}
+
+// minutesToHHMM converts minutes since midnight to "HH:MM" format.
+func minutesToHHMM(minutes int) string {
+	if minutes < 0 {
+		minutes += 1440
+	}
+	if minutes >= 1440 {
+		minutes -= 1440
+	}
+	h := minutes / 60
+	m := minutes % 60
+	return fmt.Sprintf("%02d:%02d", h, m)
+}

--- a/webapp/backend/pkg/web/handler/update_device_missed_ping_timeout.go
+++ b/webapp/backend/pkg/web/handler/update_device_missed_ping_timeout.go
@@ -1,0 +1,47 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/analogj/scrutiny/webapp/backend/pkg/database"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/validation"
+	"github.com/gin-gonic/gin"
+	"github.com/sirupsen/logrus"
+)
+
+type missedPingTimeoutRequest struct {
+	MissedPingTimeoutOverride int `json:"missed_ping_timeout_override"`
+}
+
+func UpdateDeviceMissedPingTimeout(c *gin.Context) {
+	logger := c.MustGet("LOGGER").(*logrus.Entry)
+	deviceRepo := c.MustGet("DEVICE_REPOSITORY").(database.DeviceRepo)
+
+	wwn := c.Param("wwn")
+	if err := validation.ValidateWWN(wwn); err != nil {
+		logger.Warnf("Invalid WWN format: %s", wwn)
+		c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": err.Error()})
+		return
+	}
+
+	var req missedPingTimeoutRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		logger.Warnf("Invalid request body: %v", err)
+		c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": "invalid request body"})
+		return
+	}
+
+	if req.MissedPingTimeoutOverride < 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": "timeout must be >= 0"})
+		return
+	}
+
+	err := deviceRepo.UpdateDeviceMissedPingTimeout(c, wwn, req.MissedPingTimeoutOverride)
+	if err != nil {
+		logger.Errorln("An error occurred while updating device missed ping timeout", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"success": true})
+}

--- a/webapp/backend/pkg/web/handler/upload_device_metrics.go
+++ b/webapp/backend/pkg/web/handler/upload_device_metrics.go
@@ -109,8 +109,26 @@ func UploadDeviceMetrics(c *gin.Context) {
 			false,
 		)
 		liveNotify.LoadDatabaseUrls(c, deviceRepo)
-		if err := liveNotify.Send(); err != nil {
-			logger.Warnf("Failed to send notification for device %s: %v", wwn, err)
+
+		// Route through notification gate for rate limiting and quiet hours
+		if gateVal, exists := c.Get("NOTIFICATION_GATE"); exists {
+			if gate, ok := gateVal.(*notify.NotificationGate); ok {
+				settings, settingsErr := deviceRepo.LoadSettings(c)
+				if settingsErr != nil {
+					logger.Warnf("Failed to load settings for notification gate: %v", settingsErr)
+				}
+				if settings != nil {
+					gate.TrySend(&liveNotify, settings, false)
+				} else {
+					if sendErr := liveNotify.Send(); sendErr != nil {
+						logger.Warnf("Failed to send notification for device %s: %v", wwn, sendErr)
+					}
+				}
+			}
+		} else {
+			if sendErr := liveNotify.Send(); sendErr != nil {
+				logger.Warnf("Failed to send notification for device %s: %v", wwn, sendErr)
+			}
 		}
 	}
 

--- a/webapp/backend/pkg/web/heartbeat_monitor.go
+++ b/webapp/backend/pkg/web/heartbeat_monitor.go
@@ -261,13 +261,19 @@ func (m *HeartbeatMonitor) checkAndSendHeartbeat() {
 
 	notification := notify.NewHeartbeat(m.logger, m.appEngine.Config, monitoredCount, totalCount)
 	notification.LoadDatabaseUrls(m.ctx, m.deviceRepo)
-	if err := notification.Send(); err != nil {
-		if err.Error() == "no notification endpoints configured" {
-			m.logger.Warn("Heartbeat ready but no notification endpoints are configured. Configure notify.urls in scrutiny.yaml to receive heartbeat alerts.")
+
+	// Route through notification gate (bypass quiet hours -- heartbeats are informational)
+	if gate := m.appEngine.NotificationGate; gate != nil {
+		gate.TrySend(&notification, settings, true)
+	} else {
+		if err := notification.Send(); err != nil {
+			if err.Error() == "no notification endpoints configured" {
+				m.logger.Warn("Heartbeat ready but no notification endpoints are configured. Configure notify.urls in scrutiny.yaml to receive heartbeat alerts.")
+				return
+			}
+			m.logger.Errorf("Failed to send heartbeat notification: %v", err)
 			return
 		}
-		m.logger.Errorf("Failed to send heartbeat notification: %v", err)
-		return
 	}
 
 	m.logger.Info("Heartbeat notification sent successfully")

--- a/webapp/backend/pkg/web/middleware/notification_gate.go
+++ b/webapp/backend/pkg/web/middleware/notification_gate.go
@@ -1,0 +1,14 @@
+package middleware
+
+import (
+	"github.com/analogj/scrutiny/webapp/backend/pkg/notify"
+	"github.com/gin-gonic/gin"
+)
+
+// NotificationGateMiddleware injects the notification gate into the gin context
+func NotificationGateMiddleware(gate *notify.NotificationGate) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.Set("NOTIFICATION_GATE", gate)
+		c.Next()
+	}
+}

--- a/webapp/backend/pkg/web/missed_ping_monitor.go
+++ b/webapp/backend/pkg/web/missed_ping_monitor.go
@@ -185,10 +185,12 @@ func (m *MissedPingMonitor) getCheckInterval() time.Duration {
 
 // checkMissedPingsData holds the data needed to check for missed pings
 type checkMissedPingsData struct {
-	timeoutMinutes int
-	timeout        time.Duration
-	devices        []models.Device
-	lastSeenTimes  map[string]time.Time
+	timeoutMinutes  int
+	timeout         time.Duration
+	cooldownMinutes int // 0 = use timeoutMinutes for cooldown (backward compat)
+	settings        *models.Settings
+	devices         []models.Device
+	lastSeenTimes   map[string]time.Time
 }
 
 // loadCheckData loads all data needed for missed ping checks
@@ -229,13 +231,17 @@ func (m *MissedPingMonitor) loadCheckData() (*checkMissedPingsData, error) {
 		return nil, err
 	}
 
-	m.logger.Debugf("Loaded missed ping check data: %d devices, timeout=%dm", len(devices), timeoutMinutes)
+	cooldownMinutes := settings.Metrics.MissedPingCooldownMinutes
+
+	m.logger.Debugf("Loaded missed ping check data: %d devices, timeout=%dm, cooldown=%dm", len(devices), timeoutMinutes, cooldownMinutes)
 
 	return &checkMissedPingsData{
-		timeoutMinutes: timeoutMinutes,
-		timeout:        time.Duration(timeoutMinutes) * time.Minute,
-		devices:        devices,
-		lastSeenTimes:  lastSeenTimes,
+		timeoutMinutes:  timeoutMinutes,
+		timeout:         time.Duration(timeoutMinutes) * time.Minute,
+		cooldownMinutes: cooldownMinutes,
+		settings:        settings,
+		devices:         devices,
+		lastSeenTimes:   lastSeenTimes,
 	}, nil
 }
 
@@ -253,7 +259,14 @@ func (m *MissedPingMonitor) checkDevice(device *models.Device, data *checkMissed
 		return nil
 	}
 
-	if now.Sub(lastSeen) <= data.timeout {
+	// Use per-device timeout override if set, otherwise use global timeout
+	deviceTimeoutMinutes := data.timeoutMinutes
+	if device.MissedPingTimeoutOverride > 0 {
+		deviceTimeoutMinutes = device.MissedPingTimeoutOverride
+	}
+	deviceTimeout := time.Duration(deviceTimeoutMinutes) * time.Minute
+
+	if now.Sub(lastSeen) <= deviceTimeout {
 		m.clearNotificationState(device.WWN)
 		return nil
 	}
@@ -264,15 +277,20 @@ func (m *MissedPingMonitor) checkDevice(device *models.Device, data *checkMissed
 	m.mu.RUnlock()
 
 	if alreadyNotified {
+		// Use configurable cooldown, or fall back to device timeout (backward compat)
+		cooldownMinutes := data.cooldownMinutes
+		if cooldownMinutes <= 0 {
+			cooldownMinutes = deviceTimeoutMinutes
+		}
 		timeSinceNotification := time.Since(lastNotified)
-		if timeSinceNotification < time.Duration(data.timeoutMinutes)*time.Minute {
-			m.logger.Debugf("Already notified about device %s %v ago, skipping", device.WWN, timeSinceNotification.Round(time.Minute))
+		if timeSinceNotification < time.Duration(cooldownMinutes)*time.Minute {
+			m.logger.Debugf("Already notified about device %s %v ago (cooldown: %dm), skipping", device.WWN, timeSinceNotification.Round(time.Minute), cooldownMinutes)
 			return nil
 		}
 	}
 
 	m.logger.Warnf("Device %s (%s) has not sent data for %v (threshold: %d minutes)",
-		device.WWN, device.DeviceName, time.Since(lastSeen).Round(time.Minute), data.timeoutMinutes)
+		device.WWN, device.DeviceName, time.Since(lastSeen).Round(time.Minute), deviceTimeoutMinutes)
 
 	return &notify.MissedPingDigestDevice{
 		WWN:          device.WWN,
@@ -315,6 +333,16 @@ func (m *MissedPingMonitor) checkMissedPings() {
 		return
 	}
 
+	// Flush any notifications queued during quiet hours
+	if gate := m.appEngine.NotificationGate; gate != nil && data.settings != nil {
+		flushNotify := notify.Notify{
+			Logger: m.logger,
+			Config: m.appEngine.Config,
+		}
+		flushNotify.LoadDatabaseUrls(m.ctx, m.deviceRepo)
+		gate.FlushQuietQueue(&flushNotify, data.settings)
+	}
+
 	// Clear previous error on successful data load
 	m.statusMu.Lock()
 	m.lastError = nil
@@ -332,33 +360,44 @@ func (m *MissedPingMonitor) checkMissedPings() {
 	}
 
 	if len(missed) > 0 {
-		m.sendMissedPingDigest(missed, data.timeoutMinutes)
+		m.sendMissedPingDigest(missed, data)
 	}
 
 	m.cleanupStaleNotifications(currentDeviceWWNs)
 }
 
-func (m *MissedPingMonitor) sendMissedPingDigest(devices []notify.MissedPingDigestDevice, timeoutMinutes int) {
-	notification := notify.NewMissedPingDigest(m.logger, m.appEngine.Config, devices, timeoutMinutes)
+func (m *MissedPingMonitor) sendMissedPingDigest(devices []notify.MissedPingDigestDevice, data *checkMissedPingsData) {
+	notification := notify.NewMissedPingDigest(m.logger, m.appEngine.Config, devices, data.timeoutMinutes)
 	notification.LoadDatabaseUrls(m.ctx, m.deviceRepo)
-	if err := notification.Send(); err != nil {
-		if err.Error() == "no notification endpoints configured" {
-			m.logger.Warnf("Missed pings detected for %d device(s) but no notification endpoints are configured.", len(devices))
+
+	// Route through the notification gate for rate limiting and quiet hours
+	sent := false
+	if gate := m.appEngine.NotificationGate; gate != nil && data.settings != nil {
+		sent = gate.TrySend(&notification, data.settings, false)
+	} else {
+		// Fallback: send directly if gate not available
+		if err := notification.Send(); err != nil {
+			if err.Error() == "no notification endpoints configured" {
+				m.logger.Warnf("Missed pings detected for %d device(s) but no notification endpoints are configured.", len(devices))
+				return
+			}
+			m.logger.Errorf("Failed to send missed ping digest notification: %v", err)
 			return
 		}
-		m.logger.Errorf("Failed to send missed ping digest notification: %v", err)
-		return
+		sent = true
 	}
 
-	// Mark all devices as notified
-	m.mu.Lock()
-	now := time.Now()
-	for _, d := range devices {
-		m.notifiedDevices[d.WWN] = now
-	}
-	m.mu.Unlock()
+	if sent {
+		// Mark all devices as notified
+		m.mu.Lock()
+		now := time.Now()
+		for _, d := range devices {
+			m.notifiedDevices[d.WWN] = now
+		}
+		m.mu.Unlock()
 
-	m.logger.Infof("Sent missed ping digest notification for %d device(s)", len(devices))
+		m.logger.Infof("Sent missed ping digest notification for %d device(s)", len(devices))
+	}
 }
 
 func (m *MissedPingMonitor) clearNotificationState(wwn string) {

--- a/webapp/backend/pkg/web/server.go
+++ b/webapp/backend/pkg/web/server.go
@@ -18,6 +18,7 @@ import (
 	"github.com/analogj/scrutiny/webapp/backend/pkg/errors"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/metrics"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/mqtt"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/notify"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/reports"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/web/handler"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/web/middleware"
@@ -29,10 +30,11 @@ const configKeyMetricsEnabled = "web.metrics.enabled"
 const configKeyMqttEnabled = "web.mqtt.enabled"
 
 type AppEngine struct {
-	Config            config.Interface
-	Logger            *logrus.Entry
-	MetricsCollector  *metrics.Collector
-	MqttPublisher     *mqtt.Publisher
+	Config             config.Interface
+	Logger             *logrus.Entry
+	MetricsCollector   *metrics.Collector
+	MqttPublisher      *mqtt.Publisher
+	NotificationGate   *notify.NotificationGate
 	MissedPingMonitor  *MissedPingMonitor
 	HeartbeatMonitor   *HeartbeatMonitor
 	UptimeKumaMonitor  *UptimeKumaMonitor
@@ -45,6 +47,9 @@ func (ae *AppEngine) registerMiddleware(r *gin.Engine, logger *logrus.Entry) {
 	r.Use(middleware.ConfigMiddleware(ae.Config))
 	r.Use(middleware.AuthMiddleware(ae.Config, logger))
 
+	if ae.NotificationGate != nil {
+		r.Use(middleware.NotificationGateMiddleware(ae.NotificationGate))
+	}
 	if ae.MissedPingMonitor != nil {
 		r.Use(middleware.MissedPingMonitorMiddleware(ae.MissedPingMonitor))
 	}
@@ -129,7 +134,8 @@ func (ae *AppEngine) Setup(logger *logrus.Entry) *gin.Engine {
 			api.POST("/device/:wwn/mute", handler.MuteDevice)           //used by UI to mute device
 			api.POST("/device/:wwn/unmute", handler.UnmuteDevice)       //used by UI to unmute device
 			api.POST("/device/:wwn/label", handler.UpdateDeviceLabel)                         //used by UI to set device label
-			api.POST("/device/:wwn/smart-display-mode", handler.UpdateDeviceSmartDisplayMode) //used by UI to set SMART attribute display mode
+			api.POST("/device/:wwn/smart-display-mode", handler.UpdateDeviceSmartDisplayMode)       // used by UI to set SMART attribute display mode
+			api.POST("/device/:wwn/missed-ping-timeout", handler.UpdateDeviceMissedPingTimeout) // used by UI to set per-device missed ping timeout override
 			api.DELETE("/device/:wwn", handler.DeleteDevice)                                  //used by UI to delete device
 			api.POST("/device/:wwn/performance", handler.UploadDevicePerformance)            // used by Collector to upload performance benchmarks
 			api.GET("/device/:wwn/performance", handler.GetDevicePerformance)                // used by UI to view performance history
@@ -244,7 +250,9 @@ func (ae *AppEngine) Start() error {
 			filepath.Dir(ae.Config.GetString("web.database.location"))))
 	}
 
-	// Create monitors BEFORE Setup() so middleware can register them in gin context
+	// Create notification gate and monitors BEFORE Setup() so middleware can register them in gin context
+	ae.NotificationGate = notify.NewNotificationGate(ae.Logger)
+
 	missedPingMonitor := NewMissedPingMonitor(ae)
 	ae.MissedPingMonitor = missedPingMonitor
 

--- a/webapp/frontend/src/app/core/config/app.config.ts
+++ b/webapp/frontend/src/app/core/config/app.config.ts
@@ -110,6 +110,12 @@ export interface AppConfig {
         notify_on_missed_ping?: boolean
         missed_ping_timeout_minutes?: number
         missed_ping_check_interval_mins?: number
+        // Notification cooldown / rate limiting
+        missed_ping_cooldown_minutes?: number
+        notification_rate_limit?: number
+        // Quiet hours
+        notification_quiet_start?: string
+        notification_quiet_end?: string
         // Heartbeat notifications
         heartbeat_enabled?: boolean
         heartbeat_interval_hours?: number
@@ -168,6 +174,10 @@ export const appConfig: AppConfig = {
         notify_on_missed_ping: false,
         missed_ping_timeout_minutes: 60,
         missed_ping_check_interval_mins: 5,
+        missed_ping_cooldown_minutes: 0,
+        notification_rate_limit: 0,
+        notification_quiet_start: '',
+        notification_quiet_end: '',
         heartbeat_enabled: false,
         heartbeat_interval_hours: 24,
         uptime_kuma_enabled: false,

--- a/webapp/frontend/src/app/core/models/device-model.ts
+++ b/webapp/frontend/src/app/core/models/device-model.ts
@@ -28,4 +28,5 @@ export interface DeviceModel {
 
     device_status: number;
     has_forced_failure?: boolean;
+    missed_ping_timeout_override?: number;
 }

--- a/webapp/frontend/src/app/layout/common/dashboard-settings/dashboard-settings.component.html
+++ b/webapp/frontend/src/app/layout/common/dashboard-settings/dashboard-settings.component.html
@@ -147,6 +147,38 @@
             </mat-form-field>
         </div>
 
+        <div class="flex flex-col mt-5 gt-md:flex-row" *ngIf="notifyOnMissedPing">
+            <mat-form-field class="flex-auto gt-xs:pr-3 gt-md:pr-3">
+                <mat-label>Repeat Notification Cooldown (minutes)</mat-label>
+                <input matInput type="number" [(ngModel)]="missedPingCooldownMinutes" min="0">
+                <mat-hint>Minimum time between repeat notifications per device (0 = use timeout)</mat-hint>
+            </mat-form-field>
+        </div>
+
+        <!-- Notification Rate Limiting -->
+        <div class="flex flex-col mt-5 gt-md:flex-row">
+            <mat-form-field class="flex-auto gt-xs:pr-3 gt-md:pr-3">
+                <mat-label>Notification Rate Limit (per hour)</mat-label>
+                <input matInput type="number" [(ngModel)]="notificationRateLimit" min="0">
+                <mat-hint>Maximum notifications per hour across all types (0 = unlimited)</mat-hint>
+            </mat-form-field>
+        </div>
+
+        <!-- Quiet Hours -->
+        <div class="flex flex-col mt-5 gt-md:flex-row">
+            <mat-form-field class="flex-auto gt-xs:pr-3 gt-md:pr-3">
+                <mat-label>Quiet Hours Start</mat-label>
+                <input matInput type="time" [(ngModel)]="notificationQuietStart">
+                <mat-hint>Stop sending notifications at this time (leave empty to disable)</mat-hint>
+            </mat-form-field>
+
+            <mat-form-field class="flex-auto gt-xs:pr-3 gt-md:pl-3">
+                <mat-label>Quiet Hours End</mat-label>
+                <input matInput type="time" [(ngModel)]="notificationQuietEnd">
+                <mat-hint>Resume and send queued digest at this time</mat-hint>
+            </mat-form-field>
+        </div>
+
         <div class="flex flex-col mt-5 gt-md:flex-row">
             <mat-form-field class="flex-auto gt-xs:pr-3 gt-md:pr-3">
                 <mat-label>Heartbeat Notifications</mat-label>

--- a/webapp/frontend/src/app/layout/common/dashboard-settings/dashboard-settings.component.ts
+++ b/webapp/frontend/src/app/layout/common/dashboard-settings/dashboard-settings.component.ts
@@ -48,6 +48,14 @@ export class DashboardSettingsComponent implements OnInit {
     missedPingTimeoutMinutes: number;
     missedPingCheckIntervalMins: number;
 
+    // Notification cooldown / rate limiting
+    missedPingCooldownMinutes: number;
+    notificationRateLimit: number;
+
+    // Quiet hours
+    notificationQuietStart: string;
+    notificationQuietEnd: string;
+
     // Heartbeat settings
     heartbeatEnabled: boolean;
     heartbeatIntervalHours: number;
@@ -152,6 +160,14 @@ export class DashboardSettingsComponent implements OnInit {
                 this.notifyOnMissedPing = config.metrics.notify_on_missed_ping ?? false;
                 this.missedPingTimeoutMinutes = config.metrics.missed_ping_timeout_minutes ?? 60;
                 this.missedPingCheckIntervalMins = config.metrics.missed_ping_check_interval_mins ?? 5;
+
+                // Notification cooldown / rate limiting
+                this.missedPingCooldownMinutes = config.metrics.missed_ping_cooldown_minutes ?? 0;
+                this.notificationRateLimit = config.metrics.notification_rate_limit ?? 0;
+
+                // Quiet hours
+                this.notificationQuietStart = config.metrics.notification_quiet_start ?? '';
+                this.notificationQuietEnd = config.metrics.notification_quiet_end ?? '';
 
                 // Heartbeat settings
                 this.heartbeatEnabled = config.metrics.heartbeat_enabled ?? false;
@@ -352,6 +368,10 @@ export class DashboardSettingsComponent implements OnInit {
                 notify_on_missed_ping: this.notifyOnMissedPing,
                 missed_ping_timeout_minutes: this.missedPingTimeoutMinutes,
                 missed_ping_check_interval_mins: this.missedPingCheckIntervalMins,
+                missed_ping_cooldown_minutes: this.missedPingCooldownMinutes,
+                notification_rate_limit: this.notificationRateLimit,
+                notification_quiet_start: this.notificationQuietStart,
+                notification_quiet_end: this.notificationQuietEnd,
                 heartbeat_enabled: this.heartbeatEnabled,
                 heartbeat_interval_hours: this.heartbeatIntervalHours,
                 uptime_kuma_enabled: this.uptimeKumaEnabled,

--- a/webapp/frontend/src/app/layout/common/detail-settings/detail-settings.component.html
+++ b/webapp/frontend/src/app/layout/common/detail-settings/detail-settings.component.html
@@ -29,10 +29,18 @@
                 </mat-select>
             </mat-form-field>
         </div>
+
+        <div class="flex flex-col gt-xs:flex-row">
+            <mat-form-field class="flex-auto gt-xs:pr-3">
+                <mat-label>Missed Ping Timeout Override (minutes)</mat-label>
+                <input matInput type="number" [(ngModel)]="missedPingTimeoutOverride" name="missedPingTimeoutOverride" min="0" placeholder="0">
+                <mat-hint>Override the global missed ping timeout for this device. 0 = use global ({{data.globalMissedPingTimeout}} min)</mat-hint>
+            </mat-form-field>
+        </div>
     </form>
 
 </mat-dialog-content>
 <mat-dialog-actions align="end">
     <button mat-button mat-dialog-close>Cancel</button>
-    <button mat-button [mat-dialog-close]="{ muted, label }" cdkFocusInitial>Save</button>
+    <button mat-button [mat-dialog-close]="{ muted, label, missedPingTimeoutOverride }" cdkFocusInitial>Save</button>
 </mat-dialog-actions>

--- a/webapp/frontend/src/app/layout/common/detail-settings/detail-settings.component.ts
+++ b/webapp/frontend/src/app/layout/common/detail-settings/detail-settings.component.ts
@@ -11,12 +11,19 @@ export class DetailSettingsComponent implements OnInit {
 
   muted: boolean;
   label: string;
+  missedPingTimeoutOverride: number;
 
   constructor(
-      @Inject(MAT_DIALOG_DATA) public data: { curMuted: boolean, curLabel: string }
+      @Inject(MAT_DIALOG_DATA) public data: {
+          curMuted: boolean,
+          curLabel: string,
+          curMissedPingTimeoutOverride: number,
+          globalMissedPingTimeout: number
+      }
   ) {
       this.muted = data.curMuted;
       this.label = data.curLabel || '';
+      this.missedPingTimeoutOverride = data.curMissedPingTimeoutOverride || 0;
   }
 
   ngOnInit(): void {

--- a/webapp/frontend/src/app/modules/detail/detail.component.ts
+++ b/webapp/frontend/src/app/modules/detail/detail.component.ts
@@ -658,15 +658,19 @@ export class DetailComponent implements OnInit, AfterViewInit, OnDestroy {
     openSettingsDialog(): void {
         if (!this.device) return;
 
+        const globalMissedPingTimeout = this.config?.metrics?.missed_ping_timeout_minutes || 15;
+
         const dialogRef = this.dialog.open(DetailSettingsComponent, {
             width: '600px',
             data: {
                 curMuted: this.device.muted,
-                curLabel: this.device.label
+                curLabel: this.device.label,
+                curMissedPingTimeoutOverride: this.device.missed_ping_timeout_override || 0,
+                globalMissedPingTimeout: globalMissedPingTimeout
             },
         });
 
-        dialogRef.afterClosed().subscribe((result: undefined | null | { muted: boolean, label: string }) => {
+        dialogRef.afterClosed().subscribe((result: undefined | null | { muted: boolean, label: string, missedPingTimeoutOverride: number }) => {
             if (!result || !this.device) return;
 
             const promises: Promise<any>[] = [];
@@ -677,6 +681,11 @@ export class DetailComponent implements OnInit, AfterViewInit, OnDestroy {
 
             if (result.label !== this.device.label) {
                 promises.push(this._detailService.setLabel(this.device.wwn, result.label).toPromise());
+            }
+
+            const currentOverride = this.device.missed_ping_timeout_override || 0;
+            if (result.missedPingTimeoutOverride !== currentOverride) {
+                promises.push(this._detailService.setMissedPingTimeout(this.device.wwn, result.missedPingTimeoutOverride).toPromise());
             }
 
             if (promises.length > 0) {

--- a/webapp/frontend/src/app/modules/detail/detail.service.ts
+++ b/webapp/frontend/src/app/modules/detail/detail.service.ts
@@ -75,6 +75,10 @@ export class DetailService {
         return this._httpClient.post(getBasePath() + `/api/device/${wwn}/smart-display-mode`, { smart_display_mode: mode });
     }
 
+    setMissedPingTimeout(wwn: string, timeoutMinutes: number): Observable<any> {
+        return this._httpClient.post(getBasePath() + `/api/device/${wwn}/missed-ping-timeout`, { missed_ping_timeout_override: timeoutMinutes });
+    }
+
     getPerformanceData(wwn: string, duration: string = 'week'): Observable<PerformanceResponseWrapper> {
         const params = { duration };
         return this._httpClient.get<PerformanceResponseWrapper>(


### PR DESCRIPTION
## Summary

- Add centralized `NotificationGate` for rate limiting (sliding window per-hour) and quiet hours (with overnight span support and digest delivery when quiet hours end)
- Add per-device missed ping timeout override (0 = use global setting) with new API endpoint and UI
- Add configurable cooldown (`missed_ping_cooldown_minutes`) separate from timeout for repeat notifications
- Add `notification_rate_limit` setting to cap notifications per hour across all types
- Add quiet hours (`notification_quiet_start`/`notification_quiet_end` in HH:MM format) with queued digest
- Heartbeats bypass quiet hours but respect rate limiting
- Database migration adds `missed_ping_timeout_override` column and 4 new settings entries
- Dashboard settings UI for cooldown, rate limit, and quiet hours
- Device detail settings UI for per-device timeout override

## Linked Issues

Closes #255

## Test plan

- [x] 10 new unit tests for NotificationGate (rate limiting, quiet hours, sliding window, overnight spans, queue management)
- [x] All existing backend tests pass
- [x] Frontend builds and tests pass
- [x] Go lint passes
- [x] All CI checks pass on PR #308
- [ ] Manual: verify dashboard settings UI renders and saves new fields
- [ ] Manual: verify per-device timeout override in detail settings