### PR TITLE
fix(docker): add AppArmor profile and detection for TrueNAS/Docker (#361)

### DIFF
--- a/collector/pkg/collector/metrics.go
+++ b/collector/pkg/collector/metrics.go
@@ -113,7 +113,64 @@ func (mc *MetricsCollector) Validate() error {
 		return errors.DependencyMissingError(fmt.Sprintf("%s binary is missing", mc.config.GetString(configKeySmartctlBin)))
 	}
 
+	mc.checkAppArmor()
+
 	return nil
+}
+
+// checkAppArmor reads /proc/self/attr/apparmor/current (or the legacy
+// /proc/self/attr/current) to determine if the container is confined by
+// AppArmor. When the default docker-default profile is active, smartctl
+// may fail with permission errors even when SYS_RAWIO and SYS_ADMIN
+// capabilities are granted. This method logs a warning with remediation
+// steps so users do not have to debug cryptic ioctl failures.
+func (mc *MetricsCollector) checkAppArmor() {
+	// Try the modern path first, then fall back to the legacy path.
+	paths := []string{
+		"/proc/self/attr/apparmor/current",
+		"/proc/self/attr/current",
+	}
+
+	var profile string
+	for _, p := range paths {
+		data, err := os.ReadFile(p)
+		if err != nil {
+			continue
+		}
+		profile = strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(string(data)), "(enforce)"))
+		break
+	}
+
+	if profile == "" || profile == "unconfined" {
+		mc.logger.Debugln("AppArmor: not confined or not available")
+		return
+	}
+
+	mc.logger.Infof("AppArmor: running under profile %q", profile)
+
+	if profile == "docker-default" || profile == "cri-containerd.apparmor.d" {
+		mc.logger.Warnln("AppArmor: the container is using the default Docker/containerd profile which blocks raw device I/O required by smartctl.")
+		mc.logger.Warnln("AppArmor: if you see permission errors, apply the custom scrutiny-collector profile or run with --security-opt apparmor=unconfined.")
+		mc.logger.Warnln("AppArmor: see https://github.com/Starosdev/scrutiny/blob/master/docs/TROUBLESHOOTING_APPARMOR.md for details.")
+	}
+}
+
+// hintAppArmorOnDeviceOpenFailure logs an additional hint when smartctl
+// fails to open a device (exit code bit 0x02). On AppArmor-confined
+// systems this is the most common symptom.
+func (mc *MetricsCollector) hintAppArmorOnDeviceOpenFailure(deviceName string) {
+	data, err := os.ReadFile("/proc/self/attr/apparmor/current")
+	if err != nil {
+		data, err = os.ReadFile("/proc/self/attr/current")
+	}
+	if err != nil {
+		return
+	}
+	profile := strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(string(data)), "(enforce)"))
+	if profile != "" && profile != "unconfined" {
+		mc.logger.Warnf("AppArmor: device open failure for %s may be caused by AppArmor profile %q blocking raw device I/O", deviceName, profile)
+		mc.logger.Warnln("AppArmor: see https://github.com/Starosdev/scrutiny/blob/master/docs/TROUBLESHOOTING_APPARMOR.md")
+	}
 }
 
 // func (mc *MetricsCollector) Collect(wg *sync.WaitGroup, deviceWWN string, deviceName string, deviceType string) {
