### PR TITLE
Workaround parsing bug to prevent data loss

### DIFF
--- a/webapp/backend/pkg/database/migrations/m20260401000000/device.go
+++ b/webapp/backend/pkg/database/migrations/m20260401000000/device.go
@@ -6,8 +6,6 @@ import (
 )
 
 // Device represents the schema after swapping the primary key from WWN to DeviceID.
-// This migration struct is used only for reference; the actual migration uses raw SQL
-// because SQLite cannot alter primary keys in-place.
 type Device struct {
 	CreatedAt                 time.Time
 	UpdatedAt                 time.Time

--- a/webapp/backend/pkg/database/migrations/m20260414000000/m20260414000000.go
+++ b/webapp/backend/pkg/database/migrations/m20260414000000/m20260414000000.go
@@ -1,0 +1,22 @@
+package m20260414000000
+
+import (
+	"time"
+)
+
+// AttributeOverride removes soft-deletes. The UNIQUE constraint/index on
+// Protocol/AttributeID/WWN is applied after table recreation in the migration
+// to avoid running into errors where idx_override_lookup already exists.
+type AttributeOverride struct {
+	ID          uint      `json:"id" gorm:"primaryKey"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+	WarnAbove   *int64    `json:"warn_above,omitempty"`
+	FailAbove   *int64    `json:"fail_above,omitempty"`
+	Protocol    string    `json:"protocol" gorm:"not null"`
+	AttributeId string    `json:"attribute_id" gorm:"not null"`
+	WWN         string    `json:"wwn,omitempty"`
+	Action      string    `json:"action,omitempty"`
+	Status      string    `json:"status,omitempty"`
+	Source      string    `json:"source" gorm:"default:'ui'"`
+}

--- a/webapp/backend/pkg/database/scrutiny_repository_migrations.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_migrations.go
@@ -24,7 +24,8 @@ import (
 	"github.com/analogj/scrutiny/webapp/backend/pkg/database/migrations/m20260226000000"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/database/migrations/m20260301000000"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/database/migrations/m20260315000000"
-	_ "github.com/analogj/scrutiny/webapp/backend/pkg/database/migrations/m20260401000000"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/database/migrations/m20260401000000"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/database/migrations/m20260414000000"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/database/migrations/m20260421000000"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/database/migrations/m20260508000000"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/database/migrations/m20260510000000"
@@ -726,40 +727,8 @@ func (sr *scrutinyRepository) Migrate(ctx context.Context) error {
 				}
 
 				// Step 1: Create new table with device_id as PRIMARY KEY
-				createSQL := `CREATE TABLE devices_new (
-					device_id TEXT PRIMARY KEY,
-					wwn TEXT,
-					created_at DATETIME,
-					updated_at DATETIME,
-					deleted_at DATETIME,
-					device_name TEXT,
-					device_uuid TEXT,
-					device_serial_id TEXT,
-					device_label TEXT,
-					manufacturer TEXT,
-					model_name TEXT,
-					interface_type TEXT,
-					interface_speed TEXT,
-					serial_number TEXT,
-					firmware TEXT,
-					rotation_speed INTEGER,
-					capacity INTEGER,
-					form_factor TEXT,
-					smart_support NUMERIC,
-					device_protocol TEXT,
-					device_type TEXT,
-					label TEXT,
-					host_id TEXT,
-					collector_version TEXT,
-					smart_display_mode TEXT DEFAULT 'scrutiny',
-					device_status INTEGER,
-					has_forced_failure NUMERIC DEFAULT 0,
-					archived NUMERIC,
-					muted NUMERIC,
-					missed_ping_timeout_override INTEGER DEFAULT 0
-				)`
-				if err := tx.Exec(createSQL).Error; err != nil {
-					return fmt.Errorf("failed to create devices_new: %w", err)
+				if err := tx.Table("devices_new").AutoMigrate(&m20260401000000.Device{}); err != nil {
+					return fmt.Errorf("failed to create devices_new for device_id migration: %w", err)
 				}
 
 				// Step 2: Copy all data from old table
@@ -903,21 +872,8 @@ func (sr *scrutinyRepository) Migrate(ctx context.Context) error {
 				}
 
 				// Step 2: Recreate table without deleted_at column (SQLite lacks DROP COLUMN on older versions).
-				createSQL := `CREATE TABLE attribute_overrides_new (
-					id INTEGER PRIMARY KEY AUTOINCREMENT,
-					created_at DATETIME,
-					updated_at DATETIME,
-					protocol TEXT NOT NULL,
-					attribute_id TEXT NOT NULL,
-					wwn TEXT DEFAULT '',
-					action TEXT DEFAULT '',
-					status TEXT DEFAULT '',
-					warn_above INTEGER,
-					fail_above INTEGER,
-					source TEXT DEFAULT 'ui'
-				)`
-				if err := tx.Exec(createSQL).Error; err != nil {
-					return fmt.Errorf("failed to create attribute_overrides_new: %w", err)
+				if err := tx.Table("attribute_overrides_new").AutoMigrate(&m20260414000000.AttributeOverride{}); err != nil {
+					return fmt.Errorf("failed to create attribute_overrides_new for soft-delete purge migration: %w", err)
 				}
 
 				// Step 3: Copy live data (deleted_at rows already purged in step 1).
@@ -959,39 +915,7 @@ func (sr *scrutinyRepository) Migrate(ctx context.Context) error {
 		{
 			ID: "m20260508000000", // store device smart_support as structured JSON
 			Migrate: func(tx *gorm.DB) error {
-				createSQL := `CREATE TABLE devices_new (
-					device_id TEXT PRIMARY KEY,
-					wwn TEXT,
-					created_at DATETIME,
-					updated_at DATETIME,
-					deleted_at DATETIME,
-					device_name TEXT,
-					device_uuid TEXT,
-					device_serial_id TEXT,
-					device_label TEXT,
-					manufacturer TEXT,
-					model_name TEXT,
-					interface_type TEXT,
-					interface_speed TEXT,
-					serial_number TEXT,
-					firmware TEXT,
-					rotation_speed INTEGER,
-					capacity INTEGER,
-					form_factor TEXT,
-					smart_support TEXT,
-					device_protocol TEXT,
-					device_type TEXT,
-					label TEXT,
-					host_id TEXT,
-					collector_version TEXT,
-					smart_display_mode TEXT DEFAULT 'scrutiny',
-					device_status INTEGER,
-					has_forced_failure NUMERIC DEFAULT 0,
-					archived NUMERIC,
-					muted NUMERIC,
-					missed_ping_timeout_override INTEGER DEFAULT 0
-				)`
-				if err := tx.Exec(createSQL).Error; err != nil {
+				if err := tx.Table("devices_new").AutoMigrate(&m20260508000000.Device{}); err != nil {
 					return fmt.Errorf("failed to create devices_new for smart_support migration: %w", err)
 				}
 
@@ -1040,7 +964,7 @@ func (sr *scrutinyRepository) Migrate(ctx context.Context) error {
 					return fmt.Errorf("failed to recreate idx_devices_deleted_at: %w", err)
 				}
 
-				return tx.AutoMigrate(&m20260508000000.Device{})
+				return nil
 			},
 		},
 		{

--- a/webapp/backend/pkg/models/attribute_override.go
+++ b/webapp/backend/pkg/models/attribute_override.go
@@ -10,6 +10,7 @@ import (
 // stored in the database. This allows users to ignore attributes, force their status,
 // or set custom warning/failure thresholds via the UI.
 type AttributeOverride struct {
+	ID          uint      `json:"id" gorm:"primaryKey"`
 	CreatedAt   time.Time `json:"created_at"`
 	UpdatedAt   time.Time `json:"updated_at"`
 	WarnAbove   *int64    `json:"warn_above,omitempty"`
@@ -20,7 +21,6 @@ type AttributeOverride struct {
 	Action      string    `json:"action,omitempty"`
 	Status      string    `json:"status,omitempty"`
 	Source      string    `json:"source" gorm:"default:'ui'"`
-	ID          uint      `json:"id" gorm:"primaryKey"`
 }
 
 // TableName specifies the table name for GORM


### PR DESCRIPTION
Replaces the manual `CREATE TABLE` statements with `AutoMigrate()` calls so the resulting DDL will always be what gorm+deps expect to see in future migrations, fixing both the tab *and* default-quoting issues at the same time.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Refactoring (no functional changes)

## Related Issues

Fixes Starosdev/scrutiny#539. Upstream fix: go-gorm/sqlite#222

## Testing

<!-- Describe the testing you've done -->

- [x] I have tested this locally
- [ ] I have added/updated tests that prove my fix/feature works
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary (particularly complex areas)
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [x] No console.log, debug statements, or commented-out code
