### PR TITLE
fix(smart): validate smartctl exit_status before persisting data (#348)

### DIFF
--- a/collector/pkg/collector/metrics.go
+++ b/collector/pkg/collector/metrics.go
@@ -144,11 +144,13 @@ func (mc *MetricsCollector) Collect(deviceWWN string, deviceName string, deviceT
 			// smartctl command exited with an error, we should still push the data to the API server
 			mc.logger.Errorf("smartctl returned an error code (%d) while processing %s\n", exitError.ExitCode(), deviceName)
 			mc.LogSmartctlExitCode(exitError.ExitCode())
-			// Bits 0x01 and 0x02 mean smartctl could not parse the command line or open the
-			// device respectively. In these cases the JSON output is unusable, so report the
-			// failure to the backend and skip publishing.
+			// Bits 0x01, 0x02, and 0x04 indicate fatal errors where the JSON
+			// output should not be trusted:
+			//   0x01 = command line parse error
+			//   0x02 = device open failed
+			//   0x04 = checksum error in response
 			exitCode := exitError.ExitCode()
-			if exitCode&0x01 != 0 || exitCode&0x02 != 0 {
+			if exitCode&0x07 != 0 {
 				mc.ReportDeviceError(deviceWWN, "xall", fmt.Sprintf("smartctl exited with fatal code %d while reading %s", exitCode, deviceName))
 				return
 			}

--- a/webapp/backend/pkg/web/handler/upload_device_metrics.go
+++ b/webapp/backend/pkg/web/handler/upload_device_metrics.go
@@ -37,6 +37,32 @@ func UploadDeviceMetrics(c *gin.Context) {
 		return
 	}
 
+	// Validate smartctl exit_status bitmask before persisting data.
+	// Bits 0-2 indicate conditions where the JSON data should not be trusted:
+	//   0x01 = command line parse error
+	//   0x02 = device open failed (includes standby)
+	//   0x04 = checksum error in response
+	exitStatus := collectorSmartData.Smartctl.ExitStatus
+	if exitStatus&0x07 != 0 {
+		logger.Warnf("Rejecting SMART data for device %s: smartctl exit_status %d has fatal bits set (mask 0x07)", device.WWN, exitStatus)
+		c.JSON(http.StatusUnprocessableEntity, gin.H{
+			"success": false,
+			"error":   fmt.Sprintf("smartctl exit_status %d indicates unreliable data (bits 0-2 set)", exitStatus),
+		})
+		return
+	}
+
+	// Log informational exit status bits without rejecting data.
+	// These indicate disk health issues which are exactly what we want to track:
+	//   0x08 = SMART failure detected
+	//   0x10 = prefail threshold exceeded
+	//   0x20 = disk approaching failure
+	//   0x40 = error log contains errors
+	//   0x80 = self-test log contains errors
+	if exitStatus != 0 {
+		logger.Warnf("Device %s: smartctl exit_status %d has informational bits set; persisting data", device.WWN, exitStatus)
+	}
+
 	// update the device information if necessary (SQLite - uses deviceID)
 	updatedDevice, err := deviceRepo.UpdateDevice(c, device.DeviceID, &collectorSmartData)
 	if err != nil {

--- a/webapp/backend/pkg/web/handler/upload_device_metrics_test.go
+++ b/webapp/backend/pkg/web/handler/upload_device_metrics_test.go
@@ -1,0 +1,131 @@
+package handler_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	mock_database "github.com/analogj/scrutiny/webapp/backend/pkg/database/mock"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/models"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/web/handler"
+	mock_config "github.com/analogj/scrutiny/webapp/backend/pkg/config/mock"
+	"github.com/gin-gonic/gin"
+	"github.com/golang/mock/gomock"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+// smartPayload builds a minimal smartctl JSON payload with the given exit_status.
+func smartPayload(exitStatus int) string {
+	payload := map[string]interface{}{
+		"json_format_version": []int{1, 0},
+		"smartctl": map[string]interface{}{
+			"version":       []int{7, 3},
+			"exit_status":   exitStatus,
+		},
+		"device": map[string]interface{}{
+			"name":     "/dev/sda",
+			"type":     "ata",
+			"protocol": "ATA",
+		},
+	}
+	b, _ := json.Marshal(payload)
+	return string(b)
+}
+
+// setupMetricsRouter creates a minimal router for UploadDeviceMetrics exit_status
+// rejection tests. The mock repo resolves the device but no further DB calls are
+// expected because the handler should reject before reaching them.
+func setupMetricsRouter(t *testing.T) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	mockCtrl := gomock.NewController(t)
+	t.Cleanup(func() { mockCtrl.Finish() })
+
+	fakeConfig := mock_config.NewMockInterface(mockCtrl)
+	fakeRepo := mock_database.NewMockDeviceRepo(mockCtrl)
+
+	device := models.Device{DeviceID: testDeviceWWN, DeviceName: "/dev/sda"}
+	fakeRepo.EXPECT().GetDeviceDetails(gomock.Any(), testDeviceWWN).Return(device, nil).AnyTimes()
+	fakeRepo.EXPECT().GetDeviceByWWN(gomock.Any(), testDeviceWWN).Return(device, nil).AnyTimes()
+
+	// CONFIG and DEVICE_REPOSITORY are required by the handler middleware.
+	// No further mock expectations are set because the handler must reject
+	// before calling UpdateDevice or SaveSmartAttributes.
+	_ = fakeConfig
+
+	logger := logrus.WithField("test", t.Name())
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("CONFIG", fakeConfig)
+		c.Set("DEVICE_REPOSITORY", fakeRepo)
+		c.Set("LOGGER", logger)
+		c.Next()
+	})
+	r.POST("/api/device/:id/smart", handler.UploadDeviceMetrics)
+	return r
+}
+
+func TestUploadDeviceMetrics_ExitStatus_FatalBit0(t *testing.T) {
+	router := setupMetricsRouter(t)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", fmt.Sprintf("/api/device/%s/smart", testDeviceWWN), strings.NewReader(smartPayload(1)))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusUnprocessableEntity, w.Code)
+	require.Contains(t, w.Body.String(), "unreliable data")
+}
+
+func TestUploadDeviceMetrics_ExitStatus_FatalBit1(t *testing.T) {
+	router := setupMetricsRouter(t)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", fmt.Sprintf("/api/device/%s/smart", testDeviceWWN), strings.NewReader(smartPayload(2)))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusUnprocessableEntity, w.Code)
+	require.Contains(t, w.Body.String(), "unreliable data")
+}
+
+func TestUploadDeviceMetrics_ExitStatus_FatalBit2(t *testing.T) {
+	router := setupMetricsRouter(t)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", fmt.Sprintf("/api/device/%s/smart", testDeviceWWN), strings.NewReader(smartPayload(4)))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusUnprocessableEntity, w.Code)
+	require.Contains(t, w.Body.String(), "unreliable data")
+}
+
+func TestUploadDeviceMetrics_ExitStatus_AllFatalBits(t *testing.T) {
+	router := setupMetricsRouter(t)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", fmt.Sprintf("/api/device/%s/smart", testDeviceWWN), strings.NewReader(smartPayload(7)))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusUnprocessableEntity, w.Code)
+	require.Contains(t, w.Body.String(), "unreliable data")
+}
+
+func TestUploadDeviceMetrics_ExitStatus_FatalBitWithInfoBits(t *testing.T) {
+	// exit_status 0x43 = bits 0, 1, and 6 set; bits 0-1 are fatal
+	router := setupMetricsRouter(t)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", fmt.Sprintf("/api/device/%s/smart", testDeviceWWN), strings.NewReader(smartPayload(0x43)))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusUnprocessableEntity, w.Code)
+}


### PR DESCRIPTION
## Summary

- Add exit_status bitmask validation in the backend handler before persisting SMART data to SQLite/InfluxDB
- Bits 0-2 (0x07: command line error, device open failure, checksum error) now cause a 422 rejection with a log warning
- Bits 3-7 (disk health indicators) are logged but data is still persisted -- these are the conditions we want to track
- Expand the collector-side fatal exit code check from bits 0-1 to bits 0-2, adding checksum error (0x04)
- Add 5 handler-level unit tests covering all fatal exit code rejection paths

## Linked Issues

Closes #348

## Test plan

- [x] `go test ./webapp/backend/pkg/web/handler/...` -- all 41 tests pass
- [x] Exit status 1, 2, 4, 7, 0x43 all return 422
- [x] Exit status 0 proceeds normally (covered by existing integration tests)
- [ ] Manual test with a drive in standby (exit code 2) confirms rejection + collector error report