### PR TITLE
feat(collector-zfs): add arm64 support for scrutiny collector zfs

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -137,7 +137,7 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v7
         with:
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           context: .
           file: docker/Dockerfile.collector-zfs
           push: true

--- a/docker/Dockerfile.collector-zfs
+++ b/docker/Dockerfile.collector-zfs
@@ -4,14 +4,17 @@
 
 
 ########
-FROM golang:1.26-trixie AS backendbuild
+FROM --platform=$BUILDPLATFORM golang:1.26-trixie AS backendbuild
+ARG TARGETOS
+ARG TARGETARCH
 
 WORKDIR /go/src/github.com/analogj/scrutiny
 
 COPY . /go/src/github.com/analogj/scrutiny
 
 RUN apt-get update && apt-get install -y file && rm -rf /var/lib/apt/lists/*
-RUN make binary-clean binary-collector-zfs
+RUN GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} make binary-clean binary-collector-zfs && \
+    mv scrutiny-collector-zfs-${TARGETOS:-linux}-${TARGETARCH:-amd64} scrutiny-collector-zfs
 
 ########
 FROM debian:trixie-slim AS runtime
@@ -20,7 +23,8 @@ ENV PATH="/opt/scrutiny/bin:${PATH}"
 
 RUN echo "deb http://deb.debian.org/debian trixie contrib" >> /etc/apt/sources.list.d/contrib.list && \
     apt-get update && \
-    apt-get install -y cron zfsutils-linux ca-certificates tzdata && \
+    apt-get install -y cron ca-certificates tzdata && \
+    apt-get install -y --no-install-recommends zfsutils-linux && \
     rm -rf /var/lib/apt/lists/* && \
     update-ca-certificates
 


### PR DESCRIPTION
## Summary

This PR adds native `linux/arm64` cross-compilation support to the `collector-zfs` Docker image and solves the 45+ minute QEMU emulation bottleneck. 

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD or infrastructure change

## Related Issues
Closes #90

## Changes Made

<!-- List the specific changes made in this PR -->

- Re-enabled `linux/arm64` in the `collector-zfs` build target within `.github/workflows/docker-build.yaml`.
- Integrated Docker Buildx `--platform=$BUILDPLATFORM` into `Dockerfile.collector-zfs`, enabling Go to natively cross-compile the binary to ARM64 before moving to final QEMU image assembly.
- Implemented the `--no-install-recommends` flag for `apt-get install zfsutils-linux` to reduce the total build time (see additional notes).

## Testing

<!-- Describe the testing you've done -->

- [x] I have tested this locally
- [ ] I have added/updated tests that prove my fix/feature works
- [x] All existing tests pass

I have also pushed this to a temp package repository to test it on my Raspberry Pi, resulting in my ZFS pool showing up in Scrutiny.

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary (particularly complex areas)
- [x] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [x] No console.log, debug statements, or commented-out code

## Screenshots (if applicable)

<!-- Add screenshots to demonstrate visual changes -->

## Additional Notes

Because Docker containers share their underlying kernel with the host, generating arbitrary ZFS kernel modules via `zfs-dkms` natively inside the container during build time was unnecessarily taxing the QEMU pipeline. By using `--no-install-recommends`, it skips the installation of zfs-dkms and only the necessary `zpool` libraries are downloaded.

<details>
<summary>Effects of `--no-install-recommends`</summary
The following is installed:

With `--no-install-recommends`:
Installing:
  zfsutils-linux

Installing dependencies:
  libcom-err2       libnvpair3linux        libzpool6linux
  libexpat1         libpython3-stdlib      media-types
  libffi8           libpython3.13-minimal  netbase
  libgssapi-krb5-2  libpython3.13-stdlib   python3
  libk5crypto3      libreadline8t64        python3-minimal
  libkeyutils1      libtirpc-common        python3.13
  libkrb5-3         libtirpc3t64           python3.13-minimal
  libkrb5support0   libuutil3linux         readline-common
  libncursesw6      libzfs6linux
  
Without `--no-install-recommends`:
Installing:
  zfsutils-linux

Installing dependencies:
  binutils                    libexpat1               librtmp1
  binutils-aarch64-linux-gnu  libfakeroot             libsasl2-2
  binutils-common             libffi8                 libsasl2-modules
  build-essential             libfile-fcntllock-perl  libsasl2-modules-db
  bzip2                       libgcc-14-dev           libsframe1
  ca-certificates             libgdbm-compat4t64      libssh2-1t64
  cpp                         libgdbm6t64             libstdc++-14-dev
  cpp-14                      libgnutls30t64          libtasn1-6
  cpp-14-aarch64-linux-gnu    libgomp1                libtirpc-common
  cpp-aarch64-linux-gnu       libgpm2                 libtirpc3t64
  dkms                        libgprofng0             libtsan2
  dpkg-dev                    libgssapi-krb5-2        libubsan1
  fakeroot                    libhwasan0              libunistring5
  file                        libidn2-0               libuutil3linux
  g++                         libisl23                libzfs6linux
  g++-14                      libitm1                 libzpool6linux
  g++-14-aarch64-linux-gnu    libjansson4             linux-libc-dev
  g++-aarch64-linux-gnu       libk5crypto3            lsb-release
  gcc                         libkeyutils1            make
  gcc-14                      libkmod2                manpages
  gcc-14-aarch64-linux-gnu    libkrb5-3               manpages-dev
  gcc-aarch64-linux-gnu       libkrb5support0         media-types
  kmod                        libldap-common          netbase
  krb5-locales                libldap2                openssl
  libalgorithm-diff-perl      liblocale-gettext-perl  patch
  libalgorithm-diff-xs-perl   liblsan0                perl
  libalgorithm-merge-perl     libmagic-mgc            perl-modules-5.40
  libapparmor1                libmagic1t64            publicsuffix
  libasan8                    libmpc3                 python3
  libatomic1                  libmpfr6                python3-minimal
  libbinutils                 libncursesw6            python3.13
  libbrotli1                  libnghttp2-14           python3.13-minimal
  libc-dev-bin                libnghttp3-9            readline-common
  libc6-dev                   libnvpair3linux         rpcsvc-proto
  libcc1-0                    libp11-kit0             sq
  libcom-err2                 libperl5.40             sudo
  libcrypt-dev                libpsl5t64              xz-utils
  libctf-nobfd0               libpython3-stdlib       zfs-dkms
  libctf0                     libpython3.13-minimal   zfs-zed
  libcurl4t64                 libpython3.13-stdlib
  libdpkg-perl                libreadline8t64
</details>