### PR TITLE
fix(collector): prevent cron bomb from accumulating collector processes

### DIFF
--- a/collector/cmd/collector-metrics/collector-metrics.go
+++ b/collector/cmd/collector-metrics/collector-metrics.go
@@ -212,7 +212,7 @@ OPTIONS:
 						return fmt.Errorf("invalid cron schedule %q: %w", cronSchedule, err)
 					}
 					c2.Start()
-					collectorLogger.Infof("Collector scheduled with cron expression: %s", cronSchedule)
+					collectorLogger.Warnf("Internal cron scheduler active with expression: %s. If running under system cron (Docker), ensure COLLECTOR_CRON_SCHEDULE env var is unset to avoid process accumulation.", cronSchedule)
 
 					quit := make(chan os.Signal, 1)
 					signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
@@ -261,22 +261,19 @@ OPTIONS:
 					},
 
 					&cli.StringFlag{
-						Name:    "cron-schedule",
-						Usage:   "Cron expression for scheduled collection (e.g. \"0 * * * *\"). If not set, the collector runs once and exits.",
-						EnvVars: []string{"COLLECTOR_CRON_SCHEDULE"},
+						Name:  "cron-schedule",
+						Usage: "Cron expression for scheduled collection (e.g. \"0 * * * *\"). If not set, the collector runs once and exits.",
 					},
 
 					&cli.BoolFlag{
-						Name:    "run-startup",
-						Usage:   "Run an immediate collection on startup before the first scheduled tick",
-						EnvVars: []string{"COLLECTOR_RUN_STARTUP"},
+						Name:  "run-startup",
+						Usage: "Run an immediate collection on startup before the first scheduled tick",
 					},
 
 					&cli.IntFlag{
-						Name:    "run-startup-sleep",
-						Usage:   "Seconds to sleep before the startup run (requires --run-startup)",
-						Value:   0,
-						EnvVars: []string{"COLLECTOR_RUN_STARTUP_SLEEP"},
+						Name:  "run-startup-sleep",
+						Usage: "Seconds to sleep before the startup run (requires --run-startup)",
+						Value: 0,
 					},
 				},
 			},

--- a/docker/entrypoint-collector-performance.sh
+++ b/docker/entrypoint-collector-performance.sh
@@ -19,7 +19,7 @@ sed -i 's|{COLLECTOR_PERF_CRON_SCHEDULE}|'"${COLLECTOR_PERF_CRON_SCHEDULE}"'|g' 
 if [[ "${COLLECTOR_PERF_RUN_STARTUP}" == "true" ]]; then
     sleep ${COLLECTOR_PERF_RUN_STARTUP_SLEEP}
     echo "starting scrutiny performance collector (run-once mode. subsequent calls will be triggered via cron service)"
-    /opt/scrutiny/bin/scrutiny-collector-performance run
+    COLLECTOR_CRON_SCHEDULE= COLLECTOR_PERF_RUN_STARTUP= /opt/scrutiny/bin/scrutiny-collector-performance run
 fi
 
 

--- a/docker/entrypoint-collector-zfs.sh
+++ b/docker/entrypoint-collector-zfs.sh
@@ -19,7 +19,7 @@ sed -i 's|{COLLECTOR_ZFS_CRON_SCHEDULE}|'"${COLLECTOR_ZFS_CRON_SCHEDULE}"'|g' /e
 if [[ "${COLLECTOR_ZFS_RUN_STARTUP}" == "true" ]]; then
     sleep ${COLLECTOR_ZFS_RUN_STARTUP_SLEEP}
     echo "starting scrutiny ZFS collector (run-once mode. subsequent calls will be triggered via cron service)"
-    /opt/scrutiny/bin/scrutiny-collector-zfs run
+    COLLECTOR_CRON_SCHEDULE= COLLECTOR_ZFS_RUN_STARTUP= /opt/scrutiny/bin/scrutiny-collector-zfs run
 fi
 
 

