### PR TITLE
fix(frontend): fix stat card layout in BTRFS, ZFS, and drive detail views

### DIFF
--- a/webapp/frontend/src/app/modules/btrfs-filesystem-detail/btrfs-filesystem-detail.component.html
+++ b/webapp/frontend/src/app/modules/btrfs-filesystem-detail/btrfs-filesystem-detail.component.html
@@ -19,23 +19,23 @@
     </div>
 
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
-        <treo-card class="p-6">
+        <treo-card class="flex-col p-6">
             <div class="font-semibold text-xs text-hint uppercase tracking-wider mb-2">Status</div>
             <div class="font-bold text-3xl" [ngClass]="filesystem.status === 'ONLINE' ? 'text-green-600 dark:text-green-400' : 'text-yellow-600 dark:text-yellow-400'">
                 {{ filesystem.status }}
             </div>
         </treo-card>
-        <treo-card class="p-6">
+        <treo-card class="flex-col p-6">
             <div class="font-semibold text-xs text-hint uppercase tracking-wider mb-2">Usage</div>
             <div class="font-bold text-3xl">{{ filesystem.used | fileSize : config?.file_size_si_units }}</div>
             <div class="text-sm text-hint mt-2">{{ filesystem.device_size | fileSize : config?.file_size_si_units }} total</div>
         </treo-card>
-        <treo-card class="p-6">
+        <treo-card class="flex-col p-6">
             <div class="font-semibold text-xs text-hint uppercase tracking-wider mb-2">Profiles</div>
             <div class="font-bold text-xl">{{ filesystem.data_profile || 'n/a' }}</div>
             <div class="text-sm text-hint mt-2">Metadata {{ filesystem.metadata_profile || 'n/a' }}</div>
         </treo-card>
