### PR TITLE
SCRUTINY v1.0.0 — document consumer drive profiles in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ These S.M.A.R.T hard drive self-tests can help you detect and replace failing ha
 - **Missed Ping Digest** - Batch notification when multiple collectors go unreachable
 - **HTML Email Notifications** - Rich HTML formatting with plain-text fallback for SMTP notifications, including reports, test notifications, collector errors, missed ping digests, heartbeat, performance degradation, replacement risk, and MDADM degradation alerts
 - **Workload Insights** - Daily read/write rates, R/W ratio, I/O intensity classification, SSD endurance tracking, and activity spike detection
+- **Consumer Drive Profiles** - Apply vetted ATA HDD and SSD profiles based on Backblaze-informed thresholds, with opt-out controls and replacement-risk transparency
 - **Filesystem Capacity Monitoring** - Track logical filesystem free space independently from SMART device health
 - **MDADM Monitoring** - Monitor Linux software RAID arrays with a dedicated collector
 - **Btrfs Filesystem Monitoring** - Track Btrfs health, scrub status, topology, and usage details
@@ -539,6 +540,18 @@ Add overrides to `scrutiny.yaml` under `smart.attribute_overrides`. See [example
 | Custom Threshold | Replaces default thresholds with user-defined warn_above/fail_above values |
 
 Overrides apply at the next SMART data collection. Device status is recalculated immediately when overrides are added or removed via the UI.
+
+## Consumer Drive Profiles
+
+Scrutiny can apply vetted ATA consumer drive model or family overrides when evaluating SMART status and computing replacement risk. These profiles are intended to improve interpretation for common SATA HDD and SSD lines using validated thresholds informed by Backblaze failure data.
+
+The feature is enabled by default and can be disabled globally in Dashboard Settings if you prefer generic ATA rules only. On ATA drive detail pages, Scrutiny also shows which evaluation path was used so the replacement-risk output is transparent:
+
+- matched consumer drive profile family
+- generic ATA rules because profiles were disabled
+- generic ATA rules because no vetted profile matched the drive
+
+For matching behavior, confidence thresholds, and API fields such as `consumer_drive_profiles_enabled` and `consumer_drive_profile_family`, see [docs/CONSUMER_DRIVE_PROFILES.md](./docs/CONSUMER_DRIVE_PROFILES.md).
 
 ## Notifications
 


### PR DESCRIPTION
## Summary

Document the recently added consumer drive profiles feature in the root README so the top-level project docs match the current shipped behavior.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

- Related to #468
- Related to #518
- Follows the merged feature work from #560

## Changes Made

- Added `Consumer Drive Profiles` to the README feature list
- Added a dedicated README section describing Backblaze-informed ATA profiles
- Documented the global opt-out behavior and replacement-risk transparency states
- Linked the README section to `docs/CONSUMER_DRIVE_PROFILES.md` for full details

## Testing

- [x] I have tested this locally
- [ ] I have added/updated tests that prove my fix/feature works
- [ ] All existing tests pass

Local validation performed:

- `git diff --check`
- Read-through against the current shipped docs and UI strings

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary (particularly complex areas)
- [x] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [x] No console.log, debug statements, or commented-out code

## Screenshots (if applicable)

N/A

## Additional Notes

This is a README accuracy follow-up only. No code, workflow, or deployment behavior changed.