--- a/docker/entrypoint-collector.sh
+++ b/docker/entrypoint-collector.sh
@@ -19,7 +19,7 @@ sed -i 's|{COLLECTOR_CRON_SCHEDULE}|'"${COLLECTOR_CRON_SCHEDULE}"'|g' /etc/cron.
 if [[ "${COLLECTOR_RUN_STARTUP}" == "true" ]]; then
     sleep ${COLLECTOR_RUN_STARTUP_SLEEP}
     echo "starting scrutiny collector (run-once mode. subsequent calls will be triggered via cron service)"
-    /opt/scrutiny/bin/scrutiny-collector-metrics run
+    COLLECTOR_CRON_SCHEDULE= COLLECTOR_RUN_STARTUP= /opt/scrutiny/bin/scrutiny-collector-metrics run
 fi
 
 

--- a/rootfs/etc/cron.d/scrutiny
+++ b/rootfs/etc/cron.d/scrutiny
@@ -11,5 +11,5 @@ MAILTO=""
 # correctly route collector logs (STDOUT & STDERR) to Cron foreground (collectable by Docker STDOUT)
 # cron schedule to run daily at midnight:  '0 0 * * *'
 # System environmental variables are stripped by cron, source our dump of the docker environmental variables before each command (/env.sh)
-{COLLECTOR_CRON_SCHEDULE} root . /env.sh; /opt/scrutiny/bin/scrutiny-collector-metrics run >/proc/1/fd/1 2>/proc/1/fd/2
+{COLLECTOR_CRON_SCHEDULE} root . /env.sh; unset COLLECTOR_CRON_SCHEDULE COLLECTOR_RUN_STARTUP; /opt/scrutiny/bin/scrutiny-collector-metrics run >/proc/1/fd/1 2>/proc/1/fd/2
 # An empty line is required at the end of this file for a valid cron file.

--- a/rootfs/etc/cron.d/scrutiny-performance
+++ b/rootfs/etc/cron.d/scrutiny-performance
@@ -11,5 +11,5 @@ MAILTO=""
 # correctly route collector logs (STDOUT & STDERR) to Cron foreground (collectable by Docker STDOUT)
 # cron schedule to run weekly on Sunday at 2AM:  '0 2 * * 0'
 # System environmental variables are stripped by cron, source our dump of the docker environmental variables before each command (/env.sh)
-{COLLECTOR_PERF_CRON_SCHEDULE} root . /env.sh; /opt/scrutiny/bin/scrutiny-collector-performance run >/proc/1/fd/1 2>/proc/1/fd/2
+{COLLECTOR_PERF_CRON_SCHEDULE} root . /env.sh; unset COLLECTOR_CRON_SCHEDULE COLLECTOR_RUN_STARTUP; /opt/scrutiny/bin/scrutiny-collector-performance run >/proc/1/fd/1 2>/proc/1/fd/2
 # An empty line is required at the end of this file for a valid cron file.

--- a/rootfs/etc/cron.d/scrutiny-zfs
+++ b/rootfs/etc/cron.d/scrutiny-zfs
@@ -11,5 +11,5 @@ MAILTO=""
 # correctly route collector logs (STDOUT & STDERR) to Cron foreground (collectable by Docker STDOUT)
 # cron schedule to run every 15 minutes:  '*/15 * * * *'
 # System environmental variables are stripped by cron, source our dump of the docker environmental variables before each command (/env.sh)
-{COLLECTOR_ZFS_CRON_SCHEDULE} root . /env.sh; /opt/scrutiny/bin/scrutiny-collector-zfs run >/proc/1/fd/1 2>/proc/1/fd/2
+{COLLECTOR_ZFS_CRON_SCHEDULE} root . /env.sh; unset COLLECTOR_CRON_SCHEDULE COLLECTOR_RUN_STARTUP; /opt/scrutiny/bin/scrutiny-collector-zfs run >/proc/1/fd/1 2>/proc/1/fd/2
 # An empty line is required at the end of this file for a valid cron file.

