### PR TITLE
feat(collector): add built-in cron scheduling (#333)

### DIFF
--- a/collector/cmd/collector-metrics/collector-metrics.go
+++ b/collector/cmd/collector-metrics/collector-metrics.go
@@ -6,7 +6,9 @@ import (
 	"io"
 	"log"
 	"os"
+	"os/signal"
 	"strings"
+	"syscall"
 	"time"
 
 	_ "go.uber.org/automaxprocs"
@@ -17,6 +19,7 @@ import (
 	"github.com/analogj/scrutiny/collector/pkg/errors"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/version"
 	"github.com/fatih/color"
+	"github.com/robfig/cron/v3"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
 )
@@ -138,6 +141,18 @@ OPTIONS:
 						config.Set("api.token", c.String("api-token"))
 					}
 
+					if c.IsSet("cron-schedule") {
+						config.Set("cron.schedule", c.String("cron-schedule"))
+					}
+
+					if c.IsSet("run-startup") {
+						config.Set("cron.run_on_startup", c.Bool("run-startup"))
+					}
+
+					if c.IsSet("run-startup-sleep") {
+						config.Set("cron.startup_sleep_secs", c.Int("run-startup-sleep"))
+					}
+
 					collectorLogger, logFile, err := CreateLogger(config)
 					if logFile != nil {
 						defer logFile.Close()
@@ -168,7 +183,44 @@ OPTIONS:
 						return err
 					}
 
-					return metricCollector.Run()
+					cronSchedule := config.GetString("cron.schedule")
+					if cronSchedule == "" {
+						// No schedule configured: run once and exit (original behavior).
+						return metricCollector.Run()
+					}
+
+					// Schedule configured: run on a recurring cron schedule.
+					runFunc := func() {
+						if runErr := metricCollector.Run(); runErr != nil {
+							collectorLogger.Errorf("collector run failed: %v", runErr)
+						}
+					}
+
+					if config.GetBool("cron.run_on_startup") {
+						sleepSecs := config.GetInt("cron.startup_sleep_secs")
+						if sleepSecs > 0 {
+							collectorLogger.Infof("Waiting %d seconds before startup run", sleepSecs)
+							time.Sleep(time.Duration(sleepSecs) * time.Second)
+						}
+						collectorLogger.Info("Running startup collection before first scheduled tick")
+						runFunc()
+					}
+
+					c2 := cron.New()
+					_, err = c2.AddFunc(cronSchedule, runFunc)
+					if err != nil {
+						return fmt.Errorf("invalid cron schedule %q: %w", cronSchedule, err)
+					}
+					c2.Start()
+					collectorLogger.Infof("Collector scheduled with cron expression: %s", cronSchedule)
+
+					quit := make(chan os.Signal, 1)
+					signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
+					<-quit
+					collectorLogger.Info("Shutting down collector scheduler")
+					ctx := c2.Stop()
+					<-ctx.Done()
+					return nil
 				},
 
 				Flags: []cli.Flag{
@@ -206,6 +258,25 @@ OPTIONS:
 						Name:    "api-token",
 						Usage:   "API token for authenticating with the Scrutiny server",
 						EnvVars: []string{"COLLECTOR_METRICS_API_TOKEN", "COLLECTOR_API_TOKEN"},
+					},
+
+					&cli.StringFlag{
+						Name:    "cron-schedule",
+						Usage:   "Cron expression for scheduled collection (e.g. \"0 * * * *\"). If not set, the collector runs once and exits.",
+						EnvVars: []string{"COLLECTOR_CRON_SCHEDULE"},
+					},
+
+					&cli.BoolFlag{
+						Name:    "run-startup",
+						Usage:   "Run an immediate collection on startup before the first scheduled tick",
+						EnvVars: []string{"COLLECTOR_RUN_STARTUP"},
+					},
+
+					&cli.IntFlag{
+						Name:    "run-startup-sleep",
+						Usage:   "Seconds to sleep before the startup run (requires --run-startup)",
+						Value:   0,
+						EnvVars: []string{"COLLECTOR_RUN_STARTUP_SLEEP"},
 					},
 				},
 			},

