### PR TITLE
feat(notify): support warning-level notify threshold in ShouldNotify (#254)

### DIFF
--- a/webapp/backend/pkg/notify/notify.go
+++ b/webapp/backend/pkg/notify/notify.go
@@ -38,9 +38,11 @@ const NotifyFailureTypePerformanceDegradation = "PerformanceDegradation"
 const NotifyFailureTypeReport = "Report"
 
 // ShouldNotify check if the error Message should be filtered (level mismatch or filtered_attributes)
-func ShouldNotify(logger logrus.FieldLogger, device *models.Device, smartAttrs *measurements.Smart, statusThreshold pkg.MetricsStatusThreshold, statusFilterAttributes pkg.MetricsStatusFilterAttributes, repeatNotifications bool, wwn string, c *gin.Context, deviceRepo database.DeviceRepo, cfg config.Interface) bool {
+func ShouldNotify(logger logrus.FieldLogger, device *models.Device, smartAttrs *measurements.Smart, notifyLevel pkg.MetricsNotifyLevel, statusThreshold pkg.MetricsStatusThreshold, statusFilterAttributes pkg.MetricsStatusFilterAttributes, repeatNotifications bool, wwn string, c *gin.Context, deviceRepo database.DeviceRepo, cfg config.Interface) bool {
 	// 1. check if the device is healthy
-	if device.DeviceStatus == pkg.DeviceStatusPassed {
+	// For warn level, a device with only warning attributes still has DeviceStatusPassed,
+	// so we must continue to the attribute-level check.
+	if device.DeviceStatus == pkg.DeviceStatusPassed && notifyLevel != pkg.MetricsNotifyLevelWarn {
 		logger.Debugf("ShouldNotify: skipping device %s - device status is passed", device.WWN)
 		return false
 	}
@@ -50,8 +52,6 @@ func ShouldNotify(logger logrus.FieldLogger, device *models.Device, smartAttrs *
 		logger.Debugf("ShouldNotify: skipping device %s - device is muted", device.WWN)
 		return false
 	}
-
-	//TODO: cannot check for warning notifyLevel yet.
 
 	// setup constants for comparison
 	var requiredDeviceStatus pkg.DeviceStatus
@@ -69,8 +69,14 @@ func ShouldNotify(logger logrus.FieldLogger, device *models.Device, smartAttrs *
 		requiredAttrStatus = pkg.AttributeStatusFailedScrutiny
 	}
 
-	// This is the only case where individual attributes need not be considered
-	if statusFilterAttributes == pkg.MetricsStatusFilterAttributesAll && repeatNotifications {
+	// When warn level is set, also match attributes with a warning scrutiny status.
+	if notifyLevel == pkg.MetricsNotifyLevelWarn {
+		requiredAttrStatus = pkg.AttributeStatusSet(requiredAttrStatus, pkg.AttributeStatusWarningScrutiny)
+	}
+
+	// This is the only case where individual attributes need not be considered.
+	// Warn level is excluded: there is no DeviceStatusWarn, so we must always check individual attributes.
+	if statusFilterAttributes == pkg.MetricsStatusFilterAttributesAll && repeatNotifications && notifyLevel != pkg.MetricsNotifyLevelWarn {
 		return pkg.DeviceStatusHas(device.DeviceStatus, requiredDeviceStatus)
 	}
 

--- a/webapp/backend/pkg/notify/notify_test.go
+++ b/webapp/backend/pkg/notify/notify_test.go
@@ -30,7 +30,7 @@ func TestShouldNotify_MustSkipPassingDevices(t *testing.T) {
 	defer mockCtrl.Finish()
 	fakeDatabase := mock_database.NewMockDeviceRepo(mockCtrl)
 	//assert
-	require.False(t, ShouldNotify(logrus.StandardLogger(), &device, &smartAttrs, statusThreshold, notifyFilterAttributes, true, "", &gin.Context{}, fakeDatabase, nil))
+	require.False(t, ShouldNotify(logrus.StandardLogger(), &device, &smartAttrs, pkg.MetricsNotifyLevelFail, statusThreshold, notifyFilterAttributes, true, "", &gin.Context{}, fakeDatabase, nil))
 }
 
 func TestShouldNotify_MustSkipMutedDevices(t *testing.T) {
@@ -48,7 +48,7 @@ func TestShouldNotify_MustSkipMutedDevices(t *testing.T) {
 	defer mockCtrl.Finish()
 	fakeDatabase := mock_database.NewMockDeviceRepo(mockCtrl)
 	//assert
-	require.False(t, ShouldNotify(logrus.StandardLogger(), &device, &smartAttrs, statusThreshold, notifyFilterAttributes, true, "", &gin.Context{}, fakeDatabase, nil))
+	require.False(t, ShouldNotify(logrus.StandardLogger(), &device, &smartAttrs, pkg.MetricsNotifyLevelFail, statusThreshold, notifyFilterAttributes, true, "", &gin.Context{}, fakeDatabase, nil))
 }
 
 func TestShouldNotify_MetricsStatusThresholdBoth_FailingSmartDevice(t *testing.T) {
@@ -64,7 +64,7 @@ func TestShouldNotify_MetricsStatusThresholdBoth_FailingSmartDevice(t *testing.T
 	defer mockCtrl.Finish()
 	fakeDatabase := mock_database.NewMockDeviceRepo(mockCtrl)
 	//assert
-	require.True(t, ShouldNotify(logrus.StandardLogger(), &device, &smartAttrs, statusThreshold, notifyFilterAttributes, true, "", &gin.Context{}, fakeDatabase, nil))
+	require.True(t, ShouldNotify(logrus.StandardLogger(), &device, &smartAttrs, pkg.MetricsNotifyLevelFail, statusThreshold, notifyFilterAttributes, true, "", &gin.Context{}, fakeDatabase, nil))
 }
 
 func TestShouldNotify_MetricsStatusThresholdSmart_FailingSmartDevice(t *testing.T) {
@@ -80,7 +80,7 @@ func TestShouldNotify_MetricsStatusThresholdSmart_FailingSmartDevice(t *testing.
 	defer mockCtrl.Finish()
 	fakeDatabase := mock_database.NewMockDeviceRepo(mockCtrl)
 	//assert
-	require.True(t, ShouldNotify(logrus.StandardLogger(), &device, &smartAttrs, statusThreshold, notifyFilterAttributes, true, "", &gin.Context{}, fakeDatabase, nil))
+	require.True(t, ShouldNotify(logrus.StandardLogger(), &device, &smartAttrs, pkg.MetricsNotifyLevelFail, statusThreshold, notifyFilterAttributes, true, "", &gin.Context{}, fakeDatabase, nil))
 }
 
 func TestShouldNotify_MetricsStatusThresholdScrutiny_FailingSmartDevice(t *testing.T) {
@@ -96,7 +96,7 @@ func TestShouldNotify_MetricsStatusThresholdScrutiny_FailingSmartDevice(t *testi
 	defer mockCtrl.Finish()
 	fakeDatabase := mock_database.NewMockDeviceRepo(mockCtrl)
 	//assert
-	require.False(t, ShouldNotify(logrus.StandardLogger(), &device, &smartAttrs, statusThreshold, notifyFilterAttributes, true, "", &gin.Context{}, fakeDatabase, nil))
+	require.False(t, ShouldNotify(logrus.StandardLogger(), &device, &smartAttrs, pkg.MetricsNotifyLevelFail, statusThreshold, notifyFilterAttributes, true, "", &gin.Context{}, fakeDatabase, nil))
 }
 
 func TestShouldNotify_MetricsStatusFilterAttributesCritical_WithCriticalAttrs(t *testing.T) {
@@ -117,7 +117,7 @@ func TestShouldNotify_MetricsStatusFilterAttributesCritical_WithCriticalAttrs(t 
 	fakeDatabase := mock_database.NewMockDeviceRepo(mockCtrl)
 
 	//assert
-	require.True(t, ShouldNotify(logrus.StandardLogger(), &device, &smartAttrs, statusThreshold, notifyFilterAttributes, true, "", &gin.Context{}, fakeDatabase, nil))
+	require.True(t, ShouldNotify(logrus.StandardLogger(), &device, &smartAttrs, pkg.MetricsNotifyLevelFail, statusThreshold, notifyFilterAttributes, true, "", &gin.Context{}, fakeDatabase, nil))
 }
 
 func TestShouldNotify_MetricsStatusFilterAttributesCritical_WithMultipleCriticalAttrs(t *testing.T) {
@@ -141,7 +141,7 @@ func TestShouldNotify_MetricsStatusFilterAttributesCritical_WithMultipleCritical
 	fakeDatabase := mock_database.NewMockDeviceRepo(mockCtrl)
 
 	//assert
-	require.True(t, ShouldNotify(logrus.StandardLogger(), &device, &smartAttrs, statusThreshold, notifyFilterAttributes, true, "", &gin.Context{}, fakeDatabase, nil))
+	require.True(t, ShouldNotify(logrus.StandardLogger(), &device, &smartAttrs, pkg.MetricsNotifyLevelFail, statusThreshold, notifyFilterAttributes, true, "", &gin.Context{}, fakeDatabase, nil))
 }
 
 func TestShouldNotify_MetricsStatusFilterAttributesCritical_WithNoCriticalAttrs(t *testing.T) {
@@ -162,7 +162,7 @@ func TestShouldNotify_MetricsStatusFilterAttributesCritical_WithNoCriticalAttrs(
 	fakeDatabase := mock_database.NewMockDeviceRepo(mockCtrl)
 
 	//assert
-	require.False(t, ShouldNotify(logrus.StandardLogger(), &device, &smartAttrs, statusThreshold, notifyFilterAttributes, true, "", &gin.Context{}, fakeDatabase, nil))
+	require.False(t, ShouldNotify(logrus.StandardLogger(), &device, &smartAttrs, pkg.MetricsNotifyLevelFail, statusThreshold, notifyFilterAttributes, true, "", &gin.Context{}, fakeDatabase, nil))
 }
 
 func TestShouldNotify_MetricsStatusFilterAttributesCritical_WithNoFailingCriticalAttrs(t *testing.T) {
@@ -183,7 +183,7 @@ func TestShouldNotify_MetricsStatusFilterAttributesCritical_WithNoFailingCritica
 	fakeDatabase := mock_database.NewMockDeviceRepo(mockCtrl)
 
 	//assert
-	require.False(t, ShouldNotify(logrus.StandardLogger(), &device, &smartAttrs, statusThreshold, notifyFilterAttributes, true, "", &gin.Context{}, fakeDatabase, nil))
+	require.False(t, ShouldNotify(logrus.StandardLogger(), &device, &smartAttrs, pkg.MetricsNotifyLevelFail, statusThreshold, notifyFilterAttributes, true, "", &gin.Context{}, fakeDatabase, nil))
 }
 
 func TestShouldNotify_MetricsStatusFilterAttributesCritical_MetricsStatusThresholdSmart_WithCriticalAttrsFailingScrutiny(t *testing.T) {
@@ -207,7 +207,7 @@ func TestShouldNotify_MetricsStatusFilterAttributesCritical_MetricsStatusThresho
 	fakeDatabase := mock_database.NewMockDeviceRepo(mockCtrl)
 
 	//assert
-	require.False(t, ShouldNotify(logrus.StandardLogger(), &device, &smartAttrs, statusThreshold, notifyFilterAttributes, true, "", &gin.Context{}, fakeDatabase, nil))
+	require.False(t, ShouldNotify(logrus.StandardLogger(), &device, &smartAttrs, pkg.MetricsNotifyLevelFail, statusThreshold, notifyFilterAttributes, true, "", &gin.Context{}, fakeDatabase, nil))
 }
 func TestShouldNotify_NoRepeat_DatabaseFailure(t *testing.T) {
 	t.Parallel()
@@ -228,7 +228,7 @@ func TestShouldNotify_NoRepeat_DatabaseFailure(t *testing.T) {
 	fakeDatabase.EXPECT().GetPreviousSmartSubmission(&gin.Context{}, "").Return([]measurements.Smart{}, errors.New("")).Times(1)
 
 	//assert
-	require.True(t, ShouldNotify(logrus.StandardLogger(), &device, &smartAttrs, statusThreshold, notifyFilterAttributes, false, "", &gin.Context{}, fakeDatabase, nil))
+	require.True(t, ShouldNotify(logrus.StandardLogger(), &device, &smartAttrs, pkg.MetricsNotifyLevelFail, statusThreshold, notifyFilterAttributes, false, "", &gin.Context{}, fakeDatabase, nil))
 }
 
 func TestShouldNotify_NoRepeat_NoDatabaseData(t *testing.T) {
@@ -250,7 +250,7 @@ func TestShouldNotify_NoRepeat_NoDatabaseData(t *testing.T) {
 	fakeDatabase.EXPECT().GetPreviousSmartSubmission(&gin.Context{}, "").Return([]measurements.Smart{}, nil).Times(1)
 
 	//assert
-	require.True(t, ShouldNotify(logrus.StandardLogger(), &device, &smartAttrs, statusThreshold, notifyFilterAttributes, false, "", &gin.Context{}, fakeDatabase, nil))
+	require.True(t, ShouldNotify(logrus.StandardLogger(), &device, &smartAttrs, pkg.MetricsNotifyLevelFail, statusThreshold, notifyFilterAttributes, false, "", &gin.Context{}, fakeDatabase, nil))
 }
 func TestShouldNotify_NoRepeat(t *testing.T) {
 	t.Parallel()
@@ -272,7 +272,47 @@ func TestShouldNotify_NoRepeat(t *testing.T) {
 	fakeDatabase.EXPECT().GetPreviousSmartSubmission(&gin.Context{}, "").Return([]measurements.Smart{smartAttrs}, nil).Times(1)
 
 	//assert
-	require.False(t, ShouldNotify(logrus.StandardLogger(), &device, &smartAttrs, statusThreshold, notifyFilterAttributes, false, "", &gin.Context{}, fakeDatabase, nil))
+	require.False(t, ShouldNotify(logrus.StandardLogger(), &device, &smartAttrs, pkg.MetricsNotifyLevelFail, statusThreshold, notifyFilterAttributes, false, "", &gin.Context{}, fakeDatabase, nil))
+}
+
+func TestShouldNotify_WarnLevel_PassedDeviceWithWarnAttr(t *testing.T) {
+	t.Parallel()
+	//setup
+	device := models.Device{
+		DeviceStatus: pkg.DeviceStatusPassed,
+	}
+	smartAttrs := measurements.Smart{Attributes: map[string]measurements.SmartAttribute{
+		"5": &measurements.SmartAtaAttribute{
+			Status: pkg.AttributeStatusWarningScrutiny,
+		},
+	}}
+	statusThreshold := pkg.MetricsStatusThresholdBoth
+	notifyFilterAttributes := pkg.MetricsStatusFilterAttributesAll
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	fakeDatabase := mock_database.NewMockDeviceRepo(mockCtrl)
+	//assert: warn level should trigger on a device with only warning attributes
+	require.True(t, ShouldNotify(logrus.StandardLogger(), &device, &smartAttrs, pkg.MetricsNotifyLevelWarn, statusThreshold, notifyFilterAttributes, true, "", &gin.Context{}, fakeDatabase, nil))
+}
+
+func TestShouldNotify_WarnLevel_PassedDeviceWithFailLevelSetting(t *testing.T) {
+	t.Parallel()
+	//setup
+	device := models.Device{
+		DeviceStatus: pkg.DeviceStatusPassed,
+	}
+	smartAttrs := measurements.Smart{Attributes: map[string]measurements.SmartAttribute{
+		"5": &measurements.SmartAtaAttribute{
+			Status: pkg.AttributeStatusWarningScrutiny,
+		},
+	}}
+	statusThreshold := pkg.MetricsStatusThresholdBoth
+	notifyFilterAttributes := pkg.MetricsStatusFilterAttributesAll
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	fakeDatabase := mock_database.NewMockDeviceRepo(mockCtrl)
+	//assert: fail level should not trigger on a device with only warning attributes
+	require.False(t, ShouldNotify(logrus.StandardLogger(), &device, &smartAttrs, pkg.MetricsNotifyLevelFail, statusThreshold, notifyFilterAttributes, true, "", &gin.Context{}, fakeDatabase, nil))
 }
 
 func TestNewPayload(t *testing.T) {

--- a/webapp/backend/pkg/web/handler/upload_device_metrics.go
+++ b/webapp/backend/pkg/web/handler/upload_device_metrics.go
@@ -90,6 +90,7 @@ func UploadDeviceMetrics(c *gin.Context) {
 		logger,
 		&updatedDevice,
 		&smartData,
+		pkg.MetricsNotifyLevel(appConfig.GetInt(fmt.Sprintf("%s.metrics.notify_level", config.DB_USER_SETTINGS_SUBKEY))),
 		pkg.MetricsStatusThreshold(appConfig.GetInt(fmt.Sprintf("%s.metrics.status_threshold", config.DB_USER_SETTINGS_SUBKEY))),
 		pkg.MetricsStatusFilterAttributes(appConfig.GetInt(fmt.Sprintf("%s.metrics.status_filter_attributes", config.DB_USER_SETTINGS_SUBKEY))),
 		appConfig.GetBool(fmt.Sprintf("%s.metrics.repeat_notifications", config.DB_USER_SETTINGS_SUBKEY)),


### PR DESCRIPTION
## Summary

- Add `notifyLevel pkg.MetricsNotifyLevel` parameter to `ShouldNotify()`, which previously had no way to receive the `notify_level` setting
- Allow devices with `DeviceStatusPassed` to bypass the early-exit guard when `notifyLevel == MetricsNotifyLevelWarn` (devices with only warning attributes never have a failing device status)
- OR `AttributeStatusWarningScrutiny` into `requiredAttrStatus` when warn level is active so warning attributes trigger the notification check
- Disable the device-level shortcut path for warn level (no `DeviceStatusWarn` exists — shortcut would incorrectly return false for passed devices)
- Pass `metrics.notify_level` from app config in `upload_device_metrics` handler
- Remove the `//TODO: cannot check for warning notifyLevel yet.` comment
- Update 13 existing `ShouldNotify` test call sites to pass `MetricsNotifyLevelFail` (preserving existing behavior) and add 2 new warn-level tests

## Linked Issues

Closes #254

## Test plan

- [x] All 40 notify package tests pass (`go test -v ./webapp/backend/pkg/notify/...`)
- [x] `TestShouldNotify_WarnLevel_PassedDeviceWithWarnAttr` — device with `DeviceStatusPassed` + `AttributeStatusWarningScrutiny` returns `true` when `notifyLevel = MetricsNotifyLevelWarn`
- [x] `TestShouldNotify_WarnLevel_PassedDeviceWithFailLevelSetting` — same device returns `false` when `notifyLevel = MetricsNotifyLevelFail`
- [x] Existing fail-level behavior unchanged (all 13 pre-existing `ShouldNotify` tests pass)