### PR TITLE
fix(smart): treat exit code 0x04 as non-fatal for smartctl data (#352)

### DIFF
--- a/collector/pkg/collector/metrics.go
+++ b/collector/pkg/collector/metrics.go
@@ -144,13 +144,19 @@ func (mc *MetricsCollector) Collect(deviceWWN string, deviceName string, deviceT
 			// smartctl command exited with an error, we should still push the data to the API server
 			mc.logger.Errorf("smartctl returned an error code (%d) while processing %s\n", exitError.ExitCode(), deviceName)
 			mc.LogSmartctlExitCode(exitError.ExitCode())
-			// Bits 0x01, 0x02, and 0x04 indicate fatal errors where the JSON
+			// Bits 0x01 and 0x02 indicate fatal errors where the JSON
 			// output should not be trusted:
 			//   0x01 = command line parse error
-			//   0x02 = device open failed
-			//   0x04 = checksum error in response
+			//   0x02 = device open failed (includes standby)
+			// Bit 0x04 (checksum error in response) is intentionally
+			// excluded because the JSON data is usually still valid
+			// and many drives behind RAID/HBA controllers intermittently
+			// return this code.
 			exitCode := exitError.ExitCode()
-			if exitCode&0x07 != 0 {
+			if exitCode&0x04 != 0 {
+				mc.logger.Warnf("smartctl exit code %d for %s has bit 0x04 set (checksum error); data will still be published", exitCode, deviceName)
+			}
+			if exitCode&0x03 != 0 {
 				mc.ReportDeviceError(deviceWWN, "xall", fmt.Sprintf("smartctl exited with fatal code %d while reading %s", exitCode, deviceName))
 				return
 			}

--- a/webapp/backend/pkg/web/handler/upload_device_metrics.go
+++ b/webapp/backend/pkg/web/handler/upload_device_metrics.go
@@ -38,22 +38,25 @@ func UploadDeviceMetrics(c *gin.Context) {
 	}
 
 	// Validate smartctl exit_status bitmask before persisting data.
-	// Bits 0-2 indicate conditions where the JSON data should not be trusted:
+	// Bits 0x01 and 0x02 indicate conditions where the JSON data should not be trusted:
 	//   0x01 = command line parse error
 	//   0x02 = device open failed (includes standby)
-	//   0x04 = checksum error in response
+	// Bit 0x04 (checksum error in response) is intentionally excluded because
+	// the JSON data is usually still valid and many drives behind RAID/HBA
+	// controllers intermittently return this code.
 	exitStatus := collectorSmartData.Smartctl.ExitStatus
-	if exitStatus&0x07 != 0 {
-		logger.Warnf("Rejecting SMART data for device %s: smartctl exit_status %d has fatal bits set (mask 0x07)", device.WWN, exitStatus)
+	if exitStatus&0x03 != 0 {
+		logger.Warnf("Rejecting SMART data for device %s: smartctl exit_status %d has fatal bits set (mask 0x03)", device.WWN, exitStatus)
 		c.JSON(http.StatusUnprocessableEntity, gin.H{
 			"success": false,
-			"error":   fmt.Sprintf("smartctl exit_status %d indicates unreliable data (bits 0-2 set)", exitStatus),
+			"error":   fmt.Sprintf("smartctl exit_status %d indicates unreliable data (bits 0-1 set)", exitStatus),
 		})
 		return
 	}
 
 	// Log informational exit status bits without rejecting data.
 	// These indicate disk health issues which are exactly what we want to track:
+	//   0x04 = checksum error in response (non-fatal, data usually valid)
 	//   0x08 = SMART failure detected
 	//   0x10 = prefail threshold exceeded
 	//   0x20 = disk approaching failure

--- a/webapp/backend/pkg/web/handler/upload_device_metrics_test.go
+++ b/webapp/backend/pkg/web/handler/upload_device_metrics_test.go
@@ -8,10 +8,12 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/analogj/scrutiny/webapp/backend/pkg"
+	mock_config "github.com/analogj/scrutiny/webapp/backend/pkg/config/mock"
 	mock_database "github.com/analogj/scrutiny/webapp/backend/pkg/database/mock"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/models"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/models/measurements"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/web/handler"
-	mock_config "github.com/analogj/scrutiny/webapp/backend/pkg/config/mock"
 	"github.com/gin-gonic/gin"
 	"github.com/golang/mock/gomock"
 	"github.com/sirupsen/logrus"
@@ -23,8 +25,8 @@ func smartPayload(exitStatus int) string {
 	payload := map[string]interface{}{
 		"json_format_version": []int{1, 0},
 		"smartctl": map[string]interface{}{
-			"version":       []int{7, 3},
-			"exit_status":   exitStatus,
+			"version":     []int{7, 3},
+			"exit_status": exitStatus,
 		},
 		"device": map[string]interface{}{
 			"name":     "/dev/sda",
@@ -70,6 +72,42 @@ func setupMetricsRouter(t *testing.T) *gin.Engine {
 	return r
 }
 
+// setupMetricsRouterAccept creates a router for UploadDeviceMetrics tests where the
+// exit_status validation passes and the handler proceeds to persist data. The mock
+// repo stubs all DB calls that occur after validation.
+func setupMetricsRouterAccept(t *testing.T) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	mockCtrl := gomock.NewController(t)
+	t.Cleanup(func() { mockCtrl.Finish() })
+
+	fakeConfig := mock_config.NewMockInterface(mockCtrl)
+	fakeRepo := mock_database.NewMockDeviceRepo(mockCtrl)
+
+	device := models.Device{DeviceID: testDeviceWWN, DeviceName: "/dev/sda", DeviceStatus: pkg.DeviceStatusPassed}
+	fakeRepo.EXPECT().GetDeviceDetails(gomock.Any(), testDeviceWWN).Return(device, nil).AnyTimes()
+	fakeRepo.EXPECT().GetDeviceByWWN(gomock.Any(), testDeviceWWN).Return(device, nil).AnyTimes()
+	fakeRepo.EXPECT().UpdateDevice(gomock.Any(), gomock.Any(), gomock.Any()).Return(device, nil).AnyTimes()
+	fakeRepo.EXPECT().SaveSmartAttributes(gomock.Any(), gomock.Any(), gomock.Any()).Return(measurements.Smart{Status: pkg.DeviceStatusPassed}, nil).AnyTimes()
+	fakeRepo.EXPECT().UpdateDeviceHasForcedFailure(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	fakeRepo.EXPECT().SaveSmartTemperature(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
+	fakeConfig.EXPECT().GetBool(gomock.Any()).Return(false).AnyTimes()
+	fakeConfig.EXPECT().GetInt(gomock.Any()).Return(0).AnyTimes()
+
+	logger := logrus.WithField("test", t.Name())
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("CONFIG", fakeConfig)
+		c.Set("DEVICE_REPOSITORY", fakeRepo)
+		c.Set("LOGGER", logger)
+		c.Next()
+	})
+	r.POST("/api/device/:id/smart", handler.UploadDeviceMetrics)
+	return r
+}
+
 func TestUploadDeviceMetrics_ExitStatus_FatalBit0(t *testing.T) {
 	router := setupMetricsRouter(t)
 
@@ -94,11 +132,12 @@ func TestUploadDeviceMetrics_ExitStatus_FatalBit1(t *testing.T) {
 	require.Contains(t, w.Body.String(), "unreliable data")
 }
 
-func TestUploadDeviceMetrics_ExitStatus_FatalBit2(t *testing.T) {
+func TestUploadDeviceMetrics_ExitStatus_FatalBits0And1(t *testing.T) {
+	// exit_status 3 = bits 0x01 | 0x02; both are fatal
 	router := setupMetricsRouter(t)
 
 	w := httptest.NewRecorder()
-	req, _ := http.NewRequest("POST", fmt.Sprintf("/api/device/%s/smart", testDeviceWWN), strings.NewReader(smartPayload(4)))
+	req, _ := http.NewRequest("POST", fmt.Sprintf("/api/device/%s/smart", testDeviceWWN), strings.NewReader(smartPayload(3)))
 	req.Header.Set("Content-Type", "application/json")
 	router.ServeHTTP(w, req)
 
@@ -106,16 +145,33 @@ func TestUploadDeviceMetrics_ExitStatus_FatalBit2(t *testing.T) {
 	require.Contains(t, w.Body.String(), "unreliable data")
 }
 
-func TestUploadDeviceMetrics_ExitStatus_AllFatalBits(t *testing.T) {
-	router := setupMetricsRouter(t)
+func TestUploadDeviceMetrics_ExitStatus_ChecksumNotFatal(t *testing.T) {
+	// exit_status 4 = bit 0x04 (checksum error). This is intentionally
+	// treated as non-fatal because the JSON data is usually still valid
+	// and many drives behind RAID/HBA controllers intermittently return it.
+	router := setupMetricsRouterAccept(t)
 
 	w := httptest.NewRecorder()
-	req, _ := http.NewRequest("POST", fmt.Sprintf("/api/device/%s/smart", testDeviceWWN), strings.NewReader(smartPayload(7)))
+	req, _ := http.NewRequest("POST", fmt.Sprintf("/api/device/%s/smart", testDeviceWWN), strings.NewReader(smartPayload(4)))
 	req.Header.Set("Content-Type", "application/json")
 	router.ServeHTTP(w, req)
 
-	require.Equal(t, http.StatusUnprocessableEntity, w.Code)
-	require.Contains(t, w.Body.String(), "unreliable data")
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Contains(t, w.Body.String(), "success")
+}
+
+func TestUploadDeviceMetrics_ExitStatus_ChecksumWithInfoBitsNotFatal(t *testing.T) {
+	// exit_status 0x44 = bit 0x04 (checksum) + bit 0x40 (error log has errors).
+	// Neither is fatal; data should be accepted.
+	router := setupMetricsRouterAccept(t)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", fmt.Sprintf("/api/device/%s/smart", testDeviceWWN), strings.NewReader(smartPayload(0x44)))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Contains(t, w.Body.String(), "success")
 }
 
 func TestUploadDeviceMetrics_ExitStatus_FatalBitWithInfoBits(t *testing.T) {


### PR DESCRIPTION
## Summary

- Change the fatal exit code mask from `0x07` to `0x03` in both the collector and backend handler, so that bit `0x04` (checksum error) no longer blocks data collection or triggers error notifications
- Add a warning log when bit `0x04` is set so the condition is still visible in logs without rejecting valid data
- Move `0x04` into the informational logging section alongside health indicator bits (`0x08`-`0x80`)

**Root cause:** Commit `37a8f89` (#348, v1.46.1) expanded the fatal mask from `0x03` to `0x07`, causing drives that intermittently return smartctl exit code 4 (common behind certain RAID/HBA controllers) to lose all SMART data collection and spam error notifications.

## Linked Issues

Closes #352

## Test plan

- [x] Backend handler tests pass (44 tests) -- covers exit_status 1, 2, 3, 4, 0x43, 0x44
- [x] Collector tests pass
- [x] Exit status 4 now returns HTTP 200 (data accepted)
- [x] Exit status 1 and 2 still return HTTP 422 (data rejected)
- [x] Exit status 0x44 (checksum + error log) accepted
- [x] Exit status 0x43 (fatal bits + info bits) still rejected