@@ -156,6 +213,9 @@ func (mc *MetricsCollector) Collect(deviceWWN string, deviceName string, deviceT
 			if exitCode&0x03 != 0 {
 				mc.logger.Errorf("smartctl returned a fatal error code (%d) while processing %s", exitCode, deviceName)
 				mc.LogSmartctlExitCode(exitCode, deviceName)
+				if exitCode&0x02 != 0 {
+					mc.hintAppArmorOnDeviceOpenFailure(deviceName)
+				}
 				mc.ReportDeviceError(deviceWWN, "xall", fmt.Sprintf("smartctl exited with fatal code %d while reading %s", exitCode, deviceName))
 				return
 			}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -65,6 +65,7 @@ RUN curl -L https://dl.influxdata.com/influxdb/releases/influxdb2-${INFLUXVER}-$
     && rm -rf /tmp/influxdb2-${INFLUXVER}-${TARGETARCH}.deb
 
 COPY /rootfs /
+COPY /docker/apparmor-profile /opt/scrutiny/apparmor-profile
 
 COPY --link --from=backendbuild --chmod=755 /go/src/github.com/analogj/scrutiny/scrutiny /opt/scrutiny/bin/
 COPY --link --from=backendbuild --chmod=755 /go/src/github.com/analogj/scrutiny/scrutiny-collector-metrics /opt/scrutiny/bin/

--- a/docker/Dockerfile.collector
+++ b/docker/Dockerfile.collector
@@ -26,6 +26,7 @@ RUN echo "deb http://deb.debian.org/debian trixie-backports main" > /etc/apt/sou
     update-ca-certificates
 
 COPY /docker/entrypoint-collector.sh /entrypoint-collector.sh
+COPY /docker/apparmor-profile /opt/scrutiny/apparmor-profile
 COPY /rootfs/etc/cron.d/scrutiny /etc/cron.d/scrutiny
 COPY --from=backendbuild /go/src/github.com/analogj/scrutiny/scrutiny-collector-metrics /opt/scrutiny/bin/
 RUN chmod +x /opt/scrutiny/bin/scrutiny-collector-metrics && \

--- a/docker/Dockerfile.collector-performance
+++ b/docker/Dockerfile.collector-performance
@@ -26,6 +26,7 @@ RUN echo "deb http://deb.debian.org/debian trixie-backports main" > /etc/apt/sou
     update-ca-certificates
 
 COPY /docker/entrypoint-collector-performance.sh /entrypoint-collector-performance.sh
+COPY /docker/apparmor-profile /opt/scrutiny/apparmor-profile
 COPY /rootfs/etc/cron.d/scrutiny-performance /etc/cron.d/scrutiny-performance
 COPY --from=backendbuild /go/src/github.com/analogj/scrutiny/scrutiny-collector-performance /opt/scrutiny/bin/
 RUN chmod +x /opt/scrutiny/bin/scrutiny-collector-performance && \

--- a/docker/apparmor-profile
+++ b/docker/apparmor-profile
@@ -1,0 +1,90 @@
+# AppArmor profile for Scrutiny collector containers.
+#
+# This profile grants the minimum permissions that smartctl needs to read
+# SMART data from passed-through block devices, while keeping the rest of
+# the default Docker confinement in place.
+#
+# INSTALL (run on the Docker *host*, not inside the container):
+#   sudo cp apparmor-profile /etc/apparmor.d/scrutiny-collector
+#   sudo apparmor_parser -r /etc/apparmor.d/scrutiny-collector
+#
+# USAGE (docker run):
+#   docker run --security-opt apparmor=scrutiny-collector ...
+#
+# USAGE (docker-compose):
+#   security_opt:
+#     - apparmor=scrutiny-collector
+
+#include <tunables/global>
+
+profile scrutiny-collector flags=(attach_disconnected,mediate_deleted) {
+  #include <abstractions/base>
+
+  # ---------- filesystem access ----------
+
+  # Standard container filesystem (read/write)
+  / r,
+  /** rwlk,
+
+  # Block device nodes passed via --device (read-only)
+  /dev/sd*   r,
+  /dev/hd*   r,
+  /dev/nvme* r,
+  /dev/sg*   r,
+  /dev/bsg/** r,
+  /dev/disk/** r,
+
+  # sysfs device metadata used by smartctl for device identification
+  /sys/block/** r,
+  /sys/class/block/** r,
+  /sys/class/scsi_generic/** r,
+  /sys/class/nvme/** r,
+  /sys/devices/** r,
+
+  # proc entries used by smartctl / the collector
+  /proc/*/mounts r,
+  /proc/devices r,
+
+  # ---------- capabilities ----------
+
+  # Required for ATA/SCSI passthrough ioctls (SMART data retrieval)
+  capability sys_rawio,
+
+  # Required for NVMe ioctl access
+  capability sys_admin,
+
+  # Standard capabilities expected by container processes
+  capability dac_override,
+  capability fowner,
+  capability fsetid,
+  capability kill,
+  capability setgid,
+  capability setuid,
+  capability setpcap,
+  capability net_bind_service,
+  capability net_raw,
+  capability chown,
+  capability mknod,
+  capability audit_write,
+  capability setfcap,
+
+  # ---------- network ----------
+
+  network,
+
+  # ---------- signals ----------
+
+  signal (receive) peer=unconfined,
+  signal (send,receive) peer=scrutiny-collector,
+
+  # ---------- deny rules ----------
+
+  # Prevent writes to block devices (collector only reads SMART data)
+  deny /dev/sd* w,
+  deny /dev/hd* w,
+  deny /dev/nvme* w,
+  deny /dev/sg* w,
+
+  # Prevent mounting filesystems
+  deny mount,
+}

--- a/docker/example.hubspoke.docker-compose.yml
+++ b/docker/example.hubspoke.docker-compose.yml
@@ -51,6 +51,16 @@ services:
     cap_add:
       - SYS_RAWIO
       - SYS_ADMIN  # Required for NVMe devices
+    # AppArmor: on systems with AppArmor enforced (TrueNAS SCALE, Ubuntu, Debian),
+    # the default Docker profile blocks raw device I/O even with SYS_RAWIO/SYS_ADMIN.
+    # Option 1 (recommended): load the custom profile on the host, then uncomment:
+    #   sudo cp docker/apparmor-profile /etc/apparmor.d/scrutiny-collector
+    #   sudo apparmor_parser -r /etc/apparmor.d/scrutiny-collector
+    # security_opt:
+    #   - apparmor=scrutiny-collector
+    # Option 2 (less secure): disable AppArmor for this container:
+    # security_opt:
+    #   - apparmor=unconfined
     volumes:
       - '/run/udev:/run/udev:ro'
     environment:

--- a/docker/example.omnibus.docker-compose.yml
+++ b/docker/example.omnibus.docker-compose.yml
@@ -8,6 +8,16 @@ services:
     cap_add:
       - SYS_RAWIO
       - SYS_ADMIN  # Required for NVMe devices
+    # AppArmor: on systems with AppArmor enforced (TrueNAS SCALE, Ubuntu, Debian),
+    # the default Docker profile blocks raw device I/O even with SYS_RAWIO/SYS_ADMIN.
+    # Option 1 (recommended): load the custom profile on the host, then uncomment:
+    #   sudo cp docker/apparmor-profile /etc/apparmor.d/scrutiny-collector
+    #   sudo apparmor_parser -r /etc/apparmor.d/scrutiny-collector
+    # security_opt:
+    #   - apparmor=scrutiny-collector
+    # Option 2 (less secure): disable AppArmor for this container:
+    # security_opt:
+    #   - apparmor=unconfined
     ports:
       - "8080:8080" # webapp
       - "8086:8086" # influxDB admin

--- a/docs/TROUBLESHOOTING_APPARMOR.md
+++ b/docs/TROUBLESHOOTING_APPARMOR.md
@@ -1,0 +1,177 @@
+# AppArmor Troubleshooting
+
+## Problem
+
+On systems with AppArmor enforced (TrueNAS SCALE, Ubuntu, Debian), the Scrutiny collector may fail to read SMART data from drives even when the container is started with `--cap-add SYS_RAWIO --cap-add SYS_ADMIN` and devices are passed through with `--device`.
+
+Symptoms include:
+
+- `smartctl` returns "Permission denied" or fails to open devices
+- The collector logs errors like `smartctl could not open device /dev/sdX`
+- The collector logs a warning: `AppArmor: the container is using the default Docker/containerd profile which blocks raw device I/O`
+- Adding `--cap-add` flags alone does not resolve the issue
+- The same configuration works on systems without AppArmor (e.g., Unraid)
+
+## Root Cause
+
+AppArmor's default Docker profile (`docker-default`) restricts raw device I/O operations regardless of Linux capabilities. The `SYS_RAWIO` capability grants kernel-level permission, but AppArmor applies an additional Mandatory Access Control (MAC) layer that independently blocks the SCSI/ATA/NVMe ioctl calls that `smartctl` requires.
+
+## Affected Platforms
+
+| Platform | AppArmor Status | Impact |
+|----------|----------------|--------|
+| TrueNAS SCALE | Enforced by default | Primary affected platform |
+| Ubuntu / Debian | Enforced by default | Affected with default Docker profile |
+| Unraid | Not used | Not affected |
+| Proxmox LXC | Varies | Potentially affected |
+
+## Solutions
+
+### Option 1: Custom AppArmor Profile (Recommended)
+
+Scrutiny ships a minimal AppArmor profile that grants only the specific access `smartctl` needs while keeping the rest of Docker's confinement in place.
+
+**Step 1: Copy the profile to the host**
+
+The profile is included in the Docker image at `/opt/scrutiny/apparmor-profile`. Copy it to the host's AppArmor profile directory:
+
+```bash
+# From the Docker image:
+docker cp <container_name>:/opt/scrutiny/apparmor-profile /etc/apparmor.d/scrutiny-collector
+
+# Or from the repository:
+sudo cp docker/apparmor-profile /etc/apparmor.d/scrutiny-collector
+```
+
+**Step 2: Load the profile**
+
+```bash
+sudo apparmor_parser -r /etc/apparmor.d/scrutiny-collector
+```
+
+**Step 3: Configure the container to use the profile**
+
+Docker run:
+
+```bash
+docker run \
+  --cap-add SYS_RAWIO --cap-add SYS_ADMIN \
+  --security-opt apparmor=scrutiny-collector \
+  --device=/dev/sda --device=/dev/sdb \
+  ghcr.io/starosdev/scrutiny:latest-collector
+```
+
+Docker Compose:
+
+```yaml
+services:
+  scrutiny:
+    image: ghcr.io/starosdev/scrutiny:latest-omnibus
+    cap_add:
+      - SYS_RAWIO
+      - SYS_ADMIN
+    security_opt:
+      - apparmor=scrutiny-collector
+    devices:
+      - "/dev/sda"
+      - "/dev/sdb"
+```
+
+**Step 4: Verify the profile is loaded (optional)**
+
+```bash
+sudo aa-status | grep scrutiny
+```
+
+The profile persists across reboots because AppArmor automatically loads profiles from `/etc/apparmor.d/` at boot.
+
+### Option 2: Disable AppArmor for the Container
+
+This is simpler but provides less security because the container runs without any AppArmor confinement.
+
+Docker run:
+
+```bash
+docker run \
+  --cap-add SYS_RAWIO --cap-add SYS_ADMIN \
+  --security-opt apparmor=unconfined \
+  --device=/dev/sda --device=/dev/sdb \
+  ghcr.io/starosdev/scrutiny:latest-collector
+```
+
+Docker Compose:
+
+```yaml
+services:
+  scrutiny:
+    image: ghcr.io/starosdev/scrutiny:latest-omnibus
+    cap_add:
+      - SYS_RAWIO
+      - SYS_ADMIN
+    security_opt:
+      - apparmor=unconfined
+    devices:
+      - "/dev/sda"
+      - "/dev/sdb"
+```
+
+### Option 3: Privileged Mode (Not Recommended)
+
+Running with `--privileged` disables all security restrictions. This works but is not recommended for production.
+
+```bash
+docker run --privileged --device=/dev/sda ghcr.io/starosdev/scrutiny:latest-collector
+```
+
+## Security Comparison
+
+| Approach | AppArmor | Capabilities | Device Write | Risk Level |
+|----------|----------|-------------|-------------|------------|
+| Custom profile | Enforced (minimal) | SYS_RAWIO + SYS_ADMIN | Denied | Low |
+| `apparmor=unconfined` | Disabled | SYS_RAWIO + SYS_ADMIN | Depends on caps | Medium |
+| `--privileged` | Disabled | All | Allowed | High |
+
+The custom profile explicitly denies writes to block devices, restricts mount operations, and only allows the specific capabilities and device access that `smartctl` requires.
+
+## TrueNAS SCALE
+
+TrueNAS SCALE manages Docker containers through its app system and enforces AppArmor by default. To use the custom profile:
+
+1. SSH into the TrueNAS host
+2. Copy the AppArmor profile as described in Option 1
+3. Load the profile with `apparmor_parser`
+4. In the TrueNAS app configuration, add the security option `apparmor=scrutiny-collector`
+
+If the TrueNAS app UI does not expose `security_opt`, use Option 2 (`apparmor=unconfined`) or deploy via `docker-compose` directly.
+
+## Diagnostic Logging
+
+The collector automatically detects AppArmor confinement at startup and logs warnings when a restrictive profile is detected. Look for log lines starting with `AppArmor:` in the collector output.
+
+When a device open failure occurs (smartctl exit code 0x02), the collector will additionally log a hint if AppArmor confinement is detected.
+
+To enable verbose logging for troubleshooting:
+
+```bash
+docker run -e COLLECTOR_DEBUG=true ... ghcr.io/starosdev/scrutiny:latest-collector
+```
+
+## Verifying AppArmor Status
+
+Check if AppArmor is active on the host:
+
+```bash
+sudo aa-status
+```
+
+Check which profile a running container is using:
+
+```bash
+docker inspect <container_id> | grep -i apparmor
+```
+
+Check the profile from inside the container:
+
+```bash
+cat /proc/self/attr/apparmor/current
+```


### PR DESCRIPTION
## Summary

- Add a custom AppArmor profile (`docker/apparmor-profile`) granting only the minimum permissions smartctl needs for SMART data retrieval, while keeping the rest of Docker's confinement in place
- Add startup AppArmor detection in the collector that logs actionable warnings when the default `docker-default` profile is active (which blocks raw device I/O)
- Add targeted hint logging when smartctl fails to open a device (exit code 0x02) on AppArmor-confined systems
- Ship the AppArmor profile inside collector, performance, and omnibus Docker images at `/opt/scrutiny/apparmor-profile`
- Add commented `security_opt` examples to both docker-compose files with instructions for loading the profile
- Add comprehensive troubleshooting documentation (`docs/TROUBLESHOOTING_APPARMOR.md`) covering the custom profile, `apparmor=unconfined`, TrueNAS SCALE instructions, and security comparison

## Linked Issues

Closes #361

## Test plan

- [x] `go vet ./collector/...` passes
- [x] `go build ./collector/cmd/collector-metrics/` compiles cleanly
- [x] `go test -count=1 ./collector/pkg/collector/...` passes
- [x] Docker Compose files validate (`docker compose config --quiet`)
- [x] AppArmor detection is purely observational (read + log) -- cannot cause failures
- [x] On non-Linux systems (macOS, Windows, FreeBSD), `/proc/self/attr/` doesn't exist so detection returns silently with no side effects
- [ ] Test AppArmor profile on an Ubuntu/Debian host with AppArmor enforced
- [ ] Test on TrueNAS SCALE environment