### PR TITLE
fix(collector): treat smartctl exit codes 0x40 and 0x80 as non-fatal (#353)

### DIFF
--- a/collector/pkg/collector/base.go
+++ b/collector/pkg/collector/base.go
@@ -70,23 +70,33 @@ func (c *BaseCollector) postJson(url string, body interface{}, target interface{
 	return json.NewDecoder(r.Body).Decode(target)
 }
 
+// LogSmartctlExitCode logs each set bit in the smartctl exit code bitmask.
+// Fatal bits (0x01, 0x02) are logged at ERROR; health-related bits (0x08,
+// 0x10, 0x20) at WARN; purely informational bits (0x04, 0x40, 0x80) at INFO.
 // http://www.linuxguide.it/command_line/linux-manpage/do.php?file=smartctl#sect7
-func (c *BaseCollector) LogSmartctlExitCode(exitCode int) {
+func (c *BaseCollector) LogSmartctlExitCode(exitCode int, deviceName string) {
 	if exitCode&0x01 != 0 {
-		c.logger.Errorln("smartctl could not parse commandline")
-	} else if exitCode&0x02 != 0 {
-		c.logger.Errorln("smartctl could not open device")
-	} else if exitCode&0x04 != 0 {
-		c.logger.Errorln("smartctl detected a checksum error")
-	} else if exitCode&0x08 != 0 {
-		c.logger.Errorln("smartctl detected a failing disk ")
-	} else if exitCode&0x10 != 0 {
-		c.logger.Errorln("smartctl detected a disk in pre-fail")
-	} else if exitCode&0x20 != 0 {
-		c.logger.Errorln("smartctl detected a disk close to failure")
-	} else if exitCode&0x40 != 0 {
-		c.logger.Errorln("smartctl detected a error log with errors")
-	} else if exitCode&0x80 != 0 {
-		c.logger.Errorln("smartctl detected a self test log with errors")
+		c.logger.Errorf("smartctl could not parse command line for %s", deviceName)
+	}
+	if exitCode&0x02 != 0 {
+		c.logger.Errorf("smartctl could not open device %s", deviceName)
+	}
+	if exitCode&0x04 != 0 {
+		c.logger.Infof("smartctl detected a checksum error for %s (bit 0x04)", deviceName)
+	}
+	if exitCode&0x08 != 0 {
+		c.logger.Warnf("smartctl detected a failing disk for %s (bit 0x08)", deviceName)
+	}
+	if exitCode&0x10 != 0 {
+		c.logger.Warnf("smartctl detected a disk in pre-fail for %s (bit 0x10)", deviceName)
+	}
+	if exitCode&0x20 != 0 {
+		c.logger.Warnf("smartctl detected a disk close to failure for %s (bit 0x20)", deviceName)
+	}
+	if exitCode&0x40 != 0 {
+		c.logger.Infof("smartctl error log contains records of errors for %s (bit 0x40)", deviceName)
+	}
+	if exitCode&0x80 != 0 {
+		c.logger.Infof("smartctl self-test log contains errors for %s (bit 0x80)", deviceName)
 	}
 }

--- a/collector/pkg/collector/metrics.go
+++ b/collector/pkg/collector/metrics.go
@@ -141,25 +141,26 @@ func (mc *MetricsCollector) Collect(deviceWWN string, deviceName string, deviceT
 	resultBytes := []byte(result)
 	if err != nil {
 		if exitError, ok := err.(*exec.ExitError); ok {
-			// smartctl command exited with an error, we should still push the data to the API server
-			mc.logger.Errorf("smartctl returned an error code (%d) while processing %s\n", exitError.ExitCode(), deviceName)
-			mc.LogSmartctlExitCode(exitError.ExitCode())
+			exitCode := exitError.ExitCode()
 			// Bits 0x01 and 0x02 indicate fatal errors where the JSON
 			// output should not be trusted:
 			//   0x01 = command line parse error
 			//   0x02 = device open failed (includes standby)
-			// Bit 0x04 (checksum error in response) is intentionally
-			// excluded because the JSON data is usually still valid
-			// and many drives behind RAID/HBA controllers intermittently
-			// return this code.
-			exitCode := exitError.ExitCode()
-			if exitCode&0x04 != 0 {
-				mc.logger.Warnf("smartctl exit code %d for %s has bit 0x04 set (checksum error); data will still be published", exitCode, deviceName)
-			}
+			// Other bits are informational and the JSON data is still valid:
+			//   0x04 = checksum error in response (common behind RAID/HBA)
+			//   0x08 = SMART status failure
+			//   0x10 = prefail attributes past threshold
+			//   0x20 = some attributes past threshold
+			//   0x40 = error log contains records of errors
+			//   0x80 = self-test log contains errors
 			if exitCode&0x03 != 0 {
+				mc.logger.Errorf("smartctl returned a fatal error code (%d) while processing %s", exitCode, deviceName)
+				mc.LogSmartctlExitCode(exitCode, deviceName)
 				mc.ReportDeviceError(deviceWWN, "xall", fmt.Sprintf("smartctl exited with fatal code %d while reading %s", exitCode, deviceName))
 				return
 			}
+			mc.logger.Warnf("smartctl returned a non-fatal exit code (%d) while processing %s; data will still be published", exitCode, deviceName)
+			mc.LogSmartctlExitCode(exitCode, deviceName)
 		} else {
 			mc.logger.Errorf("error while attempting to execute smartctl: %s\n", deviceName)
 			mc.logger.Errorf("ERROR MESSAGE: %v", err)

--- a/webapp/backend/pkg/web/handler/upload_device_metrics_test.go
+++ b/webapp/backend/pkg/web/handler/upload_device_metrics_test.go
@@ -174,6 +174,34 @@ func TestUploadDeviceMetrics_ExitStatus_ChecksumWithInfoBitsNotFatal(t *testing.
 	require.Contains(t, w.Body.String(), "success")
 }
 
+func TestUploadDeviceMetrics_ExitStatus_ErrorLogNotFatal(t *testing.T) {
+	// exit_status 64 = bit 0x40 (error log contains records of errors).
+	// This is informational and should not block data persistence.
+	router := setupMetricsRouterAccept(t)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", fmt.Sprintf("/api/device/%s/smart", testDeviceWWN), strings.NewReader(smartPayload(64)))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Contains(t, w.Body.String(), "success")
+}
+
+func TestUploadDeviceMetrics_ExitStatus_SelfTestLogNotFatal(t *testing.T) {
+	// exit_status 128 = bit 0x80 (self-test log contains errors).
+	// This is informational and should not block data persistence.
+	router := setupMetricsRouterAccept(t)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", fmt.Sprintf("/api/device/%s/smart", testDeviceWWN), strings.NewReader(smartPayload(128)))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Contains(t, w.Body.String(), "success")
+}
+
 func TestUploadDeviceMetrics_ExitStatus_FatalBitWithInfoBits(t *testing.T) {
 	// exit_status 0x43 = bits 0, 1, and 6 set; bits 0-1 are fatal
 	router := setupMetricsRouter(t)


### PR DESCRIPTION
## Summary

- Downgrade collector log level for smartctl exit codes 0x40 (error log has records) and 0x80 (self-test log has errors) from ERROR to INFO -- these are informational, not actionable failures
- Restructure `LogSmartctlExitCode` to use severity-appropriate log levels (ERROR for fatal bits 0x01/0x02, WARN for health bits 0x08/0x10/0x20, INFO for informational bits 0x04/0x40/0x80)
- Fix `LogSmartctlExitCode` to log all set bits in the bitmask (was `else if` chain, now independent `if` checks)
- Add backend tests for exit codes 64 and 128 confirming data is accepted

## Linked Issues

Closes #353

## Test plan

- [x] All 8 exit status tests pass (`go test -v -run TestUploadDeviceMetrics_ExitStatus ./webapp/backend/pkg/web/handler/...`)
- [x] Collector builds cleanly (`go build ./collector/...`)
- [x] `go vet` passes on changed packages