### PR TITLE
SCRUTINY v1.0.0 — add README maintenance reminder to contributor docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,8 @@ We use a Gitflow-style workflow:
 1. Fork the repository and create your branch from `develop`
 2. Follow the commit convention: `type(scope): description`
 3. Ensure all tests pass
-4. Submit a PR to `develop` (or `master` for hotfixes)
+4. Update `README.md` when your change affects the top-level product surface, feature set, supported deployment paths, or published image matrix
+5. Submit a PR to `develop` (or `master` for hotfixes)
 
 ## Code Style
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -720,6 +720,7 @@ Before submitting a pull request, ensure all of the following pass:
 - [ ] PR targets `develop` branch (or `master` for production hotfixes only)
 - [ ] Tests added for new functionality
 - [ ] Existing tests updated if behavior changed
+- [ ] `README.md` updated if the change affects the top-level feature list, deployment model, or published image/channel surface
 
 ### If You Added a Database Migration
 


### PR DESCRIPTION
## Summary

Add a small contributor-facing reminder that changes affecting the top-level product surface should update `README.md` in the same change.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

- Follow-up maintenance after recent README accuracy fixes

## Changes Made

- Added a README maintenance reminder to `CONTRIBUTING.md`
- Added a matching checklist item to `TESTING.md`
- Scoped the reminder to top-level features, deployment model, and image/channel surface changes

## Testing

- [x] I have tested this locally
- [ ] I have added/updated tests that prove my fix/feature works
- [ ] All existing tests pass

Local validation performed:

- `git diff --check`

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary (particularly complex areas)
- [x] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [x] No console.log, debug statements, or commented-out code

## Screenshots (if applicable)

N/A

## Additional Notes

This is a contributor-process reminder only. No product or workflow behavior changed.
