### PR TITLE
fix(collector): skip empty device names from smartctl --scan output (#569)

### DIFF
--- a/collector/pkg/detect/detect.go
+++ b/collector/pkg/detect/detect.go
@@ -101,6 +101,9 @@ func (d *Detect) SmartctlScan() ([]models.Device, error) {
 // - WWN is provided as component data, rather than a "string". We'll have to generate the WWN value ourselves
 // - WWN from smartctl only provided for ATA protocol drives, NVMe and SCSI drives do not include WWN.
 func (d *Detect) SmartCtlInfo(device *models.Device) error {
+	if strings.TrimSpace(device.DeviceName) == "" {
+		return fmt.Errorf("device name is empty; skipping smartctl info call")
+	}
 	fullDeviceName := DeviceFullPath(device.DeviceName)
 	args := strings.Split(d.Config.GetCommandMetricsInfoArgs(fullDeviceName), " ")
 	//only include the device type if its a non-standard one. In some cases ata drives are detected as scsi in docker, and metadata is lost.
@@ -184,6 +187,10 @@ func (d *Detect) TransformDetectedDevices(detectedDeviceConns models.Scan) []mod
 	groupedDevices := map[string][]models.Device{}
 
 	for _, scannedDevice := range detectedDeviceConns.Devices {
+		if strings.TrimSpace(scannedDevice.Name) == "" {
+			d.Logger.Warnf("smartctl --scan returned a device entry with an empty name; skipping to avoid invoking smartctl with path %q", DevicePrefix())
+			continue
+		}
 
 		// Preserve case for all device paths — filesystem paths are case-sensitive.
 		// /dev/disk/by-id/ paths may contain uppercase characters from manufacturer

--- a/collector/pkg/detect/detect_test.go
+++ b/collector/pkg/detect/detect_test.go
@@ -598,6 +598,32 @@ func TestDetect_TransformDetectedDevices_UppercaseByIDPathScanned(t *testing.T) 
 	require.Equal(t, "disk/by-id/ata-HGST_HUH721212ALE600_ABC123", transformedDevices[0].DeviceName)
 }
 
+func TestDetect_TransformDetectedDevices_EmptyDeviceName(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	fakeConfig := mock_config.NewMockInterface(mockCtrl)
+	fakeConfig.EXPECT().GetString("host.id").AnyTimes().Return("")
+	fakeConfig.EXPECT().GetDeviceOverrides().AnyTimes().Return([]models.ScanOverride{})
+	fakeConfig.EXPECT().IsAllowlistedDevice(gomock.Any()).AnyTimes().Return(true)
+
+	detectedDevices := models.Scan{
+		Devices: []models.ScanDevice{
+			{Name: "/dev/sda", InfoName: "/dev/sda", Protocol: "scsi", Type: "scsi"},
+			{Name: "", InfoName: "", Protocol: "ata", Type: "ata"},
+		},
+	}
+
+	d := detect.Detect{
+		Logger: logrus.WithFields(logrus.Fields{}),
+		Config: fakeConfig,
+	}
+
+	transformedDevices := d.TransformDetectedDevices(detectedDevices)
+
+	require.Equal(t, 1, len(transformedDevices))
+	require.Equal(t, "sda", transformedDevices[0].DeviceName)
+}
+
 func TestDetect_TransformDetectedDevices_RaidWithLabel(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()


### PR DESCRIPTION
## Summary

- Skip scan entries with empty device names in `TransformDetectedDevices` — these cause `smartctl` to be invoked with a bare prefix path (e.g. `/dev/`) which always fails with exit code 1
- Add secondary guard in `SmartCtlInfo` to return an error immediately if `DeviceName` is empty, preventing the issue if an empty device ever reaches that path by other means
- Log a warning when an empty-named entry is skipped so operators can see it in debug output

## Linked Issues

Closes #569

## Test plan

- [x] New test `TestDetect_TransformDetectedDevices_EmptyDeviceName` verifies scan with one valid + one empty-named device returns only the valid device
- [x] All existing detect tests pass (`go test ./collector/pkg/detect/...`)
- [x] `go vet ./collector/...` clean