### PR TITLE
fix: collector fixes, MDADM host-id, Btrfs/ZFS layout, orphan device rows

### DIFF
--- a/collector/cmd/collector-mdadm/collector-mdadm.go
+++ b/collector/cmd/collector-mdadm/collector-mdadm.go
@@ -25,6 +25,7 @@ import (
 const flagApiToken = "api-token"
 const flagLogFile = "log-file"
 const flagApiEndpoint = "api-endpoint"
+const flagHostId = "host-id"
 const configKeyLogFile = "log.file"
 
 var goos string
@@ -133,6 +134,10 @@ func main() {
 						config.Set("api.token", c.String(flagApiToken))
 					}
 
+					if c.IsSet(flagHostId) {
+						config.Set("host.id", c.String(flagHostId))
+					}
+
 					collectorLogger, logFile, err := CreateLogger(config)
 					if logFile != nil {
 						defer logFile.Close()
@@ -190,6 +195,12 @@ func main() {
 						Name:    flagApiToken,
 						Usage:   "API token for authenticating with the Scrutiny server",
 						EnvVars: []string{"COLLECTOR_MDADM_API_TOKEN", "COLLECTOR_API_TOKEN"},
+					},
+					&cli.StringFlag{
+						Name:    flagHostId,
+						Usage:   "Host identifier/label, used for grouping arrays",
+						Value:   "",
+						EnvVars: []string{"COLLECTOR_MDADM_HOST_ID", "COLLECTOR_HOST_ID"},
 					},
 				},
 			},

