### PR TITLE
feat(collector): add configurable timeout for smartctl and fio command execution

### DIFF
--- a/collector/pkg/collector/metrics.go
+++ b/collector/pkg/collector/metrics.go
@@ -2,6 +2,7 @@ package collector
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -131,7 +132,10 @@ func (mc *MetricsCollector) Collect(deviceWWN string, deviceName string, deviceT
 	}
 	args = append(args, fullDeviceName)
 
-	result, err := mc.shell.Command(mc.logger, mc.config.GetString(configKeySmartctlBin), args, "", os.Environ())
+	timeout := time.Duration(mc.config.GetInt("commands.metrics_smartctl_timeout")) * time.Second
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	result, err := mc.shell.CommandContext(ctx, mc.logger, mc.config.GetString(configKeySmartctlBin), args, "", os.Environ())
 	resultBytes := []byte(result)
 	if err != nil {
 		if exitError, ok := err.(*exec.ExitError); ok {
@@ -166,7 +170,10 @@ func (mc *MetricsCollector) collectAndMergeFarm(smartJson []byte, fullDeviceName
 	}
 	farmArgs = append(farmArgs, fullDeviceName)
 
-	farmResult, farmErr := mc.shell.Command(mc.logger, mc.config.GetString(configKeySmartctlBin), farmArgs, "", os.Environ())
+	farmTimeout := time.Duration(mc.config.GetInt("commands.metrics_smartctl_timeout")) * time.Second
+	farmCtx, farmCancel := context.WithTimeout(context.Background(), farmTimeout)
+	defer farmCancel()
+	farmResult, farmErr := mc.shell.CommandContext(farmCtx, mc.logger, mc.config.GetString(configKeySmartctlBin), farmArgs, "", os.Environ())
 	if farmErr != nil {
 		mc.logger.Debugf("FARM log collection failed for %s (drive may not support FARM): %v", deviceName, farmErr)
 		return smartJson

--- a/collector/pkg/common/shell/interface.go
+++ b/collector/pkg/common/shell/interface.go
@@ -1,6 +1,8 @@
 package shell
 
 import (
+	"context"
+
 	"github.com/sirupsen/logrus"
 )
 
@@ -8,4 +10,5 @@ import (
 // mockgen -source=collector/pkg/common/shell/interface.go -destination=collector/pkg/common/shell/mock/mock_shell.go
 type Interface interface {
 	Command(logger *logrus.Entry, cmdName string, cmdArgs []string, workingDir string, environ []string) (string, error)
+	CommandContext(ctx context.Context, logger *logrus.Entry, cmdName string, cmdArgs []string, workingDir string, environ []string) (string, error)
 }

--- a/collector/pkg/common/shell/local_shell.go
+++ b/collector/pkg/common/shell/local_shell.go
@@ -2,20 +2,26 @@ package shell
 
 import (
 	"bytes"
+	"context"
 	"errors"
-	"github.com/sirupsen/logrus"
 	"io"
 	"os/exec"
 	"path"
 	"strings"
+
+	"github.com/sirupsen/logrus"
 )
 
 type localShell struct{}
 
 func (s *localShell) Command(logger *logrus.Entry, cmdName string, cmdArgs []string, workingDir string, environ []string) (string, error) {
+	return s.CommandContext(context.Background(), logger, cmdName, cmdArgs, workingDir, environ)
+}
+
+func (s *localShell) CommandContext(ctx context.Context, logger *logrus.Entry, cmdName string, cmdArgs []string, workingDir string, environ []string) (string, error) {
 	logger.Infof("Executing command: %s %s", cmdName, strings.Join(cmdArgs, " "))
 
-	cmd := exec.Command(cmdName, cmdArgs...)
+	cmd := exec.CommandContext(ctx, cmdName, cmdArgs...)
 	var stdBuffer bytes.Buffer
 
 	logWriters := []io.Writer{
@@ -41,5 +47,4 @@ func (s *localShell) Command(logger *logrus.Entry, cmdName string, cmdArgs []str
 
 	err := cmd.Run()
 	return stdBuffer.String(), err
-
 }

--- a/collector/pkg/common/shell/local_shell_test.go
+++ b/collector/pkg/common/shell/local_shell_test.go
@@ -1,10 +1,13 @@
 package shell
 
 import (
-	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/require"
+	"context"
 	"os/exec"
 	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
 )
 
 func TestLocalShellCommand(t *testing.T) {
@@ -63,4 +66,19 @@ func TestLocalShellCommand_InvalidCommand(t *testing.T) {
 	//assert
 	_, castOk := err.(*exec.ExitError)
 	require.False(t, castOk)
+}
+
+func TestLocalShellCommandContext_Timeout(t *testing.T) {
+	t.Parallel()
+
+	//setup
+	testShell := localShell{}
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+	defer cancel()
+
+	//test
+	_, err := testShell.CommandContext(ctx, logrus.WithField("exec", "test"), "sleep", []string{"5"}, "", nil)
+
+	//assert
+	require.Error(t, err)
 }

--- a/collector/pkg/common/shell/mock/mock_shell.go
+++ b/collector/pkg/common/shell/mock/mock_shell.go
@@ -5,6 +5,7 @@
 package mock_shell
 
 import (
+	context "context"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -47,4 +48,19 @@ func (m *MockInterface) Command(logger *logrus.Entry, cmdName string, cmdArgs []
 func (mr *MockInterfaceMockRecorder) Command(logger, cmdName, cmdArgs, workingDir, environ interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Command", reflect.TypeOf((*MockInterface)(nil).Command), logger, cmdName, cmdArgs, workingDir, environ)
+}
+
+// CommandContext mocks base method.
+func (m *MockInterface) CommandContext(ctx context.Context, logger *logrus.Entry, cmdName string, cmdArgs []string, workingDir string, environ []string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CommandContext", ctx, logger, cmdName, cmdArgs, workingDir, environ)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CommandContext indicates an expected call of CommandContext.
+func (mr *MockInterfaceMockRecorder) CommandContext(ctx, logger, cmdName, cmdArgs, workingDir, environ interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CommandContext", reflect.TypeOf((*MockInterface)(nil).CommandContext), ctx, logger, cmdName, cmdArgs, workingDir, environ)
 }

--- a/collector/pkg/config/config.go
+++ b/collector/pkg/config/config.go
@@ -53,6 +53,8 @@ func (c *configuration) Init() error {
 	c.SetDefault("commands.metrics_smartctl_wait", 0)
 	c.SetDefault("commands.metrics_farm_enabled", false)
 	c.SetDefault("commands.metrics_farm_args", "-l farm --json")
+	c.SetDefault("commands.metrics_smartctl_timeout", 120)
+	c.SetDefault("commands.performance_fio_timeout", 300)
 
 	//configure env variable parsing.
 	c.SetEnvPrefix("COLLECTOR")

--- a/collector/pkg/detect/detect.go
+++ b/collector/pkg/detect/detect.go
@@ -1,12 +1,14 @@
 package detect
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/analogj/scrutiny/collector/pkg/common/shell"
 	"github.com/analogj/scrutiny/collector/pkg/config"
@@ -47,7 +49,10 @@ func stripDevicePrefix(devicePath string) string {
 func (d *Detect) SmartctlScan() ([]models.Device, error) {
 	//we use smartctl to detect all the drives available.
 	args := strings.Split(d.Config.GetString("commands.metrics_scan_args"), " ")
-	detectedDeviceConnJson, err := d.Shell.Command(d.Logger, d.Config.GetString("commands.metrics_smartctl_bin"), args, "", os.Environ())
+	timeout := time.Duration(d.Config.GetInt("commands.metrics_smartctl_timeout")) * time.Second
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	detectedDeviceConnJson, err := d.Shell.CommandContext(ctx, d.Logger, d.Config.GetString("commands.metrics_smartctl_bin"), args, "", os.Environ())
 	if err != nil {
 		d.Logger.Errorf("Error scanning for devices: %v", err)
 		return nil, err
@@ -78,7 +83,10 @@ func (d *Detect) SmartCtlInfo(device *models.Device) error {
 	}
 	args = append(args, fullDeviceName)
 
-	availableDeviceInfoJson, err := d.Shell.Command(d.Logger, d.Config.GetString("commands.metrics_smartctl_bin"), args, "", os.Environ())
+	timeout := time.Duration(d.Config.GetInt("commands.metrics_smartctl_timeout")) * time.Second
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	availableDeviceInfoJson, err := d.Shell.CommandContext(ctx, d.Logger, d.Config.GetString("commands.metrics_smartctl_bin"), args, "", os.Environ())
 	var exitErr *exec.ExitError
 	if errors.As(err, &exitErr) {
 		exitCode := exitErr.ExitCode()

--- a/collector/pkg/detect/detect_test.go
+++ b/collector/pkg/detect/detect_test.go
@@ -25,11 +25,12 @@ func TestDetect_SmartctlScan(t *testing.T) {
 	fakeConfig.EXPECT().GetDeviceOverrides().AnyTimes().Return([]models.ScanOverride{})
 	fakeConfig.EXPECT().GetString("commands.metrics_smartctl_bin").AnyTimes().Return("smartctl")
 	fakeConfig.EXPECT().GetString("commands.metrics_scan_args").AnyTimes().Return("--scan --json")
+	fakeConfig.EXPECT().GetInt("commands.metrics_smartctl_timeout").AnyTimes().Return(120)
 	fakeConfig.EXPECT().IsAllowlistedDevice(gomock.Any()).AnyTimes().Return(true)
 
 	fakeShell := mock_shell.NewMockInterface(mockCtrl)
 	testScanResults, err := os.ReadFile("testdata/smartctl_scan_simple.json")
-	fakeShell.EXPECT().Command(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(string(testScanResults), err)
+	fakeShell.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(string(testScanResults), err)
 
 	d := detect.Detect{
 		Logger: logrus.WithFields(logrus.Fields{}),
@@ -55,11 +56,12 @@ func TestDetect_SmartctlScan_Megaraid(t *testing.T) {
 	fakeConfig.EXPECT().GetDeviceOverrides().AnyTimes().Return([]models.ScanOverride{})
 	fakeConfig.EXPECT().GetString("commands.metrics_smartctl_bin").AnyTimes().Return("smartctl")
 	fakeConfig.EXPECT().GetString("commands.metrics_scan_args").AnyTimes().Return("--scan --json")
+	fakeConfig.EXPECT().GetInt("commands.metrics_smartctl_timeout").AnyTimes().Return(120)
 	fakeConfig.EXPECT().IsAllowlistedDevice(gomock.Any()).AnyTimes().Return(true)
 
 	fakeShell := mock_shell.NewMockInterface(mockCtrl)
 	testScanResults, err := os.ReadFile("testdata/smartctl_scan_megaraid.json")
-	fakeShell.EXPECT().Command(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(string(testScanResults), err)
+	fakeShell.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(string(testScanResults), err)
 
 	d := detect.Detect{
 		Logger: logrus.WithFields(logrus.Fields{}),
@@ -88,11 +90,12 @@ func TestDetect_SmartctlScan_Nvme(t *testing.T) {
 	fakeConfig.EXPECT().GetDeviceOverrides().AnyTimes().Return([]models.ScanOverride{})
 	fakeConfig.EXPECT().GetString("commands.metrics_smartctl_bin").AnyTimes().Return("smartctl")
 	fakeConfig.EXPECT().GetString("commands.metrics_scan_args").AnyTimes().Return("--scan --json")
+	fakeConfig.EXPECT().GetInt("commands.metrics_smartctl_timeout").AnyTimes().Return(120)
 	fakeConfig.EXPECT().IsAllowlistedDevice(gomock.Any()).AnyTimes().Return(true)
 
 	fakeShell := mock_shell.NewMockInterface(mockCtrl)
 	testScanResults, err := os.ReadFile("testdata/smartctl_scan_nvme.json")
-	fakeShell.EXPECT().Command(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(string(testScanResults), err)
+	fakeShell.EXPECT().CommandContext(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(string(testScanResults), err)
 
 	d := detect.Detect{
 		Logger: logrus.WithFields(logrus.Fields{}),
@@ -376,6 +379,9 @@ func TestDetect_SmartCtlInfo(t *testing.T) {
 		fakeConfig.EXPECT().
 			GetString("commands.metrics_smartctl_bin").
 			Return("smartctl")
+		fakeConfig.EXPECT().
+			GetInt("commands.metrics_smartctl_timeout").
+			Return(120)
 
 		someLogger := logrus.WithFields(logrus.Fields{})
 
@@ -384,7 +390,7 @@ func TestDetect_SmartCtlInfo(t *testing.T) {
 
 		fakeShell := mock_shell.NewMockInterface(ctrl)
 		fakeShell.EXPECT().
-			Command(someLogger, "smartctl", append(strings.Split(someArgs, " "), "/dev/"+someDeviceName), "", gomock.Any()).
+			CommandContext(gomock.Any(), someLogger, "smartctl", append(strings.Split(someArgs, " "), "/dev/"+someDeviceName), "", gomock.Any()).
 			Return(string(smartctlInfoResults), err)
 
 		d := detect.Detect{

--- a/collector/pkg/performance/collector.go
+++ b/collector/pkg/performance/collector.go
@@ -2,6 +2,7 @@ package performance
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -484,7 +485,11 @@ func (c *Collector) buildFioArgs(rwMode string, blockSize string, profile string
 func (c *Collector) runFio(fioBin string, args []string) ([]byte, error) {
 	c.logger.Debugf("Executing: %s %s", fioBin, strings.Join(args, " "))
 
-	cmd := exec.Command(fioBin, args...)
+	timeout := time.Duration(c.config.GetInt("commands.performance_fio_timeout")) * time.Second
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, fioBin, args...)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr


### PR DESCRIPTION
## Summary

- Adds `context.Context` support to the shell interface via a new `CommandContext` method so all `smartctl` and `fio` subprocess calls can be cancelled when a timeout expires
- Adds two new config keys: `commands.metrics_smartctl_timeout` (default: 120s) and `commands.performance_fio_timeout` (default: 300s)
- Prevents the collector from blocking indefinitely when a drive becomes unresponsive mid-collection

## Linked Issues

Closes #267

## Test plan

- [x] Shell timeout test passes (`TestLocalShellCommandContext_Timeout`)
- [x] All collector tests pass (`go test ./collector/...`)
- [x] Live tested on Zeus dev environment: confirmed `signal: killed` at exactly 2s with a fake hung smartctl wrapper
- [x] Normal collection verified unaffected (all healthy drives complete within timeout)
- [x] Multi-platform build matrix passed in CI