### PR TITLE
fix(collector): prevent double /dev/ prefix on Windows device paths (#320)

### DIFF
--- a/collector/pkg/detect/detect.go
+++ b/collector/pkg/detect/detect.go
@@ -22,6 +22,20 @@ type Detect struct {
 	Shell  shell.Interface
 }
 
+// stripDevicePrefix removes the platform-specific device prefix from a device path.
+// On platforms where DevicePrefix() is empty (e.g., Windows), it falls back to
+// stripping the common "/dev/" prefix to avoid storing paths like "/dev/sda" as
+// the device name, which would cause doubling in the UI (e.g., "/dev//dev/sda").
+func stripDevicePrefix(devicePath string) string {
+	prefix := DevicePrefix()
+	if prefix != "" {
+		return strings.TrimPrefix(devicePath, prefix)
+	}
+	// Fallback: strip "/dev/" if present (handles Windows where smartctl
+	// outputs /dev/sda but DevicePrefix() is empty)
+	return strings.TrimPrefix(devicePath, "/dev/")
+}
+
 //private/common functions
 
 // This function calls smartctl --scan which can be used to detect storage devices.
@@ -147,7 +161,7 @@ func (d *Detect) TransformDetectedDevices(detectedDeviceConns models.Scan) []mod
 			HostId:           d.Config.GetString("host.id"),
 			CollectorVersion: version.VERSION,
 			DeviceType:       scannedDevice.Type,
-			DeviceName:       strings.TrimPrefix(deviceFile, DevicePrefix()),
+			DeviceName:       stripDevicePrefix(deviceFile),
 		}
 
 		//find (or create) a slice to contain the devices in this group
@@ -177,7 +191,7 @@ func (d *Detect) TransformDetectedDevices(detectedDeviceConns models.Scan) []mod
 						HostId:           d.Config.GetString("host.id"),
 						CollectorVersion: version.VERSION,
 						DeviceType:       overrideDeviceType,
-						DeviceName:       strings.TrimPrefix(overrideDeviceFile, DevicePrefix()),
+						DeviceName:       stripDevicePrefix(overrideDeviceFile),
 						Label:            overrideDevice.Label,
 					})
 				}
@@ -203,7 +217,7 @@ func (d *Detect) TransformDetectedDevices(detectedDeviceConns models.Scan) []mod
 					HostId:           d.Config.GetString("host.id"),
 					CollectorVersion: version.VERSION,
 					DeviceType:       deviceType,
-					DeviceName:       strings.TrimPrefix(overrideDeviceFile, DevicePrefix()),
+					DeviceName:       stripDevicePrefix(overrideDeviceFile),
 					Label:            overrideDevice.Label,
 				})
 			}

--- a/webapp/frontend/src/app/modules/workload/workload.component.ts
+++ b/webapp/frontend/src/app/modules/workload/workload.component.ts
@@ -180,7 +180,7 @@ export class WorkloadComponent implements OnInit, AfterViewInit, OnDestroy {
     private buildNameTitle(insight: WorkloadInsightModel): string {
         const parts: string[] = [];
         if (insight.device_name) {
-            parts.push(`/dev/${insight.device_name}`);
+            parts.push(insight.device_name.startsWith('/dev/') ? insight.device_name : `/dev/${insight.device_name}`);
         }
         if (insight.device_type && insight.device_type !== 'scsi' && insight.device_type !== 'ata') {
             parts.push(insight.device_type);

--- a/webapp/frontend/src/app/shared/device-title.pipe.ts
+++ b/webapp/frontend/src/app/shared/device-title.pipe.ts
@@ -11,7 +11,7 @@ export class DeviceTitlePipe implements PipeTransform {
         const titleParts = []
         switch(titleType){
             case 'name':
-                titleParts.push(`/dev/${device.device_name}`)
+                titleParts.push(device.device_name.startsWith('/dev/') ? device.device_name : `/dev/${device.device_name}`)
                 if (device.device_type && device.device_type !== 'scsi' && device.device_type !== 'ata'){
                     titleParts.push(device.device_type)
                 }


### PR DESCRIPTION
## Summary

- Fix double `/dev/` prefix on Windows device paths (e.g., `/dev//dev/sda` instead of `/dev/sda`)
- Add `stripDevicePrefix()` helper in collector that falls back to stripping `/dev/` when platform prefix is empty (Windows)
- Add defensive checks in frontend `DeviceTitlePipe` and `WorkloadComponent` to avoid prepending `/dev/` when already present

## Linked Issues

Closes #320

## Test plan

- [x] Collector detect tests pass (17/17)
- [x] `go vet` clean
- [x] CI checks pending