--- a/rootfs/etc/services.d/collector-once/run
+++ b/rootfs/etc/services.d/collector-once/run
@@ -14,7 +14,7 @@ s6-svwait -u /run/service/scrutiny
 until $(curl --output /dev/null --silent --head --fail http://localhost:8080/api/health); do echo "scrutiny api not ready" && sleep 5; done
 
 echo "starting scrutiny collector (run-once mode. subsequent calls will be triggered via cron service)"
-/opt/scrutiny/bin/scrutiny-collector-metrics run
+COLLECTOR_CRON_SCHEDULE= COLLECTOR_RUN_STARTUP= /opt/scrutiny/bin/scrutiny-collector-metrics run
 
 # prevent script's core logic from running again
 touch /tmp/custom-init-performed

--- a/rootfs/etc/services.d/collector-performance-once/run
+++ b/rootfs/etc/services.d/collector-performance-once/run
@@ -21,7 +21,7 @@ s6-svwait -u /run/service/scrutiny
 until $(curl --output /dev/null --silent --head --fail http://localhost:8080/api/health); do echo "scrutiny api not ready" && sleep 5; done
 
 echo "starting performance collector (run-once mode)"
-/opt/scrutiny/bin/scrutiny-collector-performance run
+COLLECTOR_CRON_SCHEDULE= /opt/scrutiny/bin/scrutiny-collector-performance run
 
 touch /tmp/perf-collector-init-performed
 s6-svc -D /run/service/collector-performance-once

--- a/rootfs/etc/services.d/collector-zfs-once/run
+++ b/rootfs/etc/services.d/collector-zfs-once/run
@@ -21,7 +21,7 @@ s6-svwait -u /run/service/scrutiny
 until $(curl --output /dev/null --silent --head --fail http://localhost:8080/api/health); do echo "scrutiny api not ready" && sleep 5; done
 
 echo "starting ZFS collector (run-once mode)"
-/opt/scrutiny/bin/scrutiny-collector-zfs run
+COLLECTOR_CRON_SCHEDULE= /opt/scrutiny/bin/scrutiny-collector-zfs run
 
 touch /tmp/zfs-collector-init-performed
 s6-svc -D /run/service/collector-zfs-once


### PR DESCRIPTION
## Summary

Fixes #365 - Collector cron processes accumulate exponentially in Docker containers when `COLLECTOR_CRON_SCHEDULE` env var is set.

**Root cause:** When system cron fires and runs `scrutiny-collector-metrics run`, the `COLLECTOR_CRON_SCHEDULE` env var is sourced from `/env.sh`. The Go binary picks it up via CLI flag EnvVars binding and Viper AutomaticEnv, activating an internal Go cron scheduler that blocks forever. Each system cron tick spawns another long-lived process -- exponential growth.

**Reproduced on Zeus:** Confirmed 3 accumulated scheduler instances on prod and 7 on dev after just 2.5 minutes with `*/1 * * * *` schedule.

## Changes

- **Crontab templates** (`rootfs/etc/cron.d/scrutiny*`): Unset `COLLECTOR_CRON_SCHEDULE` and `COLLECTOR_RUN_STARTUP` before invoking collector binary
- **Entrypoint scripts** (`docker/entrypoint-collector*.sh`): Clear cron env vars for startup runs using inline env override
- **S6 once services** (`rootfs/etc/services.d/collector-*-once/run`): Same fix for omnibus container startup collectors
- **CLI flag hardening** (`collector/cmd/collector-metrics/collector-metrics.go`): Remove `EnvVars` bindings from `cron-schedule`, `run-startup`, and `run-startup-sleep` flags so internal scheduler only activates via explicit `--cron-schedule` CLI flag or `collector.yaml`
- **Warning log**: Changed scheduler activation log from info to warn with guidance about env var conflict

## Test plan

- [x] Reproduced bug on prod Zeus (3 schedulers in 2.5 min)
- [x] Reproduced bug on dev Zeus (7 collector processes in 2.5 min)
- [x] Restored both environments to normal
- [x] Go tests pass (`go test ./collector/...`)
- [ ] Build Docker image with fix and verify no process accumulation with `COLLECTOR_CRON_SCHEDULE='*/1 * * * *'`
- [ ] Verify `COLLECTOR_RUN_STARTUP=true` still works correctly
- [ ] Verify `--cron-schedule` CLI flag still works for non-Docker usage