### PR TITLE
SCRUTINY v1.0.0 — add beta GHCR publish channel and align release docs

### DIFF
--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -1,0 +1,64 @@
+name: Publish Beta Image
+
+on:
+  push:
+    branches:
+      - beta
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-beta-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  build-and-publish:
+    name: Build and Publish Beta
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Normalize image name
+        id: image_name
+        run: |
+          set -euo pipefail
+          echo "value=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+        with:
+          platforms: arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log into registry
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push beta image
+        uses: docker/build-push-action@v7
+        with:
+          platforms: linux/amd64,linux/arm64
+          context: .
+          file: docker/Dockerfile
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ steps.image_name.outputs.value }}:beta
+            ${{ env.REGISTRY }}/${{ steps.image_name.outputs.value }}:beta-omnibus
+          cache-from: type=gha,scope=beta-omnibus
+          cache-to: type=gha,mode=max,scope=beta-omnibus

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - beta
       - develop
     paths:
       - 'webapp/**'
@@ -72,6 +73,7 @@ jobs:
             type=raw,value=${{ inputs.tag_suffix }}-collector,enable=${{ github.event_name == 'workflow_dispatch' }}
             # Branch builds
             type=raw,value=latest-collector,enable=${{ (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')) && github.event_name != 'workflow_dispatch' }}
+            type=raw,value=beta-collector,enable=${{ github.ref == 'refs/heads/beta' && github.event_name != 'workflow_dispatch' }}
             type=raw,value=develop-collector,enable=${{ github.ref == 'refs/heads/develop' && github.event_name != 'workflow_dispatch' }}
             # Version tags
             type=semver,pattern={{version}}-collector
@@ -131,6 +133,7 @@ jobs:
             type=raw,value=${{ inputs.tag_suffix }}-collector-zfs,enable=${{ github.event_name == 'workflow_dispatch' }}
             # Branch builds
             type=raw,value=latest-collector-zfs,enable=${{ (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')) && github.event_name != 'workflow_dispatch' }}
+            type=raw,value=beta-collector-zfs,enable=${{ github.ref == 'refs/heads/beta' && github.event_name != 'workflow_dispatch' }}
             type=raw,value=develop-collector-zfs,enable=${{ github.ref == 'refs/heads/develop' && github.event_name != 'workflow_dispatch' }}
             # Version tags
             type=semver,pattern={{version}}-collector-zfs
@@ -190,6 +193,7 @@ jobs:
             type=raw,value=${{ inputs.tag_suffix }}-collector-mdadm,enable=${{ github.event_name == 'workflow_dispatch' }}
             # Branch builds
             type=raw,value=latest-collector-mdadm,enable=${{ (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')) && github.event_name != 'workflow_dispatch' }}
+            type=raw,value=beta-collector-mdadm,enable=${{ github.ref == 'refs/heads/beta' && github.event_name != 'workflow_dispatch' }}
             type=raw,value=develop-collector-mdadm,enable=${{ github.ref == 'refs/heads/develop' && github.event_name != 'workflow_dispatch' }}
             # Version tags
             type=semver,pattern={{version}}-collector-mdadm
@@ -249,6 +253,7 @@ jobs:
             type=raw,value=${{ inputs.tag_suffix }}-collector-btrfs,enable=${{ github.event_name == 'workflow_dispatch' }}
             # Branch builds
             type=raw,value=latest-collector-btrfs,enable=${{ (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')) && github.event_name != 'workflow_dispatch' }}
+            type=raw,value=beta-collector-btrfs,enable=${{ github.ref == 'refs/heads/beta' && github.event_name != 'workflow_dispatch' }}
             type=raw,value=develop-collector-btrfs,enable=${{ github.ref == 'refs/heads/develop' && github.event_name != 'workflow_dispatch' }}
             # Version tags
             type=semver,pattern={{version}}-collector-btrfs
@@ -308,6 +313,7 @@ jobs:
             type=raw,value=${{ inputs.tag_suffix }}-collector-performance,enable=${{ github.event_name == 'workflow_dispatch' }}
             # Branch builds
             type=raw,value=latest-collector-performance,enable=${{ (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')) && github.event_name != 'workflow_dispatch' }}
+            type=raw,value=beta-collector-performance,enable=${{ github.ref == 'refs/heads/beta' && github.event_name != 'workflow_dispatch' }}
             type=raw,value=develop-collector-performance,enable=${{ github.ref == 'refs/heads/develop' && github.event_name != 'workflow_dispatch' }}
             # Version tags
             type=semver,pattern={{version}}-collector-performance
@@ -368,6 +374,7 @@ jobs:
             type=raw,value=${{ inputs.tag_suffix }}-web,enable=${{ github.event_name == 'workflow_dispatch' }}
             # Branch builds
             type=raw,value=latest-web,enable=${{ (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')) && github.event_name != 'workflow_dispatch' }}
+            type=raw,value=beta-web,enable=${{ github.ref == 'refs/heads/beta' && github.event_name != 'workflow_dispatch' }}
             type=raw,value=develop-web,enable=${{ github.ref == 'refs/heads/develop' && github.event_name != 'workflow_dispatch' }}
             # Version tags
             type=semver,pattern={{version}}-web
@@ -429,6 +436,8 @@ jobs:
             type=raw,value=${{ inputs.tag_suffix }},enable=${{ github.event_name == 'workflow_dispatch' && inputs.tag_suffix == 'latest' }}
             # Branch builds
             type=raw,value=latest-omnibus,enable=${{ (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')) && github.event_name != 'workflow_dispatch' }}
+            type=raw,value=beta-omnibus,enable=${{ github.ref == 'refs/heads/beta' && github.event_name != 'workflow_dispatch' }}
+            type=raw,value=beta,enable=${{ github.ref == 'refs/heads/beta' && github.event_name != 'workflow_dispatch' }}
             type=raw,value=develop-omnibus,enable=${{ github.ref == 'refs/heads/develop' && github.event_name != 'workflow_dispatch' }}
             type=raw,value=develop,enable=${{ github.ref == 'refs/heads/develop' && github.event_name != 'workflow_dispatch' }}
             # Version tags

--- a/.github/workflows/sync-develop.yaml
+++ b/.github/workflows/sync-develop.yaml
@@ -1,4 +1,4 @@
-name: Sync develop after master merge
+name: Sync beta and develop after master merge
 
 on:
   push:
@@ -6,8 +6,29 @@ on:
       - master
 
 jobs:
-  sync:
+  sync-beta:
+    name: Merge master into beta
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Merge master into beta
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout beta
+          git merge origin/master --no-edit
+          git push origin beta
+
+  sync-develop:
     name: Merge master into develop
+    needs: sync-beta
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ We follow a predictable release cadence to balance new features with stability:
 
 | When | What | Channel |
 | --- | --- | --- |
-| **Sunday** | Bug fixes and stability improvements | Stable (`:latest`) |
-| **Saturday** | New features and experiments | Beta (`:beta`) |
+| **Sunday** | Integration testing and maintainer validation | Testing (`:develop`) |
+| **Saturday** | New features and release candidates | Beta (`:beta`) |
 | **Monthly** | Promote mature beta features to stable | Stable (`:latest`) |
 | **As needed** | Critical hotfixes and urgent security patches | Stable (`:latest`) |
 
@@ -74,7 +74,9 @@ Releases are created manually, not on every commit. Track upcoming work on the [
 This repository also owns the testing and production deployment definitions for Scrutiny.
 
 - Testing images publish from the `develop` branch through [`Deploy Testing Stack`](./.github/workflows/deploy-testing.yml)
+- Beta images publish from the `beta` branch through [`Publish Beta Image`](./.github/workflows/deploy-beta.yml)
 - Production deploys from the `master` branch through [`Automated Release and Deploy`](./.github/workflows/release-and-deploy.yml)
+- `beta` is an optional pre-release channel for features that need validation before going to `master`
 - Zeus production and testing are separate host appdata trees:
   - production: `/mnt/user/appdata/scrutiny`
   - testing: `/mnt/user/appdata/scrutiny-dev`
@@ -129,6 +131,9 @@ These S.M.A.R.T hard drive self-tests can help you detect and replace failing ha
 - **Missed Ping Digest** - Batch notification when multiple collectors go unreachable
 - **HTML Email Notifications** - Rich HTML formatting with plain-text fallback for SMTP notifications, including reports, test notifications, collector errors, missed ping digests, heartbeat, performance degradation, replacement risk, and MDADM degradation alerts
 - **Workload Insights** - Daily read/write rates, R/W ratio, I/O intensity classification, SSD endurance tracking, and activity spike detection
+- **Filesystem Capacity Monitoring** - Track logical filesystem free space independently from SMART device health
+- **MDADM Monitoring** - Monitor Linux software RAID arrays with a dedicated collector
+- **Btrfs Filesystem Monitoring** - Track Btrfs health, scrub status, topology, and usage details
 - **Home Assistant MQTT Discovery** - Native push-based integration with automatic entity creation (temperature, health status, power-on hours, power cycles, drive problem)
 - **Heartbeat Notifications** - Periodic "all clear" alerts for uptime monitoring integration
 - **Uptime Kuma Push Monitor** - Dedicated push-based health status updates to Uptime Kuma endpoints
@@ -215,13 +220,26 @@ the following Docker images:
   scheduler. You can run one collector on each server.
 - `ghcr.io/starosdev/scrutiny:latest-collector-zfs` - ZFS pool collector for monitoring ZFS health.
   Run alongside or instead of the standard collector if you use ZFS. See [docs/ZFS_POOL_MONITORING.md](./docs/ZFS_POOL_MONITORING.md) for setup instructions.
+- `ghcr.io/starosdev/scrutiny:latest-collector-mdadm` - MDADM collector for Linux software RAID monitoring.
+  See [docs/MDADM_MONITORING.md](./docs/MDADM_MONITORING.md) for setup instructions.
+- `ghcr.io/starosdev/scrutiny:latest-collector-btrfs` - Btrfs filesystem health collector.
+  See [docs/BTRFS_FILESYSTEM_MONITORING.md](./docs/BTRFS_FILESYSTEM_MONITORING.md) for setup instructions.
 - `ghcr.io/starosdev/scrutiny:latest-collector-performance` - Performance benchmark collector using fio.
   Runs periodic benchmarks and tracks throughput, IOPS, and latency over time. See [Performance Benchmarking](#performance-benchmarking) for details.
 - `ghcr.io/starosdev/scrutiny:latest-web` - Contains the Web UI and API. Only one container necessary
 - `influxdb:2.2` - InfluxDB image, used by the Web container to persist SMART data. Only one container necessary.
   See [docs/TROUBLESHOOTING_INFLUXDB.md](./docs/TROUBLESHOOTING_INFLUXDB.md)
 
-Default CI image publishing currently builds `latest-web` and `latest-collector-performance` for `linux/amd64` and `linux/arm64`. The `arm/v7` variants are no longer part of the default GitHub Actions Docker matrix.
+Branch channel tags follow the same pattern across images:
+
+- `develop-*` from the `develop` branch
+- `beta-*` from the `beta` branch
+- `latest-*` and semver tags from `master` and release tags
+
+Default CI image publishing currently builds:
+
+- `collector` for `linux/amd64`, `linux/arm64`, and `linux/arm/v7`
+- `web`, `collector-zfs`, `collector-mdadm`, `collector-btrfs`, and `collector-performance` for `linux/amd64` and `linux/arm64`
 
 > See [docker/example.hubspoke.docker-compose.yml](docker/example.hubspoke.docker-compose.yml) for a docker-compose file.
 
@@ -271,12 +289,18 @@ docker exec scrutiny /opt/scrutiny/bin/scrutiny-collector-metrics run
 # Configuration
 By default Scrutiny looks for its YAML configuration files in `/opt/scrutiny/config`
 
-There are four configuration files available:
+There are four primary configuration files available:
 
 - Webapp/API config via `scrutiny.yaml` - [example.scrutiny.yaml](example.scrutiny.yaml).
 - Collector config via `collector.yaml` - [example.collector.yaml](example.collector.yaml).
 - ZFS Collector config via `collector-zfs.yaml` - [example.collector-zfs.yaml](example.collector-zfs.yaml). See [docs/ZFS_POOL_MONITORING.md](./docs/ZFS_POOL_MONITORING.md) for setup instructions.
 - Performance Collector config via `collector-performance.yaml` - [example.collector-performance.yaml](example.collector-performance.yaml). Falls back to `collector.yaml` if not found.
+
+Additional dedicated collectors also have their own config surfaces:
+
+- MDADM collector via `collector-mdadm.yaml` - see [docs/MDADM_MONITORING.md](./docs/MDADM_MONITORING.md)
+- Btrfs collector via `collector-btrfs.yaml` - see [docs/BTRFS_FILESYSTEM_MONITORING.md](./docs/BTRFS_FILESYSTEM_MONITORING.md)
+- Filesystem capacity collector uses its own binary and scheduling env vars - see [docs/FILESYSTEM_CAPACITY.md](./docs/FILESYSTEM_CAPACITY.md)
 
 None of these files are required, however if provided, they allow you to configure how Scrutiny functions.
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -713,11 +713,11 @@ Before submitting a pull request, ensure all of the following pass:
 
 ### Contribution Standards (from CONTRIBUTING.md)
 
-- [ ] Branch created from `develop` (not `master`)
+- [ ] Branch created from `develop` (feature work may optionally be promoted to `beta` before `master` when pre-release validation is needed)
 - [ ] Branch naming: `feature/SCR-{id}-description` or `fix/SCR-{id}-description`
 - [ ] Commit messages follow `type(scope): description` convention
 - [ ] No emojis in code, commits, comments, or documentation
-- [ ] PR targets `develop` branch (or `master` for hotfixes only)
+- [ ] PR targets `develop` branch (or `master` for production hotfixes only)
 - [ ] Tests added for new functionality
 - [ ] Existing tests updated if behavior changed
 

--- a/docs/DEPLOYMENTS.md
+++ b/docs/DEPLOYMENTS.md
@@ -9,6 +9,7 @@ For release-version verification details, see [RELEASE_VERSION_VERIFICATION.md](
 | Environment | Branch | Workflow | Published Image | Notes |
 | --- | --- | --- | --- | --- |
 | Testing | `develop` | `.github/workflows/deploy-testing.yml` | `ghcr.io/starosdev/scrutiny:develop` and `develop-omnibus` | External hosts pull these tags when they want the latest testing build |
+| Beta | `beta` | `.github/workflows/deploy-beta.yml` | `ghcr.io/starosdev/scrutiny:beta` and `beta-omnibus` | External hosts pull these tags when they want a pre-release candidate ahead of stable |
 | Production | `master` | `.github/workflows/release-and-deploy.yml` | `ghcr.io/starosdev/scrutiny:latest` and `latest-omnibus` | External hosts pull these tags when they want the latest production build |
 
 ## What The Workflows Do
@@ -16,7 +17,8 @@ For release-version verification details, see [RELEASE_VERSION_VERIFICATION.md](
 - Check out the repo
 - Normalize the GHCR image name to lowercase
 - Build the omnibus image for `linux/amd64` and `linux/arm64`
-- Build the default `web`, `collector-performance`, `collector-zfs`, and `collector-btrfs` images for `linux/amd64` and `linux/arm64`
+- Build the default `web`, `collector-zfs`, `collector-mdadm`, `collector-btrfs`, and `collector-performance` images for `linux/amd64` and `linux/arm64`
+- Build the base `collector` image for `linux/amd64`, `linux/arm64`, and `linux/arm/v7`
 - Exclude `webapp/backend/pkg/version/version.go` from the Docker workflow path trigger so release-version sync commits do not rebuild images on their own
 - Push the published tags to GHCR
 
@@ -44,8 +46,10 @@ Environment rollout is outside GitHub Actions.
 If Zeus should move to a new image, do that from the host by pulling the published tags and restarting the compose project there. The current Zeus mapping is still:
 
 - develop image path: `ghcr.io/starosdev/scrutiny:develop-omnibus`
+- beta image path: `ghcr.io/starosdev/scrutiny:beta-omnibus`
 - production image path: `ghcr.io/starosdev/scrutiny:latest`
 - develop port: `8680`
+- beta port: choose a separate host port for side-by-side validation if you run it alongside testing or production
 - production port: `8580`
 - production appdata root: `/mnt/user/appdata/scrutiny`
 - Zeus testing appdata root: `/mnt/user/appdata/scrutiny-dev`
@@ -58,6 +62,12 @@ Zeus does not currently run testing and production from the same appdata tree.
 
 - Production uses `/mnt/user/appdata/scrutiny`
 - Testing uses `/mnt/user/appdata/scrutiny-dev`
+
+This repo now treats `beta` as an optional pre-release channel for changes that need validation before `master`.
+
+- `develop` is the integration branch and testing image source
+- `beta` is the optional pre-release branch and beta image source
+- `master` is the stable branch and latest image source
 
 That distinction matters for both manual host rollouts and the helper scripts in `ops/`:
 

--- a/docs/TESTERS.md
+++ b/docs/TESTERS.md
@@ -4,7 +4,7 @@ Scrutiny supports many operating systems, CPU architectures and runtime environm
 difficult to test. 
 Thankfully the following users have been gracious enough to test/validate Scrutiny works on their system.
 
-> NOTE: If you're interested in volunteering to test Scrutiny beta builds on your system, please [open an issue](https://github.com/Starosdev/scrutiny/issues). 
+> NOTE: If you're interested in validating Scrutiny beta images for features that need pre-release testing before they reach stable, please [open an issue](https://github.com/Starosdev/scrutiny/issues).
 
 | Architecture Name | Binaries | Docker |
 | --- | --- | --- |

--- a/docs/TROUBLESHOOTING_DOCKER.md
+++ b/docs/TROUBLESHOOTING_DOCKER.md
@@ -1,22 +1,22 @@
-# Docker Images `master-omnibus` vs `latest`
+# Docker Image Channels
 
-> TL;DR; The `master-omnibus` and `latest` tags are almost semantically identical, as I follow a `golden master` 
-development process. However if you want to ensure you're only using the latest release, you can change to `latest`
+> TL;DR: use `develop` for testing, `beta` for pre-release validation, and `latest` for stable production.
 
-The CI script used to orchestrate the docker image builds can be found here: https://github.com/Starosdev/scrutiny/blob/master/.github/workflows/docker-build.yaml#L166-L184
+The CI script used to orchestrate the Docker image builds lives in `.github/workflows/docker-build.yaml`.
 
-In general Scrutiny follows a `golden master` development process, which means that the `master` branch is not directly updated (unless its for documentation changes), 
-instead development is done in a feature branch, or committed to the `beta` branch. 
+Scrutiny now uses three branch-backed image channels:
 
-As development progresses, and we're satisfied that a feature is complete, and the quality is acceptable, 
-I merge the changes to `master` and trigger the creation of a new release -- ie, when master is updated, a new release
-is almost immediately created (and tagged with `latest`)
+- `develop` branch -> `develop` and `develop-omnibus`
+- `beta` branch -> `beta` and `beta-omnibus`
+- `master` branch -> `latest` and `latest-omnibus`
 
-So changing from `master-omnibus -> latest` will be the same thing for all intents and purposes. 
+Typical flow is `develop -> master`, with optional `develop -> beta -> master` promotion when a feature needs pre-release validation.
 
-> NOTE: Previously, there was a `automated cron build` that ran on the `master` and `beta` branches. 
-They used to trigger a `nightly` build, even if nothing has changed on the branch. This has a couple of benefits, but one is to 
-ensure that there's no broken external dependencies in our (unchanged) code. This `nightly` build no longer updates the `master-omnibus` tag. 
+Use cases:
+
+- `develop-*` for integration and maintainer testing
+- `beta-*` for release-candidate validation
+- `latest-*` for stable production deployments
 
 # Running Docker `rootless`
 

--- a/docs/plans/2026-03-14-release-schedule-design.md
+++ b/docs/plans/2026-03-14-release-schedule-design.md
@@ -1,7 +1,7 @@
 # Release Schedule Design
 
 **Date:** 2026-03-14
-**Status:** Implemented
+**Status:** Implemented and superseded by the current `develop -> beta -> master` promotion flow
 **Issue:** [#366](https://github.com/Starosdev/scrutiny/issues/366) - Limit releases to once a week or when stable
 
 ## Problem
@@ -24,7 +24,8 @@ A predictable release cadence with a GitHub Project board for tracking what ship
 ### CI/CD Changes
 
 - **`release.yaml`** -- Removed push triggers to `master`/`beta`. Releases are manual only via `workflow_dispatch`.
-- **`docker-build.yaml`** -- No changes. Docker images still auto-build on push to `master` and `develop`.
+- **`docker-build.yaml`** -- Extended to auto-build on push to `develop`, `beta`, and `master`, with branch-matched channel tags.
+- **`deploy-beta.yml`** -- Added to publish the omnibus beta channel from the `beta` branch.
 - **Release notes path** -- Raw release notes are generated deterministically from merged PR summaries and linked issues. OpenAI is allowed only to polish wording; if that rewrite drops structure or bullets, the workflow falls back to the raw notes.
 
 ### GitHub Project Board
@@ -80,7 +81,6 @@ Triggers on `issues: [opened, labeled]` so re-labeling re-routes.
 ### Documentation Updated
 
 - README.md -- Release schedule section added near the top
-- CLAUDE.md -- Release schedule, release process, and project board routing rules
 - `create-pull-request` command -- Updated to reflect manual-only releases
 - `pre-deploy-check` command -- Added manual release reminder
 


### PR DESCRIPTION
## Summary

Add a first-class GHCR beta publish channel and align the repo workflows and docs to the intended branch model.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD or infrastructure change

## Related Issues

- Related to the README/release-channel alignment work discussed in this branch

## Changes Made

- Added `.github/workflows/deploy-beta.yml` to publish `beta` and `beta-omnibus` from the `beta` branch
- Updated `.github/workflows/docker-build.yaml` so component images also publish `beta-*` tags while keeping `develop-*` and `latest-*`
- Updated `.github/workflows/sync-develop.yaml` so post-`master` sync also refreshes `beta`
- Updated `README.md`, `docs/DEPLOYMENTS.md`, `docs/TROUBLESHOOTING_DOCKER.md`, `TESTING.md`, and `docs/TESTERS.md` to describe beta as an optional GHCR pre-release channel rather than a required gate
- Updated the release-schedule design note under `docs/plans/` to match the current workflow behavior

## Testing

- [x] I have tested this locally
- [ ] I have added/updated tests that prove my fix/feature works
- [ ] All existing tests pass

Local validation performed:

- `git diff --check`
- Parsed edited workflow YAML with Ruby `YAML.load_file(...)`
- Confirmed branch state before push

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary (particularly complex areas)
- [x] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [x] No console.log, debug statements, or commented-out code

## Screenshots (if applicable)

N/A

## Additional Notes

Beta is GHCR-only by design in this change. No Zeus beta deployment environment or host-side beta rollout path was added.
