### PR TITLE
fix(mqtt): replace deprecated object_id with default_entity_id in HA discovery

### DIFF
--- a/webapp/backend/pkg/mqtt/discovery.go
+++ b/webapp/backend/pkg/mqtt/discovery.go
@@ -151,7 +151,7 @@ func buildSensorDiscovery(topicPrefix, safeDeviceID, entityID string, devInfo ma
 	payload := map[string]interface{}{
 		"name":               cfg.Name,
 		"unique_id":          id,
-		"object_id":          id,
+		"default_entity_id":  fmt.Sprintf("sensor.%s", id),
 		"state_topic":        st,
 		"value_template":     cfg.ValueTemplate,
 		"availability_topic": availabilityTopic,
@@ -189,7 +189,7 @@ func buildBinarySensorDiscovery(topicPrefix, safeDeviceID, entityID string, devI
 	payload := map[string]interface{}{
 		"name":               "Drive Problem",
 		"unique_id":          id,
-		"object_id":          id,
+		"default_entity_id":  fmt.Sprintf("binary_sensor.%s", id),
 		"state_topic":        st,
 		"value_template":     "{{ value_json.problem }}",
 		"payload_on":         "ON",

--- a/webapp/backend/pkg/mqtt/discovery_test.go
+++ b/webapp/backend/pkg/mqtt/discovery_test.go
@@ -64,6 +64,8 @@ func TestBuildDiscoveryMessages_TemperatureSensor(t *testing.T) {
 	require.Equal(t, "scrutiny/availability", payload["availability_topic"])
 	require.Equal(t, "scrutiny/device/"+safe+"/state", payload["state_topic"])
 	require.Equal(t, "scrutiny_"+safe+"_temperature", payload["unique_id"])
+	require.Equal(t, "sensor.scrutiny_"+safe+"_temperature", payload["default_entity_id"])
+	require.Nil(t, payload["object_id"], "object_id should no longer be present")
 }
 
 func TestBuildDiscoveryMessages_StatusSensor(t *testing.T) {
@@ -103,6 +105,10 @@ func TestBuildDiscoveryMessages_ProblemBinarySensor(t *testing.T) {
 	require.Equal(t, "ON", payload["payload_on"])
 	require.Equal(t, "OFF", payload["payload_off"])
 	require.Equal(t, "{{ value_json.problem }}", payload["value_template"])
+
+	safe := "d290f1ee6c544b0190e6d701748f0851"
+	require.Equal(t, "binary_sensor.scrutiny_"+safe+"_problem", payload["default_entity_id"])
+	require.Nil(t, payload["object_id"], "object_id should no longer be present")
 }
 
 func TestBuildDiscoveryMessages_DeviceInfo(t *testing.T) {


### PR DESCRIPTION
## Summary

- Replaces deprecated `object_id` with `default_entity_id` in MQTT discovery payloads, as required by Home Assistant Core 2026.4
- `default_entity_id` includes the entity domain prefix (`sensor.` or `binary_sensor.`), matching the new HA MQTT discovery spec
- Adds test assertions verifying the new field is present and `object_id` is absent

Closes #312

## Test plan

- [x] All 27 mqtt package tests pass (`go test -v ./webapp/backend/pkg/mqtt/...`)
- [x] `go vet` clean on mqtt package
- [ ] Deploy and verify no deprecation warnings in HA logs