--- a/collector/pkg/detect/detect.go
+++ b/collector/pkg/detect/detect.go
@@ -101,6 +101,9 @@ func (d *Detect) SmartctlScan() ([]models.Device, error) {
 // - WWN is provided as component data, rather than a "string". We'll have to generate the WWN value ourselves
 // - WWN from smartctl only provided for ATA protocol drives, NVMe and SCSI drives do not include WWN.
 func (d *Detect) SmartCtlInfo(device *models.Device) error {
+	if strings.TrimSpace(device.DeviceName) == "" {
+		return fmt.Errorf("device name is empty; skipping smartctl info call")
+	}
 	fullDeviceName := DeviceFullPath(device.DeviceName)
 	args := strings.Split(d.Config.GetCommandMetricsInfoArgs(fullDeviceName), " ")
 	//only include the device type if its a non-standard one. In some cases ata drives are detected as scsi in docker, and metadata is lost.
@@ -184,6 +187,10 @@ func (d *Detect) TransformDetectedDevices(detectedDeviceConns models.Scan) []mod
 	groupedDevices := map[string][]models.Device{}
 
 	for _, scannedDevice := range detectedDeviceConns.Devices {
+		if strings.TrimSpace(scannedDevice.Name) == "" {
+			d.Logger.Warnf("smartctl --scan returned a device entry with an empty name; skipping to avoid invoking smartctl with path %q", DevicePrefix())
+			continue
+		}
 
 		// Preserve case for all device paths — filesystem paths are case-sensitive.
 		// /dev/disk/by-id/ paths may contain uppercase characters from manufacturer

--- a/collector/pkg/detect/detect_test.go
+++ b/collector/pkg/detect/detect_test.go
@@ -598,6 +598,32 @@ func TestDetect_TransformDetectedDevices_UppercaseByIDPathScanned(t *testing.T) 
 	require.Equal(t, "disk/by-id/ata-HGST_HUH721212ALE600_ABC123", transformedDevices[0].DeviceName)
 }
 
+func TestDetect_TransformDetectedDevices_EmptyDeviceName(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	fakeConfig := mock_config.NewMockInterface(mockCtrl)
+	fakeConfig.EXPECT().GetString("host.id").AnyTimes().Return("")
+	fakeConfig.EXPECT().GetDeviceOverrides().AnyTimes().Return([]models.ScanOverride{})
+	fakeConfig.EXPECT().IsAllowlistedDevice(gomock.Any()).AnyTimes().Return(true)
+
+	detectedDevices := models.Scan{
+		Devices: []models.ScanDevice{
+			{Name: "/dev/sda", InfoName: "/dev/sda", Protocol: "scsi", Type: "scsi"},
+			{Name: "", InfoName: "", Protocol: "ata", Type: "ata"},
+		},
+	}
+
+	d := detect.Detect{
+		Logger: logrus.WithFields(logrus.Fields{}),
+		Config: fakeConfig,
+	}
+
+	transformedDevices := d.TransformDetectedDevices(detectedDevices)
+
+	require.Equal(t, 1, len(transformedDevices))
+	require.Equal(t, "sda", transformedDevices[0].DeviceName)
+}
+
 func TestDetect_TransformDetectedDevices_RaidWithLabel(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()

--- a/docker/example.omnibus.docker-compose.yml
+++ b/docker/example.omnibus.docker-compose.yml
@@ -37,7 +37,11 @@ services:
       - /proc/mounts:/host/proc/mounts:ro
       - ./config:/opt/scrutiny/config
       - ./influxdb:/opt/scrutiny/influxdb
-      # environment:
+      # Btrfs: if your Btrfs volumes are not visible inside the container,
+      # bind-mount each host volume path (Synology DSM, similar NAS platforms):
+      # - /volume1:/volume1:ro
+      # - /volume2:/volume2:ro
+    environment:
       # Enable ZFS pool monitoring (uncomment to enable)
       # See docs/ZFS_POOL_MONITORING.md for details
       # COLLECTOR_ZFS_CRON_SCHEDULE: "*/15 * * * *"
@@ -45,6 +49,10 @@ services:
       # Enable MDADM RAID monitoring (uncomment to enable)
       # COLLECTOR_MDADM_CRON_SCHEDULE: "*/15 * * * *"
       # COLLECTOR_MDADM_RUN_STARTUP: "true"
+      # Enable Btrfs filesystem monitoring (uncomment to enable)
+      # See docs/BTRFS_FILESYSTEM_MONITORING.md for details
+      # COLLECTOR_BTRFS_CRON_SCHEDULE: "*/15 * * * *"
+      # COLLECTOR_BTRFS_RUN_STARTUP: "true"
       # Enable filesystem capacity monitoring (requires host mount visibility)
       # COLLECTOR_FILESYSTEM_CRON_SCHEDULE: "*/15 * * * *"
       # COLLECTOR_FILESYSTEM_RUN_STARTUP: "true"

--- a/webapp/backend/pkg/database/scrutiny_repository_device.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_device.go
@@ -22,6 +22,17 @@ import (
 // insert device into DB (and update specified columns if device is already registered)
 // update device fields that may change: (DeviceType, HostID)
 func (sr *scrutinyRepository) RegisterDevice(ctx context.Context, dev models.Device) error {
+	// Reject devices with no identifying information. A device must have at least
+	// one of: device_name, model_name, serial_number, or wwn. Without any of these,
+	// the generated device_id would be a deterministic UUID for the all-empty input,
+	// which would create an orphan blank row in the devices table.
+	if strings.TrimSpace(dev.DeviceName) == "" &&
+		strings.TrimSpace(dev.ModelName) == "" &&
+		strings.TrimSpace(dev.SerialNumber) == "" &&
+		strings.TrimSpace(dev.WWN) == "" {
+		return fmt.Errorf("cannot register device with no identifying information (device_name, model_name, serial_number, and wwn are all empty)")
+	}
+
 	// Compute deterministic device ID from model, serial, and WWN
 	if dev.DeviceID == "" {
 		dev.DeviceID = deviceid.Generate(dev.ModelName, dev.SerialNumber, dev.WWN)

--- a/webapp/backend/pkg/database/scrutiny_repository_device_register_test.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_device_register_test.go
@@ -171,3 +171,44 @@ func TestRegisterDeviceDeletesLegacyDuplicateOnceCanonicalRowExists(t *testing.T
 	require.Equal(t, canonicalID, devices[0].DeviceID)
 	require.Equal(t, legacyCreatedAt, devices[0].CreatedAt.UTC().Truncate(time.Second))
 }
+
+func TestRegisterDeviceRejectsBlankDevice(t *testing.T) {
+	repo := createDeviceRegisterTestRepository(t)
+	ctx := context.Background()
+
+	err := repo.RegisterDevice(ctx, models.Device{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no identifying information")
+
+	var count int64
+	require.NoError(t, repo.gormClient.WithContext(ctx).Model(&models.Device{}).Count(&count).Error)
+	require.Equal(t, int64(0), count)
+}
+
+func TestRegisterDeviceAcceptsDeviceWithOnlyDeviceName(t *testing.T) {
+	repo := createDeviceRegisterTestRepository(t)
+	ctx := context.Background()
+
+	err := repo.RegisterDevice(ctx, models.Device{
+		DeviceName: "sda",
+	})
+	require.NoError(t, err)
+
+	var count int64
+	require.NoError(t, repo.gormClient.WithContext(ctx).Model(&models.Device{}).Count(&count).Error)
+	require.Equal(t, int64(1), count)
+}
+
+func TestRegisterDeviceAcceptsDeviceWithOnlySerialNumber(t *testing.T) {
+	repo := createDeviceRegisterTestRepository(t)
+	ctx := context.Background()
+
+	err := repo.RegisterDevice(ctx, models.Device{
+		SerialNumber: "SN123456",
+	})
+	require.NoError(t, err)
+
+	var count int64
+	require.NoError(t, repo.gormClient.WithContext(ctx).Model(&models.Device{}).Count(&count).Error)
+	require.Equal(t, int64(1), count)
+}

--- a/webapp/backend/pkg/database/scrutiny_repository_migrations.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_migrations.go
@@ -1101,6 +1101,22 @@ missed_ping_timeout_override INTEGER DEFAULT 0
 				return tx.Create(&defaultSetting).Error
 			},
 		},
+		{
+			ID: "m20260528000000", // remove orphan blank device rows (#567)
+			// Devices with no identifying information (all of device_name, model_name,
+			// serial_number, and wwn empty or NULL) are invalid and cannot be tracked
+			// or removed via the UI. This migration removes any such rows that may have
+			// been inserted by legacy collector runs or backfill migrations.
+			Migrate: func(tx *gorm.DB) error {
+				return tx.Exec(`
+					DELETE FROM devices
+					WHERE (device_name IS NULL OR TRIM(device_name) = '')
+					  AND (model_name  IS NULL OR TRIM(model_name)  = '')
+					  AND (serial_number IS NULL OR TRIM(serial_number) = '')
+					  AND (wwn IS NULL OR TRIM(wwn) = '')
+				`).Error
+			},
+		},
 	})
 
 	if err := m.Migrate(); err != nil {

--- a/webapp/backend/pkg/database/scrutiny_repository_migrations_test.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_migrations_test.go
@@ -418,3 +418,95 @@ CREATE TABLE devices (
 	require.True(t, repo.gormClient.Migrator().HasColumn(&models.Device{}, "muted"))
 	require.True(t, repo.gormClient.Migrator().HasColumn(&models.Device{}, "missed_ping_timeout_override"))
 }
+
+func TestMigrateRemovesOrphanBlankDeviceRows(t *testing.T) {
+	repo := createMigrationTestRepositoryWithAppliedMigrations(t, []string{
+		"20201107210306",
+		"20220503113100",
+		"20220503120000",
+		"m20220509170100",
+		"m20220709181300",
+		"m20220716214900",
+		"m20250221084400",
+		"m20251108044508",
+		"m20260108000000",
+		"m20260122000000",
+		"m20260129000000",
+		"m20260131000000",
+		"m20260202000000",
+		"m20260225000000",
+		"m20260226000000",
+		"m20260301000000",
+		"m20260315000000",
+		"m20260401000000",
+		"m20260402000000",
+		"m20260410000000",
+		"m20260411000000",
+		"m20260413000000",
+		"m20260414000000",
+		"m20260421000000",
+		"m20260508000000",
+		"m20260510000000",
+		"m20260514000000",
+		"m20260516000000",
+		"m20260523000000",
+		"m20260524000000",
+	})
+	ctx := context.Background()
+
+	// Recreate the devices table with the post-m20260401000000 schema (device_id as primary key)
+	// to simulate the state of the database before the m20260528000000 migration runs.
+	require.NoError(t, repo.gormClient.Exec(`DROP TABLE devices`).Error)
+	require.NoError(t, repo.gormClient.Exec(`
+CREATE TABLE devices (
+	device_id TEXT PRIMARY KEY,
+	wwn TEXT,
+	created_at DATETIME,
+	updated_at DATETIME,
+	deleted_at DATETIME,
+	device_name TEXT,
+	device_uuid TEXT,
+	device_serial_id TEXT,
+	device_label TEXT,
+	manufacturer TEXT,
+	model_family TEXT,
+	model_name TEXT,
+	interface_type TEXT,
+	interface_speed TEXT,
+	serial_number TEXT,
+	firmware TEXT,
+	rotation_speed INTEGER,
+	capacity INTEGER,
+	form_factor TEXT,
+	smart_support TEXT,
+	device_protocol TEXT,
+	device_type TEXT,
+	label TEXT,
+	host_id TEXT,
+	collector_version TEXT,
+	smart_display_mode TEXT DEFAULT 'scrutiny',
+	device_status INTEGER,
+	has_forced_failure NUMERIC DEFAULT 0,
+	archived NUMERIC,
+	muted NUMERIC,
+	missed_ping_timeout_override INTEGER DEFAULT 0
+)`).Error)
+
+	// Insert one blank orphan row (all identifying fields empty) and one valid row.
+	require.NoError(t, repo.gormClient.Exec(`
+		INSERT INTO devices (device_id, wwn, device_name, model_name, serial_number, smart_display_mode)
+		VALUES
+			('blank-uuid', '', '', '', '', 'scrutiny'),
+			('valid-uuid', 'wwn-1', 'sda', 'Samsung SSD 870', 'SN123', 'scrutiny')
+	`).Error)
+
+	require.NoError(t, repo.Migrate(ctx))
+
+	var deviceCount int64
+	require.NoError(t, repo.gormClient.Raw(`SELECT COUNT(*) FROM devices`).Scan(&deviceCount).Error)
+	require.Equal(t, int64(1), deviceCount, "blank orphan row should have been removed")
+
+	var remainingID string
+	require.NoError(t, repo.gormClient.Raw(`SELECT device_id FROM devices LIMIT 1`).Scan(&remainingID).Error)
+	require.Equal(t, "valid-uuid", remainingID, "valid device should be preserved")
+}

--- a/webapp/frontend/src/app/modules/btrfs-filesystem-detail/btrfs-filesystem-detail.component.html
+++ b/webapp/frontend/src/app/modules/btrfs-filesystem-detail/btrfs-filesystem-detail.component.html
@@ -19,23 +19,23 @@
     </div>
 
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
-        <treo-card class="p-6">
+        <treo-card class="flex-col p-6">
             <div class="font-semibold text-xs text-hint uppercase tracking-wider mb-2">Status</div>
             <div class="font-bold text-3xl" [ngClass]="filesystem.status === 'ONLINE' ? 'text-green-600 dark:text-green-400' : 'text-yellow-600 dark:text-yellow-400'">
                 {{ filesystem.status }}
             </div>
         </treo-card>
-        <treo-card class="p-6">
+        <treo-card class="flex-col p-6">
             <div class="font-semibold text-xs text-hint uppercase tracking-wider mb-2">Usage</div>
             <div class="font-bold text-3xl">{{ filesystem.used | fileSize : config?.file_size_si_units }}</div>
             <div class="text-sm text-hint mt-2">{{ filesystem.device_size | fileSize : config?.file_size_si_units }} total</div>
         </treo-card>
-        <treo-card class="p-6">
+        <treo-card class="flex-col p-6">
             <div class="font-semibold text-xs text-hint uppercase tracking-wider mb-2">Profiles</div>
             <div class="font-bold text-xl">{{ filesystem.data_profile || 'n/a' }}</div>
             <div class="text-sm text-hint mt-2">Metadata {{ filesystem.metadata_profile || 'n/a' }}</div>
         </treo-card>
-        <treo-card class="p-6">
+        <treo-card class="flex-col p-6">
             <div class="font-semibold text-xs text-hint uppercase tracking-wider mb-2">Scrub</div>
             <div class="font-bold text-3xl">{{ filesystem.scrub_state }}</div>
             @if (filesystem.scrub_finished_at) {

--- a/webapp/frontend/src/app/modules/detail/detail.component.html
+++ b/webapp/frontend/src/app/modules/detail/detail.component.html
@@ -755,7 +755,7 @@
                 @if (getLatestPerformance(); as latest) {
                 <div class="grid grid-cols-2 md:grid-cols-3 gap-4 mb-4">
                     @if (latest.seq_read_bw_bytes > 0) {
-                    <treo-card class="p-4">
+                    <treo-card class="flex-col p-4">
                         <div class="font-semibold text-xs text-hint uppercase tracking-wider">Seq Read</div>
                         <div class="font-bold text-2xl my-2">{{ latest.seq_read_bw_bytes | fileSize : config?.file_size_si_units }}/s</div>
                         @if (performanceBaseline?.sample_count > 1) { @if (getBaselineDelta(latest.seq_read_bw_bytes, performanceBaseline?.seq_read_bw_bytes, true); as delta) {
@@ -768,7 +768,7 @@
                         } }
                     </treo-card>
                     } @if (latest.seq_write_bw_bytes > 0) {
-                    <treo-card class="p-4">
+                    <treo-card class="flex-col p-4">
                         <div class="font-semibold text-xs text-hint uppercase tracking-wider">Seq Write</div>
                         <div class="font-bold text-2xl my-2">{{ latest.seq_write_bw_bytes | fileSize : config?.file_size_si_units }}/s</div>
                         @if (performanceBaseline?.sample_count > 1) { @if (getBaselineDelta(latest.seq_write_bw_bytes, performanceBaseline?.seq_write_bw_bytes, true); as delta) {
@@ -781,7 +781,7 @@
                         } }
                     </treo-card>
                     } @if (latest.rand_read_iops > 0) {
-                    <treo-card class="p-4">
+                    <treo-card class="flex-col p-4">
                         <div class="font-semibold text-xs text-hint uppercase tracking-wider">Rand Read IOPS</div>
                         <div class="font-bold text-2xl my-2">{{ latest.rand_read_iops | number : '1.0-0' }}</div>
                         @if (performanceBaseline?.sample_count > 1) { @if (getBaselineDelta(latest.rand_read_iops, performanceBaseline?.rand_read_iops, true); as delta) {
@@ -794,7 +794,7 @@
                         } }
                     </treo-card>
                     } @if (latest.rand_write_iops > 0) {
-                    <treo-card class="p-4">
+                    <treo-card class="flex-col p-4">
                         <div class="font-semibold text-xs text-hint uppercase tracking-wider">Rand Write IOPS</div>
                         <div class="font-bold text-2xl my-2">{{ latest.rand_write_iops | number : '1.0-0' }}</div>
                         @if (performanceBaseline?.sample_count > 1) { @if (getBaselineDelta(latest.rand_write_iops, performanceBaseline?.rand_write_iops, true); as delta) {
@@ -807,7 +807,7 @@
                         } }
                     </treo-card>
                     } @if (latest.rand_read_lat_ns_avg > 0) {
-                    <treo-card class="p-4">
+                    <treo-card class="flex-col p-4">
                         <div class="font-semibold text-xs text-hint uppercase tracking-wider">Read Latency</div>
                         <div class="font-bold text-2xl my-2">{{ latest.rand_read_lat_ns_avg | latency }}</div>
                         @if (performanceBaseline?.sample_count > 1) { @if (getBaselineDelta(latest.rand_read_lat_ns_avg, performanceBaseline?.rand_read_lat_ns_avg, false); as
@@ -821,7 +821,7 @@
                         } }
                     </treo-card>
                     } @if (latest.rand_write_lat_ns_avg > 0) {
-                    <treo-card class="p-4">
+                    <treo-card class="flex-col p-4">
                         <div class="font-semibold text-xs text-hint uppercase tracking-wider">Write Latency</div>
                         <div class="font-bold text-2xl my-2">{{ latest.rand_write_lat_ns_avg | latency }}</div>
                         @if (performanceBaseline?.sample_count > 1) { @if (getBaselineDelta(latest.rand_write_lat_ns_avg, performanceBaseline?.rand_write_lat_ns_avg, false); as

--- a/webapp/frontend/src/app/modules/zfs-pool-detail/zfs-pool-detail.component.html
+++ b/webapp/frontend/src/app/modules/zfs-pool-detail/zfs-pool-detail.component.html
@@ -23,7 +23,7 @@
     <!-- Pool Overview -->
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
         <!-- Status Card -->
-        <treo-card class="p-6">
+        <treo-card class="flex-col p-6">
             <div class="font-semibold text-xs text-hint uppercase tracking-wider mb-2">Status</div>
             <div [ngClass]="getStatusColorClass(pool.status)" class="font-bold text-3xl">
                 {{ pool.status }}
@@ -31,7 +31,7 @@
         </treo-card>
 
         <!-- Capacity Card -->
-        <treo-card class="p-6">
+        <treo-card class="flex-col p-6">
             <div class="font-semibold text-xs text-hint uppercase tracking-wider mb-2">Capacity</div>
             <div class="font-bold text-3xl">{{ pool.capacity_percent }}%</div>
             <div class="mt-2 h-2 bg-gray-200 rounded overflow-hidden">
@@ -49,13 +49,13 @@
         </treo-card>
 
         <!-- Fragmentation Card -->
-        <treo-card class="p-6">
+        <treo-card class="flex-col p-6">
             <div class="font-semibold text-xs text-hint uppercase tracking-wider mb-2">Fragmentation</div>
             <div class="font-bold text-3xl">{{ pool.fragmentation }}%</div>
         </treo-card>
 
         <!-- Scrub Status Card -->
-        <treo-card class="p-6">
+        <treo-card class="flex-col p-6">
             <div class="font-semibold text-xs text-hint uppercase tracking-wider mb-2">Last Scrub</div>
             @switch (pool.scrub_state) { @case ('none') {
             <div class="font-bold text-3xl text-hint">Never</div>


### PR DESCRIPTION
## Summary

- Fix MDADM collector missing `--host-id` / `COLLECTOR_MDADM_HOST_ID` flag (#573)
- Fix collector skipping devices with empty names from `smartctl --scan` output (#569)
- Fix orphan blank device rows created after registration when device name is empty (#567)
- Fix Btrfs filesystem detail and ZFS pool detail stat card flex layout on mobile (#572)
- Fix omnibus compose docs missing Btrfs env vars and environment block indentation

## Linked Issues

Closes #567
Closes #569
Closes #572
Closes #573

## Test plan

- [x] `go vet ./...` passes
- [x] Frontend ESLint passes
- [x] CI running on develop (Docker build + Publish Testing Image)
- [ ] Manual verification on target hardware after deploy