### PR TITLE
feat(mqtt): add on-demand MQTT sync endpoint for HA entity cleanup

### DIFF
--- a/webapp/backend/pkg/mqtt/publisher.go
+++ b/webapp/backend/pkg/mqtt/publisher.go
@@ -128,18 +128,22 @@ func (p *Publisher) RemoveDevice(device *models.Device) {
 	p.logger.Debugf("MQTT: removed device %s from Home Assistant", device.DeviceID)
 }
 
-// LoadInitialData publishes discovery and state for all active devices from the database.
-// On startup, it also cleans up old WWN-based MQTT topics by publishing empty payloads.
-func (p *Publisher) LoadInitialData(deviceRepo database.DeviceRepo, ctx context.Context) error {
-	start := time.Now()
-	p.logger.Info("MQTT: loading initial device data...")
+// SyncAllDevices re-syncs all MQTT discovery entities with Home Assistant.
+// It cleans up legacy WWN-based topics, removes archived devices, and re-publishes
+// discovery + state for all active devices. Returns counts of devices published
+// and legacy topics cleaned.
+func (p *Publisher) SyncAllDevices(deviceRepo database.DeviceRepo, ctx context.Context) (int, int, error) {
+	if !p.client.IsConnected() {
+		return 0, 0, fmt.Errorf("MQTT client is not connected")
+	}
 
 	summary, err := deviceRepo.GetSummary(ctx)
 	if err != nil {
-		return fmt.Errorf("MQTT: failed to load device summary: %w", err)
+		return 0, 0, fmt.Errorf("MQTT: failed to load device summary: %w", err)
 	}
 
 	// Clean up legacy WWN-based topics for all devices
+	cleaned := 0
 	for _, deviceSummary := range summary {
 		device := deviceSummary.Device
 		if device.WWN != "" {
@@ -150,6 +154,7 @@ func (p *Publisher) LoadInitialData(deviceRepo database.DeviceRepo, ctx context.
 			// Clear legacy state topic
 			legacyStateTopic := fmt.Sprintf("scrutiny/device/%s/state", device.WWN)
 			_ = p.client.Publish(legacyStateTopic, "", true)
+			cleaned++
 		}
 	}
 
@@ -160,6 +165,8 @@ func (p *Publisher) LoadInitialData(deviceRepo database.DeviceRepo, ctx context.
 	for _, deviceSummary := range summary {
 		device := deviceSummary.Device
 		if device.Archived {
+			// Remove archived devices from HA (in case they were previously published)
+			p.RemoveDevice(&device)
 			continue
 		}
 
@@ -168,7 +175,21 @@ func (p *Publisher) LoadInitialData(deviceRepo database.DeviceRepo, ctx context.
 		published++
 	}
 
-	p.logger.Infof("MQTT: published discovery and state for %d devices in %v", published, time.Since(start))
+	return published, cleaned, nil
+}
+
+// LoadInitialData publishes discovery and state for all active devices from the database.
+// On startup, it also cleans up old WWN-based MQTT topics by publishing empty payloads.
+func (p *Publisher) LoadInitialData(deviceRepo database.DeviceRepo, ctx context.Context) error {
+	start := time.Now()
+	p.logger.Info("MQTT: loading initial device data...")
+
+	published, cleaned, err := p.SyncAllDevices(deviceRepo, ctx)
+	if err != nil {
+		return err
+	}
+
+	p.logger.Infof("MQTT: synced %d devices, cleaned %d legacy topics in %v", published, cleaned, time.Since(start))
 	return nil
 }
 

--- a/webapp/backend/pkg/web/handler/mqtt_cleanup.go
+++ b/webapp/backend/pkg/web/handler/mqtt_cleanup.go
@@ -1,0 +1,43 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/analogj/scrutiny/webapp/backend/pkg/database"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/mqtt"
+	"github.com/gin-gonic/gin"
+	"github.com/sirupsen/logrus"
+)
+
+// MqttSync re-syncs all MQTT discovery entities with Home Assistant.
+// It cleans up legacy WWN-based topics, removes archived devices, and re-publishes
+// discovery + state for all active devices.
+func MqttSync(c *gin.Context) {
+	logger := c.MustGet("LOGGER").(*logrus.Entry)
+	deviceRepo := c.MustGet("DEVICE_REPOSITORY").(database.DeviceRepo)
+
+	pubVal, exists := c.Get("MQTT_PUBLISHER")
+	if !exists {
+		c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": "MQTT integration is not enabled"})
+		return
+	}
+	pub, ok := pubVal.(*mqtt.Publisher)
+	if !ok || pub == nil {
+		c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": "MQTT publisher is not connected"})
+		return
+	}
+
+	published, cleaned, err := pub.SyncAllDevices(deviceRepo, c)
+	if err != nil {
+		logger.Errorf("MQTT sync failed: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": err.Error()})
+		return
+	}
+
+	logger.Infof("MQTT sync completed: %d devices published, %d legacy topics cleaned", published, cleaned)
+	c.JSON(http.StatusOK, gin.H{
+		"success":           true,
+		"devices_published": published,
+		"topics_cleaned":    cleaned,
+	})
+}

--- a/webapp/backend/pkg/web/server.go
+++ b/webapp/backend/pkg/web/server.go
@@ -115,6 +115,7 @@ func (ae *AppEngine) Setup(logger *logrus.Entry) *gin.Engine {
 			api.POST("/health/notify", handler.SendTestNotification)        //check if notifications are configured correctly
 			api.GET("/health/missed-ping-status", handler.GetMissedPingStatus) //get missed ping monitor diagnostic status
 			api.POST("/health/uptime-kuma-test", handler.TestUptimeKumaPush) // test Uptime Kuma push monitor
+			api.POST("/health/mqtt-sync", handler.MqttSync)                 // re-sync all MQTT discovery entities with HA
 
 			api.POST("/devices/register", handler.RegisterDevices)         //used by Collector to register new devices and retrieve filtered list
 			api.GET("/summary", handler.GetDevicesSummary)                 //used by Dashboard


### PR DESCRIPTION
## Summary

- Extracts `SyncAllDevices()` from `LoadInitialData()` in `publisher.go` for reusable MQTT entity sync
- Adds `POST /api/health/mqtt-sync` endpoint to trigger on-demand cleanup of stale HA entities
- Archived devices are now actively removed from HA during sync
- Legacy WWN-based topics are cleaned up alongside re-publishing current DeviceID-based discovery

## Test plan

- [ ] Backend builds cleanly (`go build ./webapp/backend/...`)
- [ ] Test endpoint on zeus dev: `curl -X POST http://192.168.1.33:8680/api/health/mqtt-sync`
- [ ] Verify HA entities are refreshed after sync
- [ ] Verify startup behavior unchanged (LoadInitialData delegates to SyncAllDevices)