### PR TITLE
fix(database): prevent orphan blank device rows after registration (#567)

### DIFF
--- a/webapp/backend/pkg/database/scrutiny_repository_device.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_device.go
@@ -22,6 +22,17 @@ import (
 // insert device into DB (and update specified columns if device is already registered)
 // update device fields that may change: (DeviceType, HostID)
 func (sr *scrutinyRepository) RegisterDevice(ctx context.Context, dev models.Device) error {
+	// Reject devices with no identifying information. A device must have at least
+	// one of: device_name, model_name, serial_number, or wwn. Without any of these,
+	// the generated device_id would be a deterministic UUID for the all-empty input,
+	// which would create an orphan blank row in the devices table.
+	if strings.TrimSpace(dev.DeviceName) == "" &&
+		strings.TrimSpace(dev.ModelName) == "" &&
+		strings.TrimSpace(dev.SerialNumber) == "" &&
+		strings.TrimSpace(dev.WWN) == "" {
+		return fmt.Errorf("cannot register device with no identifying information (device_name, model_name, serial_number, and wwn are all empty)")
+	}
+
 	// Compute deterministic device ID from model, serial, and WWN
 	if dev.DeviceID == "" {
 		dev.DeviceID = deviceid.Generate(dev.ModelName, dev.SerialNumber, dev.WWN)

--- a/webapp/backend/pkg/database/scrutiny_repository_device_register_test.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_device_register_test.go
@@ -171,3 +171,44 @@ func TestRegisterDeviceDeletesLegacyDuplicateOnceCanonicalRowExists(t *testing.T
 	require.Equal(t, canonicalID, devices[0].DeviceID)
 	require.Equal(t, legacyCreatedAt, devices[0].CreatedAt.UTC().Truncate(time.Second))
 }
+
+func TestRegisterDeviceRejectsBlankDevice(t *testing.T) {
+	repo := createDeviceRegisterTestRepository(t)
+	ctx := context.Background()
+
+	err := repo.RegisterDevice(ctx, models.Device{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no identifying information")
+
+	var count int64
+	require.NoError(t, repo.gormClient.WithContext(ctx).Model(&models.Device{}).Count(&count).Error)
+	require.Equal(t, int64(0), count)
+}
+
+func TestRegisterDeviceAcceptsDeviceWithOnlyDeviceName(t *testing.T) {
+	repo := createDeviceRegisterTestRepository(t)
+	ctx := context.Background()
+
+	err := repo.RegisterDevice(ctx, models.Device{
+		DeviceName: "sda",
+	})
+	require.NoError(t, err)
+
+	var count int64
+	require.NoError(t, repo.gormClient.WithContext(ctx).Model(&models.Device{}).Count(&count).Error)
+	require.Equal(t, int64(1), count)
+}
+
+func TestRegisterDeviceAcceptsDeviceWithOnlySerialNumber(t *testing.T) {
+	repo := createDeviceRegisterTestRepository(t)
+	ctx := context.Background()
+
+	err := repo.RegisterDevice(ctx, models.Device{
+		SerialNumber: "SN123456",
+	})
+	require.NoError(t, err)
+
+	var count int64
+	require.NoError(t, repo.gormClient.WithContext(ctx).Model(&models.Device{}).Count(&count).Error)
+	require.Equal(t, int64(1), count)
+}

--- a/webapp/backend/pkg/database/scrutiny_repository_migrations.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_migrations.go
@@ -1101,6 +1101,22 @@ missed_ping_timeout_override INTEGER DEFAULT 0
 				return tx.Create(&defaultSetting).Error
 			},
 		},
+		{
+			ID: "m20260528000000", // remove orphan blank device rows (#567)
+			// Devices with no identifying information (all of device_name, model_name,
+			// serial_number, and wwn empty or NULL) are invalid and cannot be tracked
+			// or removed via the UI. This migration removes any such rows that may have
+			// been inserted by legacy collector runs or backfill migrations.
+			Migrate: func(tx *gorm.DB) error {
+				return tx.Exec(`
+					DELETE FROM devices
+					WHERE (device_name IS NULL OR TRIM(device_name) = '')
+					  AND (model_name  IS NULL OR TRIM(model_name)  = '')
+					  AND (serial_number IS NULL OR TRIM(serial_number) = '')
+					  AND (wwn IS NULL OR TRIM(wwn) = '')
+				`).Error
+			},
+		},
 	})
 
 	if err := m.Migrate(); err != nil {

--- a/webapp/backend/pkg/database/scrutiny_repository_migrations_test.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_migrations_test.go
@@ -418,3 +418,95 @@ CREATE TABLE devices (
 	require.True(t, repo.gormClient.Migrator().HasColumn(&models.Device{}, "muted"))
 	require.True(t, repo.gormClient.Migrator().HasColumn(&models.Device{}, "missed_ping_timeout_override"))
 }
+
+func TestMigrateRemovesOrphanBlankDeviceRows(t *testing.T) {
+	repo := createMigrationTestRepositoryWithAppliedMigrations(t, []string{
+		"20201107210306",
+		"20220503113100",
+		"20220503120000",
+		"m20220509170100",
+		"m20220709181300",
+		"m20220716214900",
+		"m20250221084400",
+		"m20251108044508",
+		"m20260108000000",
+		"m20260122000000",
+		"m20260129000000",
+		"m20260131000000",
+		"m20260202000000",
+		"m20260225000000",
+		"m20260226000000",
+		"m20260301000000",
+		"m20260315000000",
+		"m20260401000000",
+		"m20260402000000",
+		"m20260410000000",
+		"m20260411000000",
+		"m20260413000000",
+		"m20260414000000",
+		"m20260421000000",
+		"m20260508000000",
+		"m20260510000000",
+		"m20260514000000",
+		"m20260516000000",
+		"m20260523000000",
+		"m20260524000000",
+	})
+	ctx := context.Background()
+
+	// Recreate the devices table with the post-m20260401000000 schema (device_id as primary key)
+	// to simulate the state of the database before the m20260528000000 migration runs.
+	require.NoError(t, repo.gormClient.Exec(`DROP TABLE devices`).Error)
+	require.NoError(t, repo.gormClient.Exec(`
+CREATE TABLE devices (
+	device_id TEXT PRIMARY KEY,
+	wwn TEXT,
+	created_at DATETIME,
+	updated_at DATETIME,
+	deleted_at DATETIME,
+	device_name TEXT,
+	device_uuid TEXT,
+	device_serial_id TEXT,
+	device_label TEXT,
+	manufacturer TEXT,
+	model_family TEXT,
+	model_name TEXT,
+	interface_type TEXT,
+	interface_speed TEXT,
+	serial_number TEXT,
+	firmware TEXT,
+	rotation_speed INTEGER,
+	capacity INTEGER,
+	form_factor TEXT,
+	smart_support TEXT,
+	device_protocol TEXT,
+	device_type TEXT,
+	label TEXT,
+	host_id TEXT,
+	collector_version TEXT,
+	smart_display_mode TEXT DEFAULT 'scrutiny',
+	device_status INTEGER,
+	has_forced_failure NUMERIC DEFAULT 0,
+	archived NUMERIC,
+	muted NUMERIC,
+	missed_ping_timeout_override INTEGER DEFAULT 0
+)`).Error)
+
+	// Insert one blank orphan row (all identifying fields empty) and one valid row.
+	require.NoError(t, repo.gormClient.Exec(`
+		INSERT INTO devices (device_id, wwn, device_name, model_name, serial_number, smart_display_mode)
+		VALUES
+			('blank-uuid', '', '', '', '', 'scrutiny'),
+			('valid-uuid', 'wwn-1', 'sda', 'Samsung SSD 870', 'SN123', 'scrutiny')
+	`).Error)
+
+	require.NoError(t, repo.Migrate(ctx))
+
+	var deviceCount int64
+	require.NoError(t, repo.gormClient.Raw(`SELECT COUNT(*) FROM devices`).Scan(&deviceCount).Error)
+	require.Equal(t, int64(1), deviceCount, "blank orphan row should have been removed")
+
+	var remainingID string
+	require.NoError(t, repo.gormClient.Raw(`SELECT device_id FROM devices LIMIT 1`).Scan(&remainingID).Error)
+	require.Equal(t, "valid-uuid", remainingID, "valid device should be preserved")
+}


### PR DESCRIPTION
## Summary

- Reject devices with all identifying fields empty in `RegisterDevice`, preventing blank orphan rows created by `deviceid.Generate("","","")` producing a deterministic UUID from empty inputs
- Add migration `m20260528000000` to delete any existing orphan blank rows (where `device_name`, `model_name`, `serial_number`, and `wwn` are all NULL or empty)
- Add tests covering blank-device rejection and migration cleanup behavior

## Linked Issues

Closes #567

## Test plan

- [x] `TestRegisterDeviceRejectsBlankDevice` -- blank device returns error, no row inserted
- [x] `TestRegisterDeviceAcceptsDeviceWithOnlyDeviceName` -- partial identity accepted
- [x] `TestRegisterDeviceAcceptsDeviceWithOnlySerialNumber` -- partial identity accepted
- [x] `TestMigrateRemovesOrphanBlankDeviceRows` -- migration removes blank rows, preserves valid ones
- [x] `go test ./webapp/backend/pkg/database/...` passes
- [x] `go vet ./webapp/backend/pkg/database/...` clean