### PR TITLE
fix(database): add migration to seed Uptime Kuma settings (#351)

### DIFF
--- a/webapp/backend/pkg/database/scrutiny_repository_migrations.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_migrations.go
@@ -862,6 +862,32 @@ func (sr *scrutinyRepository) Migrate(ctx context.Context) error {
 				return nil
 			},
 		},
+		{
+			ID: "m20260413000000", // add Uptime Kuma push monitor settings (#351)
+			Migrate: func(tx *gorm.DB) error {
+				var defaultSettings = []m20220716214900.Setting{
+					{
+						SettingKeyName:        "metrics.uptime_kuma_enabled",
+						SettingKeyDescription: "Enable Uptime Kuma push monitor (true | false)",
+						SettingDataType:       "bool",
+						SettingValueBool:      false,
+					},
+					{
+						SettingKeyName:        "metrics.uptime_kuma_push_url",
+						SettingKeyDescription: "Uptime Kuma push monitor URL",
+						SettingDataType:       "string",
+						SettingValueString:    "",
+					},
+					{
+						SettingKeyName:        "metrics.uptime_kuma_interval_seconds",
+						SettingKeyDescription: "Seconds between Uptime Kuma pushes (default: 60)",
+						SettingDataType:       "numeric",
+						SettingValueNumeric:   60,
+					},
+				}
+				return tx.Create(&defaultSettings).Error
+			},
+		},
 	})
 
 	if err := m.Migrate(); err != nil {


### PR DESCRIPTION
## Summary

- Added database migration to seed the three Uptime Kuma setting entries (`metrics.uptime_kuma_enabled`, `metrics.uptime_kuma_push_url`, `metrics.uptime_kuma_interval_seconds`)
- These settings were missing from the migrations, causing `SaveSettings` to silently skip them (it only updates existing rows). The values lived only in Viper's in-memory config and were lost on container restart.

## Linked Issues

Closes #351

## Test plan

- [x] CI checks passed
- [x] Migration runs without errors on existing database
- [x] Settings visible in API response after migration
- [x] Enabled Uptime Kuma via API, restarted container, verified settings persisted
- [x] Tested on dev environment (zeus)