### PR TITLE
feat(api): add on-demand device status reset endpoint and UI button (#271)

### DIFF
--- a/webapp/backend/pkg/web/handler/reset_device_status.go
+++ b/webapp/backend/pkg/web/handler/reset_device_status.go
@@ -1,0 +1,28 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/analogj/scrutiny/webapp/backend/pkg/database"
+	"github.com/gin-gonic/gin"
+	"github.com/sirupsen/logrus"
+)
+
+func ResetDeviceStatus(c *gin.Context) {
+	logger := c.MustGet("LOGGER").(*logrus.Entry)
+	deviceRepo := c.MustGet("DEVICE_REPOSITORY").(database.DeviceRepo)
+
+	device, err := ResolveDevice(c, logger, deviceRepo)
+	if err != nil {
+		return
+	}
+
+	_, err = deviceRepo.ResetDeviceStatus(c, device.DeviceID)
+	if err != nil {
+		logger.Errorln("An error occurred while resetting device status", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"success": true})
+}

--- a/webapp/backend/pkg/web/server.go
+++ b/webapp/backend/pkg/web/server.go
@@ -134,6 +134,7 @@ func (ae *AppEngine) Setup(logger *logrus.Entry) *gin.Engine {
 			api.POST("/device/:id/unarchive", handler.UnarchiveDevice) // used by UI to unarchive device
 			api.POST("/device/:id/mute", handler.MuteDevice)           // used by UI to mute device
 			api.POST("/device/:id/unmute", handler.UnmuteDevice)       // used by UI to unmute device
+			api.POST("/device/:id/reset-status", handler.ResetDeviceStatus) // used by UI to reset device failed status
 			api.POST("/device/:id/label", handler.UpdateDeviceLabel)                         // used by UI to set device label
 			api.POST("/device/:id/smart-display-mode", handler.UpdateDeviceSmartDisplayMode)       // used by UI to set SMART attribute display mode
 			api.POST("/device/:id/missed-ping-timeout", handler.UpdateDeviceMissedPingTimeout) // used by UI to set per-device missed ping timeout override

--- a/webapp/frontend/src/app/modules/detail/detail.component.html
+++ b/webapp/frontend/src/app/modules/detail/detail.component.html
@@ -45,6 +45,17 @@
           <span class="ml-2">Settings</span>
         </button>
 
+        @if (device?.device_status !== 0) {
+          <button
+            class="ml-2 xs:hidden"
+            mat-stroked-button
+            (click)="resetDeviceStatus()"
+            matTooltip="Reset device status to passed">
+            <mat-icon class="icon-size-20" [svgIcon]="'refresh'"></mat-icon>
+            <span class="ml-2">Reset Status</span>
+          </button>
+        }
+
         <!-- Actions menu (mobile / xs) -->
         <div class="hidden xs:flex">
           <button
@@ -71,6 +82,15 @@
               </mat-icon>
               <span class="ml-2">Settings</span>
             </button>
+
+            @if (device?.device_status !== 0) {
+              <button
+                mat-menu-item
+                (click)="resetDeviceStatus()">
+                <mat-icon class="icon-size-20" [svgIcon]="'refresh'"></mat-icon>
+                <span class="ml-2">Reset Status</span>
+              </button>
+            }
           </mat-menu>
         </div>
       </div>

--- a/webapp/frontend/src/app/modules/detail/detail.component.ts
+++ b/webapp/frontend/src/app/modules/detail/detail.component.ts
@@ -655,6 +655,18 @@ export class DetailComponent implements OnInit, AfterViewInit, OnDestroy {
             .subscribe();
     }
 
+    resetDeviceStatus(): void {
+        if (!this.device) return;
+
+        this._detailService.resetStatus(this.device.device_id)
+            .pipe(takeUntil(this._unsubscribeAll))
+            .subscribe(() => {
+                this._detailService.getData(this.device.device_id)
+                    .pipe(takeUntil(this._unsubscribeAll))
+                    .subscribe();
+            });
+    }
+
     openSettingsDialog(): void {
         if (!this.device) return;
 

--- a/webapp/frontend/src/app/modules/detail/detail.service.ts
+++ b/webapp/frontend/src/app/modules/detail/detail.service.ts
@@ -52,6 +52,13 @@ export class DetailService {
     }
 
     /**
+     * Reset device failed status to passed
+     */
+    resetStatus(deviceId: string): Observable<any> {
+        return this._httpClient.post(getBasePath() + `/api/device/${deviceId}/reset-status`, {});
+    }
+
+    /**
      * Mute / Unmute certain device
      */
     setMuted(deviceId, muted): Observable<any> {


### PR DESCRIPTION
## Summary

- Adds `POST /api/device/:wwn/reset-status` endpoint to manually clear a device's failed status
- Adds a "Reset Status" button to the device detail page (desktop toolbar and mobile menu)
- Button is only visible when `device_status !== 0` (device is in a failed state)
- Clicking the button resets status to passed and refreshes the page immediately

## Linked Issues

Closes #271

## Test plan

- [x] Backend endpoint created following `archive_device.go` pattern
- [x] Route registered in `server.go`
- [x] Frontend service method added
- [x] Frontend component method added with data refresh on success
- [x] Button conditionally rendered with Angular 21 `@if` control flow syntax
- [x] Manually tested on dev environment — button appears for failed devices, resets status, and disappears after reset