### PR TITLE
fix(backend): address potential memory leak sources (#419)

### DIFF
--- a/rootfs/etc/services.d/influxdb/run
+++ b/rootfs/etc/services.d/influxdb/run
@@ -10,6 +10,8 @@ bolt-path: /opt/scrutiny/influxdb/influxd.bolt
 engine-path: /opt/scrutiny/influxdb/engine
 http-bind-address: ":8086"
 reporting-disabled: true
+storage-cache-max-memory-size: 256000000
+storage-cache-snapshot-memory-size: 25000000
 EOF
 fi
 

--- a/webapp/backend/pkg/database/scrutiny_repository.go
+++ b/webapp/backend/pkg/database/scrutiny_repository.go
@@ -327,6 +327,7 @@ func InfluxSetupComplete(influxEndpoint string, tlsConfig *tls.Config) (bool, er
 	if err != nil {
 		return false, err
 	}
+	defer res.Body.Close()
 
 	body, err := ioutil.ReadAll(res.Body)
 	if err != nil {
@@ -499,6 +500,7 @@ func (sr *scrutinyRepository) GetSummary(ctx context.Context) (map[string]*model
 
 	result, err := sr.influxQueryApi.Query(ctx, queryStr)
 	if err == nil {
+		defer result.Close()
 		// Use Next() to iterate over query result lines
 		for result.Next() {
 			//get summary data from Influxdb.
@@ -642,6 +644,7 @@ union(tables: [dailyData, weeklyData, monthlyData, yearlyData])
 	if err != nil {
 		return nil, fmt.Errorf("failed to query last seen times: %w", err)
 	}
+	defer result.Close()
 
 	for result.Next() {
 		values := result.Record().Values()

--- a/webapp/backend/pkg/database/scrutiny_repository_device_smart_attributes.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_device_smart_attributes.go
@@ -80,6 +80,7 @@ func (sr *scrutinyRepository) GetSmartAttributeHistory(ctx context.Context, wwn 
 
 	result, err := sr.influxQueryApi.Query(ctx, queryStr)
 	if err == nil {
+		defer result.Close()
 		// Use Next() to iterate over query result lines
 		for result.Next() {
 			smartData, err := measurements.NewSmartFromInfluxDB(result.Record().Values(), sr.logger)
@@ -140,6 +141,7 @@ from(bucket: "%s")
 	if err != nil {
 		return nil, err
 	}
+	defer result.Close()
 
 	for result.Next() {
 		smartData, err := measurements.NewSmartFromInfluxDB(result.Record().Values(), sr.logger)
@@ -181,6 +183,7 @@ from(bucket: "%s")
 	if err != nil {
 		return nil, err
 	}
+	defer result.Close()
 
 	for result.Next() {
 		smartData, err := measurements.NewSmartFromInfluxDB(result.Record().Values(), sr.logger)

--- a/webapp/backend/pkg/database/scrutiny_repository_performance.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_performance.go
@@ -52,6 +52,7 @@ func (sr *scrutinyRepository) GetPerformanceHistory(ctx context.Context, wwn str
 	if err != nil {
 		return nil, fmt.Errorf("failed to query performance metrics: %v", err)
 	}
+	defer result.Close()
 
 	var history []measurements.Performance
 	for result.Next() {
@@ -92,6 +93,7 @@ func (sr *scrutinyRepository) GetPerformanceBaseline(ctx context.Context, wwn st
 	if err != nil {
 		return nil, fmt.Errorf("failed to query performance baseline: %v", err)
 	}
+	defer result.Close()
 
 	var results []measurements.Performance
 	for result.Next() {

--- a/webapp/backend/pkg/database/scrutiny_repository_temperature.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_temperature.go
@@ -80,6 +80,7 @@ func (sr *scrutinyRepository) GetSmartTemperatureHistory(ctx context.Context, du
 
 	result, err := sr.influxQueryApi.Query(ctx, queryStr)
 	if err == nil {
+		defer result.Close()
 		// Use Next() to iterate over query result lines
 		for result.Next() {
 

--- a/webapp/backend/pkg/database/scrutiny_repository_workload.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_workload.go
@@ -203,6 +203,7 @@ func (sr *scrutinyRepository) queryWorkloadFirstLast(ctx context.Context, durati
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to query workload data: %w", err)
 	}
+	defer result.Close()
 
 	for result.Next() {
 		values := result.Record().Values()
@@ -323,6 +324,7 @@ func (sr *scrutinyRepository) queryWorkloadRecent(ctx context.Context) (map[stri
 	if err != nil {
 		return nil, fmt.Errorf("failed to query recent workload data: %w", err)
 	}
+	defer result.Close()
 
 	for result.Next() {
 		values := result.Record().Values()

--- a/webapp/backend/pkg/database/scrutiny_repository_zfs.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_zfs.go
@@ -304,6 +304,7 @@ func (sr *scrutinyRepository) GetZFSPoolMetricsHistory(ctx context.Context, guid
 	if err != nil {
 		return nil, fmt.Errorf("failed to query ZFS pool metrics: %v", err)
 	}
+	defer result.Close()
 
 	var metricsHistory []measurements.ZFSPoolMetrics
 	for result.Next() {


### PR DESCRIPTION
## Summary

- Close InfluxDB `QueryTableResult` at all 11 query call sites to prevent HTTP response body leaks on early returns
- Close HTTP response body in `InfluxSetupComplete` health check
- Cap InfluxDB TSM cache memory in omnibus mode (256MB max, 25MB snapshot threshold) to prevent unbounded growth

## Linked Issues

Closes #419

## Test plan

- [x] `go vet ./webapp/backend/...` passes
- [x] `go test ./webapp/backend/...` passes
- [ ] Deploy to dev environment and monitor memory usage over 24-48 hours