### PR TITLE
fix(settings): block override submission for remaining 400 cases (#476)

### DIFF
--- a/webapp/frontend/src/app/layout/common/dashboard-settings/dashboard-settings.component.html
+++ b/webapp/frontend/src/app/layout/common/dashboard-settings/dashboard-settings.component.html
@@ -498,7 +498,7 @@
                     <button mat-raised-button color="primary"
                             class="mt-4"
                             (click)="addOverride()"
-                            [disabled]="!newOverride.protocol || !newOverride.attribute_id || (newOverride.action === '' && newOverride.warn_above == null && newOverride.fail_above == null)">
+                            [disabled]="!newOverride.protocol || !newOverride.attribute_id || (newOverride.action === '' && newOverride.warn_above == null && newOverride.fail_above == null) || (newOverride.action === 'force_status' && !newOverride.status)">
                         Add Override
                     </button>
                 </div>

--- a/webapp/frontend/src/app/layout/common/dashboard-settings/dashboard-settings.component.ts
+++ b/webapp/frontend/src/app/layout/common/dashboard-settings/dashboard-settings.component.ts
@@ -227,6 +227,12 @@ export class DashboardSettingsComponent implements OnInit {
         if (this.newOverride.action === '' && this.newOverride.warn_above == null && this.newOverride.fail_above == null) {
             return;
         }
+        if (this.newOverride.action === 'force_status' && !this.newOverride.status) {
+            return;
+        }
+        if (this.newOverride.action === '' && this.newOverride.warn_above != null && this.newOverride.fail_above != null && this.newOverride.warn_above >= this.newOverride.fail_above) {
+            return;
+        }
 
         const override: AttributeOverride = {
             protocol: this.newOverride.protocol as OverrideProtocol,


### PR DESCRIPTION
## Summary

- Disables Add Override button when action is `force_status` but no status is selected
- Adds guard in `addOverride()` to abort when `force_status` has no status
- Adds guard to abort when Custom Threshold has `warn_above >= fail_above`

Both scenarios were accepted by the frontend but rejected by backend validation with a 400, unaddressed by the previous fix in #477.

## Linked Issues

Closes #476

## Test plan

- [ ] Select Force Status action, leave status empty — button is disabled
- [ ] Select Custom Threshold, set warn_above >= fail_above — form does not submit
- [ ] All previously working override actions (Ignore, valid Force Status, valid Custom Threshold) still submit successfully