-        <treo-card class="p-6">
+        <treo-card class="flex-col p-6">
             <div class="font-semibold text-xs text-hint uppercase tracking-wider mb-2">Scrub</div>
             <div class="font-bold text-3xl">{{ filesystem.scrub_state }}</div>
             @if (filesystem.scrub_finished_at) {

--- a/webapp/frontend/src/app/modules/detail/detail.component.html
+++ b/webapp/frontend/src/app/modules/detail/detail.component.html
@@ -755,7 +755,7 @@
                 @if (getLatestPerformance(); as latest) {
                 <div class="grid grid-cols-2 md:grid-cols-3 gap-4 mb-4">
                     @if (latest.seq_read_bw_bytes > 0) {
-                    <treo-card class="p-4">
+                    <treo-card class="flex-col p-4">
                         <div class="font-semibold text-xs text-hint uppercase tracking-wider">Seq Read</div>
                         <div class="font-bold text-2xl my-2">{{ latest.seq_read_bw_bytes | fileSize : config?.file_size_si_units }}/s</div>
                         @if (performanceBaseline?.sample_count > 1) { @if (getBaselineDelta(latest.seq_read_bw_bytes, performanceBaseline?.seq_read_bw_bytes, true); as delta) {
@@ -768,7 +768,7 @@
                         } }
                     </treo-card>
                     } @if (latest.seq_write_bw_bytes > 0) {
-                    <treo-card class="p-4">
+                    <treo-card class="flex-col p-4">
                         <div class="font-semibold text-xs text-hint uppercase tracking-wider">Seq Write</div>
                         <div class="font-bold text-2xl my-2">{{ latest.seq_write_bw_bytes | fileSize : config?.file_size_si_units }}/s</div>
                         @if (performanceBaseline?.sample_count > 1) { @if (getBaselineDelta(latest.seq_write_bw_bytes, performanceBaseline?.seq_write_bw_bytes, true); as delta) {
@@ -781,7 +781,7 @@
                         } }
                     </treo-card>
                     } @if (latest.rand_read_iops > 0) {
-                    <treo-card class="p-4">
+                    <treo-card class="flex-col p-4">
                         <div class="font-semibold text-xs text-hint uppercase tracking-wider">Rand Read IOPS</div>
                         <div class="font-bold text-2xl my-2">{{ latest.rand_read_iops | number : '1.0-0' }}</div>
                         @if (performanceBaseline?.sample_count > 1) { @if (getBaselineDelta(latest.rand_read_iops, performanceBaseline?.rand_read_iops, true); as delta) {
@@ -794,7 +794,7 @@
                         } }
                     </treo-card>
                     } @if (latest.rand_write_iops > 0) {
-                    <treo-card class="p-4">
+                    <treo-card class="flex-col p-4">
                         <div class="font-semibold text-xs text-hint uppercase tracking-wider">Rand Write IOPS</div>
                         <div class="font-bold text-2xl my-2">{{ latest.rand_write_iops | number : '1.0-0' }}</div>
                         @if (performanceBaseline?.sample_count > 1) { @if (getBaselineDelta(latest.rand_write_iops, performanceBaseline?.rand_write_iops, true); as delta) {
@@ -807,7 +807,7 @@
                         } }
                     </treo-card>
                     } @if (latest.rand_read_lat_ns_avg > 0) {
-                    <treo-card class="p-4">
+                    <treo-card class="flex-col p-4">
                         <div class="font-semibold text-xs text-hint uppercase tracking-wider">Read Latency</div>
                         <div class="font-bold text-2xl my-2">{{ latest.rand_read_lat_ns_avg | latency }}</div>
                         @if (performanceBaseline?.sample_count > 1) { @if (getBaselineDelta(latest.rand_read_lat_ns_avg, performanceBaseline?.rand_read_lat_ns_avg, false); as
@@ -821,7 +821,7 @@
                         } }
                     </treo-card>
                     } @if (latest.rand_write_lat_ns_avg > 0) {
-                    <treo-card class="p-4">
+                    <treo-card class="flex-col p-4">
                         <div class="font-semibold text-xs text-hint uppercase tracking-wider">Write Latency</div>
                         <div class="font-bold text-2xl my-2">{{ latest.rand_write_lat_ns_avg | latency }}</div>
                         @if (performanceBaseline?.sample_count > 1) { @if (getBaselineDelta(latest.rand_write_lat_ns_avg, performanceBaseline?.rand_write_lat_ns_avg, false); as

--- a/webapp/frontend/src/app/modules/zfs-pool-detail/zfs-pool-detail.component.html
+++ b/webapp/frontend/src/app/modules/zfs-pool-detail/zfs-pool-detail.component.html
@@ -23,7 +23,7 @@
     <!-- Pool Overview -->
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
         <!-- Status Card -->
-        <treo-card class="p-6">
+        <treo-card class="flex-col p-6">
             <div class="font-semibold text-xs text-hint uppercase tracking-wider mb-2">Status</div>
             <div [ngClass]="getStatusColorClass(pool.status)" class="font-bold text-3xl">
                 {{ pool.status }}
@@ -31,7 +31,7 @@
         </treo-card>
 
         <!-- Capacity Card -->
-        <treo-card class="p-6">
+        <treo-card class="flex-col p-6">
             <div class="font-semibold text-xs text-hint uppercase tracking-wider mb-2">Capacity</div>
             <div class="font-bold text-3xl">{{ pool.capacity_percent }}%</div>
             <div class="mt-2 h-2 bg-gray-200 rounded overflow-hidden">
@@ -49,13 +49,13 @@
         </treo-card>
 
         <!-- Fragmentation Card -->
-        <treo-card class="p-6">
+        <treo-card class="flex-col p-6">
             <div class="font-semibold text-xs text-hint uppercase tracking-wider mb-2">Fragmentation</div>
             <div class="font-bold text-3xl">{{ pool.fragmentation }}%</div>
         </treo-card>
 
         <!-- Scrub Status Card -->
-        <treo-card class="p-6">
+        <treo-card class="flex-col p-6">
             <div class="font-semibold text-xs text-hint uppercase tracking-wider mb-2">Last Scrub</div>
             @switch (pool.scrub_state) { @case ('none') {
             <div class="font-bold text-3xl text-hint">Never</div>


### PR DESCRIPTION
## Summary

- `treo-card` has `display: flex` (row direction) from its base SCSS, causing direct children to lay out horizontally instead of vertically
- Stat cards in detail views need `flex-col` so label/value pairs stack vertically
- Affects BTRFS filesystem detail (reported), ZFS pool detail, and drive performance metric cards

## Changes

- Added `flex-col` to the 4 overview stat cards in `btrfs-filesystem-detail.component.html`
- Added `flex-col` to the 4 overview stat cards in `zfs-pool-detail.component.html`
- Added `flex-col` to the 6 performance metric cards in `detail.component.html`

## Test plan

- [ ] View BTRFS filesystem detail page — stat cards (Status, Usage, Profiles, Scrub) should stack label above value
- [ ] View ZFS pool detail page — stat cards should stack label above value
- [ ] View drive detail page — performance metric cards should stack label above value
- [ ] Verify no regression on mobile viewport