### PR TITLE
fix(detect): handle macOS IOService/IODeviceTree device paths correctly (#336)

### DIFF
--- a/collector/pkg/collector/metrics.go
+++ b/collector/pkg/collector/metrics.go
@@ -124,7 +124,7 @@ func (mc *MetricsCollector) Collect(deviceWWN string, deviceName string, deviceT
 	}
 	mc.logger.Infof("Collecting smartctl results for %s\n", deviceName)
 
-	fullDeviceName := fmt.Sprintf("%s%s", detect.DevicePrefix(), deviceName)
+	fullDeviceName := detect.DeviceFullPath(deviceName)
 	args := strings.Split(mc.config.GetCommandMetricsSmartArgs(fullDeviceName), " ")
 	//only include the device type if its a non-standard one. In some cases ata drives are detected as scsi in docker, and metadata is lost.
 	if len(deviceType) > 0 && deviceType != "scsi" && deviceType != "ata" {

--- a/collector/pkg/detect/detect.go
+++ b/collector/pkg/detect/detect.go
@@ -28,7 +28,11 @@ type Detect struct {
 // On platforms where DevicePrefix() is empty (e.g., Windows), it falls back to
 // stripping the common "/dev/" prefix to avoid storing paths like "/dev/sda" as
 // the device name, which would cause doubling in the UI (e.g., "/dev//dev/sda").
+// IOService/IODeviceTree paths are returned unchanged since they have no prefix.
 func stripDevicePrefix(devicePath string) string {
+	if isIOPath(devicePath) {
+		return devicePath
+	}
 	prefix := DevicePrefix()
 	if prefix != "" {
 		return strings.TrimPrefix(devicePath, prefix)
@@ -36,6 +40,25 @@ func stripDevicePrefix(devicePath string) string {
 	// Fallback: strip "/dev/" if present (handles Windows where smartctl
 	// outputs /dev/sda but DevicePrefix() is empty)
 	return strings.TrimPrefix(devicePath, "/dev/")
+}
+
+// isIOPath reports whether name is a macOS IOService or IODeviceTree path.
+// These paths must be passed verbatim to smartctl without a /dev/ prefix
+// and without case modification.
+func isIOPath(name string) bool {
+	lower := strings.ToLower(name)
+	return strings.HasPrefix(lower, "ioservice:") || strings.HasPrefix(lower, "iodevicetree:")
+}
+
+// DeviceFullPath returns the full path used when invoking smartctl for a device.
+// For standard devices it prepends DevicePrefix() (e.g. "/dev/"); IOService and
+// IODeviceTree paths are returned verbatim because they are self-contained
+// identifiers that must not be prefixed.
+func DeviceFullPath(deviceName string) string {
+	if isIOPath(deviceName) {
+		return deviceName
+	}
+	return fmt.Sprintf("%s%s", DevicePrefix(), deviceName)
 }
 
 //private/common functions
@@ -75,7 +98,7 @@ func (d *Detect) SmartctlScan() ([]models.Device, error) {
 // - WWN is provided as component data, rather than a "string". We'll have to generate the WWN value ourselves
 // - WWN from smartctl only provided for ATA protocol drives, NVMe and SCSI drives do not include WWN.
 func (d *Detect) SmartCtlInfo(device *models.Device) error {
-	fullDeviceName := fmt.Sprintf("%s%s", DevicePrefix(), device.DeviceName)
+	fullDeviceName := DeviceFullPath(device.DeviceName)
 	args := strings.Split(d.Config.GetCommandMetricsInfoArgs(fullDeviceName), " ")
 	//only include the device type if its a non-standard one. In some cases ata drives are detected as scsi in docker, and metadata is lost.
 	if len(device.DeviceType) > 0 && device.DeviceType != "scsi" && device.DeviceType != "ata" {
@@ -158,7 +181,12 @@ func (d *Detect) TransformDetectedDevices(detectedDeviceConns models.Scan) []mod
 
 	for _, scannedDevice := range detectedDeviceConns.Devices {
 
-		deviceFile := strings.ToLower(scannedDevice.Name)
+		// Preserve case for IOService/IODeviceTree paths; they are case-sensitive
+		// macOS identifiers that must be passed verbatim to smartctl.
+		deviceFile := scannedDevice.Name
+		if !isIOPath(deviceFile) {
+			deviceFile = strings.ToLower(deviceFile)
+		}
 
 		// If the user has defined a device allow list, and this device isnt there, then ignore it
 		if !d.Config.IsAllowlistedDevice(deviceFile) {

--- a/collector/pkg/detect/detect_test.go
+++ b/collector/pkg/detect/detect_test.go
@@ -487,6 +487,68 @@ func TestDetect_TransformDetectedDevices_NoLabel(t *testing.T) {
 	require.Equal(t, "", transformedDevices[0].Label)
 }
 
+func TestDetect_TransformDetectedDevices_IOServicePath(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	fakeConfig := mock_config.NewMockInterface(mockCtrl)
+	fakeConfig.EXPECT().GetString("host.id").AnyTimes().Return("")
+	fakeConfig.EXPECT().GetDeviceOverrides().AnyTimes().Return([]models.ScanOverride{})
+	fakeConfig.EXPECT().IsAllowlistedDevice(gomock.Any()).AnyTimes().Return(true)
+
+	const ioServicePath = "IOService:/AppleARMPE/arm-io@10F00000/AppleT8110AHCIE@ba010000/IOAHCIBlockStorageDevice"
+
+	detectedDevices := models.Scan{
+		Devices: []models.ScanDevice{
+			{Name: ioServicePath, InfoName: ioServicePath, Protocol: "ata", Type: "ata"},
+		},
+	}
+
+	d := detect.Detect{Config: fakeConfig}
+	transformedDevices := d.TransformDetectedDevices(detectedDevices)
+
+	require.Equal(t, 1, len(transformedDevices))
+	// Case must be preserved — smartctl requires the exact IOService path
+	require.Equal(t, ioServicePath, transformedDevices[0].DeviceName)
+	require.Equal(t, "ata", transformedDevices[0].DeviceType)
+}
+
+func TestDetect_TransformDetectedDevices_IODeviceTreePath(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	fakeConfig := mock_config.NewMockInterface(mockCtrl)
+	fakeConfig.EXPECT().GetString("host.id").AnyTimes().Return("")
+	fakeConfig.EXPECT().GetDeviceOverrides().AnyTimes().Return([]models.ScanOverride{})
+	fakeConfig.EXPECT().IsAllowlistedDevice(gomock.Any()).AnyTimes().Return(true)
+
+	const ioDeviceTreePath = "IODeviceTree:/arm-io@10F00000/SDIO@10F00000/IOSDHostDevice/IOSDBlockStorageDevice"
+
+	detectedDevices := models.Scan{
+		Devices: []models.ScanDevice{
+			{Name: ioDeviceTreePath, InfoName: ioDeviceTreePath, Protocol: "ata", Type: "ata"},
+		},
+	}
+
+	d := detect.Detect{Config: fakeConfig}
+	transformedDevices := d.TransformDetectedDevices(detectedDevices)
+
+	require.Equal(t, 1, len(transformedDevices))
+	// Case must be preserved — smartctl requires the exact IODeviceTree path
+	require.Equal(t, ioDeviceTreePath, transformedDevices[0].DeviceName)
+}
+
+func TestDetect_DeviceFullPath_IOServicePreservesPath(t *testing.T) {
+	const ioServicePath = "IOService:/AppleARMPE/arm-io@10F00000/IOAHCIBlockStorageDevice"
+	// DeviceFullPath must return the IOService path verbatim (no /dev/ prefix)
+	require.Equal(t, ioServicePath, detect.DeviceFullPath(ioServicePath))
+}
+
+func TestDetect_DeviceFullPath_StandardDeviceGetsPrefixed(t *testing.T) {
+	// Standard device names should still receive the platform device prefix
+	result := detect.DeviceFullPath("sda")
+	require.True(t, strings.HasSuffix(result, "sda"))
+	require.NotEqual(t, "sda", result, "standard device should have a prefix added")
+}
+
 func TestDetect_TransformDetectedDevices_RaidWithLabel(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()


### PR DESCRIPTION
## Summary

- Add `isIOPath()` helper to detect macOS `IOService:` and `IODeviceTree:` path types
- Add `DeviceFullPath()` exported function that conditionally applies the `/dev/` prefix — IO paths are returned verbatim, standard paths get the platform prefix as before
- Fix `TransformDetectedDevices` to skip `strings.ToLower` for IO paths, preserving the case-sensitive identifiers smartctl requires
- Fix `SmartCtlInfo` and `MetricsCollector.Collect` to use `DeviceFullPath` instead of manually concatenating `DevicePrefix()`, so IO paths are never prefixed with `/dev/`
- All existing `/dev/` device handling is unchanged on Linux, Windows, FreeBSD, and macOS standard devices

## Linked Issues

Closes #336

## Test plan

- [x] `TestDetect_TransformDetectedDevices_IOServicePath` — IOService path case and value preserved after transform
- [x] `TestDetect_TransformDetectedDevices_IODeviceTreePath` — IODeviceTree path case and value preserved after transform
- [x] `TestDetect_DeviceFullPath_IOServicePreservesPath` — `DeviceFullPath` returns IOService path verbatim
- [x] `TestDetect_DeviceFullPath_StandardDeviceGetsPrefixed` — standard device names still receive platform prefix
- [x] All existing detect package tests pass
- [x] `go build ./collector/...` succeeds