--- a/collector/pkg/config/config.go
+++ b/collector/pkg/config/config.go
@@ -72,6 +72,10 @@ func (c *configuration) Init() error {
 
 	c.SetDefault("allow_listed_devices", []string{})
 
+	c.SetDefault("cron.schedule", "")
+	c.SetDefault("cron.run_on_startup", false)
+	c.SetDefault("cron.startup_sleep_secs", 0)
+
 	//if you want to load a non-standard location system config file (~/drawbridge.yml), use ReadConfig
 	c.SetConfigType("yaml")
 	//c.SetConfigName("drawbridge")

--- a/example.collector.yaml
+++ b/example.collector.yaml
@@ -160,6 +160,26 @@ devices:
 #  performance_fio_bin: 'fio'  # Path to fio binary
 
 ########################################################################################################################
+# Built-in Cron Scheduling
+#
+# The collector can run on a recurring schedule without an external cron daemon.
+# When a schedule is configured, the process stays alive and collects on each tick.
+# Without a schedule, the collector runs once and exits (default behavior).
+#
+# Environment variable overrides:
+#   cron.schedule          -> COLLECTOR_CRON_SCHEDULE
+#   cron.run_on_startup    -> COLLECTOR_RUN_STARTUP
+#   cron.startup_sleep_secs -> COLLECTOR_RUN_STARTUP_SLEEP
+#
+########################################################################################################################
+
+#cron:
+#  schedule: "0 * * * *"   # Standard 5-field cron expression. Leave empty to run once and exit.
+#  run_on_startup: false    # Run an immediate collection on startup before the first scheduled tick.
+#  startup_sleep_secs: 0   # Seconds to sleep before the startup run (useful for letting the system settle).
+
+
+########################################################################################################################
 # FEATURES COMING SOON
 #
 # The following commented out sections are a preview of additional configuration options that will be available soon.

--- a/go.mod
+++ b/go.mod
@@ -71,6 +71,7 @@ require (
 	github.com/prometheus/common v0.44.0 // indirect
 	github.com/prometheus/procfs v0.11.1 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0 // indirect
+	github.com/robfig/cron/v3 v3.0.1 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sagikazarmark/locafero v0.12.0 // indirect
 	github.com/spf13/afero v1.15.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/nicholas-fedor/shoutrrr v0.13.2
 	github.com/prometheus/client_golang v1.17.0
+	github.com/robfig/cron/v3 v3.0.1
 	github.com/samber/lo v1.25.0
 	github.com/sirupsen/logrus v1.8.3
 	github.com/spf13/viper v1.21.0
@@ -71,7 +72,6 @@ require (
 	github.com/prometheus/common v0.44.0 // indirect
 	github.com/prometheus/procfs v0.11.1 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0 // indirect
-	github.com/robfig/cron/v3 v3.0.1 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sagikazarmark/locafero v0.12.0 // indirect
 	github.com/spf13/afero v1.15.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -263,6 +263,8 @@ github.com/prometheus/procfs v0.11.1 h1:xRC8Iq1yyca5ypa9n1EZnWZkt7dwcoRPQwX/5gwa
 github.com/prometheus/procfs v0.11.1/go.mod h1:eesXgaPo1q7lBpVMoMy0ZOFTth9hBn4W/y0/p/ScXhY=
 github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0 h1:OdAsTTz6OkFY5QxjkYwrChwuRruF69c169dPK26NUlk=
 github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=


### PR DESCRIPTION
## Summary

- Embeds `robfig/cron/v3` scheduler directly in the collector binary, removing the dependency on an external `crond` daemon
- Adds `--cron-schedule`, `--run-startup`, and `--run-startup-sleep` CLI flags
- Adds `cron.schedule`, `cron.run_on_startup`, and `cron.startup_sleep_secs` YAML config keys
- Supports `COLLECTOR_CRON_SCHEDULE`, `COLLECTOR_RUN_STARTUP`, and `COLLECTOR_RUN_STARTUP_SLEEP` env vars
- Without a schedule configured, single-run behavior is completely unchanged
- Blocks on SIGINT/SIGTERM and drains the scheduler gracefully on shutdown
- Documents the new config block in `example.collector.yaml`

## Linked Issues

Closes #333

## Test plan

- [x] `go build ./collector/cmd/collector-metrics/` passes
- [x] `go vet ./collector/...` passes
- [x] `go mod tidy` run — `robfig/cron/v3` correctly classified as direct dependency
- [ ] Manual: run collector with `--cron-schedule "* * * * *"` and verify recurring collection
- [ ] Manual: run collector without `--cron-schedule` and verify single-run exit behavior is unchanged
- [ ] Manual: verify `COLLECTOR_CRON_SCHEDULE` env var is picked up correctly