### PR TITLE
fix(collector): add --host-id flag to MDADM collector (SCR-573)

### DIFF
--- a/collector/cmd/collector-mdadm/collector-mdadm.go
+++ b/collector/cmd/collector-mdadm/collector-mdadm.go
@@ -25,6 +25,7 @@ import (
 const flagApiToken = "api-token"
 const flagLogFile = "log-file"
 const flagApiEndpoint = "api-endpoint"
+const flagHostId = "host-id"
 const configKeyLogFile = "log.file"
 
 var goos string
@@ -133,6 +134,10 @@ func main() {
 						config.Set("api.token", c.String(flagApiToken))
 					}
 
+					if c.IsSet(flagHostId) {
+						config.Set("host.id", c.String(flagHostId))
+					}
+
 					collectorLogger, logFile, err := CreateLogger(config)
 					if logFile != nil {
 						defer logFile.Close()
@@ -190,6 +195,12 @@ func main() {
 						Name:    flagApiToken,
 						Usage:   "API token for authenticating with the Scrutiny server",
 						EnvVars: []string{"COLLECTOR_MDADM_API_TOKEN", "COLLECTOR_API_TOKEN"},
+					},
+					&cli.StringFlag{
+						Name:    flagHostId,
+						Usage:   "Host identifier/label, used for grouping arrays",
+						Value:   "",
+						EnvVars: []string{"COLLECTOR_MDADM_HOST_ID", "COLLECTOR_HOST_ID"},
 					},
 				},
 			},


### PR DESCRIPTION
## Summary

- Adds `--host-id` CLI flag to the MDADM collector, matching the ZFS and metrics collectors
- Adds `COLLECTOR_MDADM_HOST_ID` / `COLLECTOR_HOST_ID` env var support
- The underlying `detect.go` already read `host.id` from config to generate deterministic array IDs; the flag was simply never declared in the CLI

## Linked Issues

Closes #573

## Test plan

- [x] `go vet ./collector/...` passes
- [x] `go test ./collector/...` passes (all packages including `pkg/mdadm` and `pkg/mdadm/detect`)
- [x] Binary builds cleanly
- [ ] Manual verification: invoke collector with `--host-id <value>` on a system with MDADM arrays