### PR TITLE
Update a drive profile entry to include 4TB variant of the MX500

### DIFF
--- a/webapp/backend/pkg/thresholds/consumer_drive_profiles.json
+++ b/webapp/backend/pkg/thresholds/consumer_drive_profiles.json
@@ -295,7 +295,7 @@
       "vendor": "Crucial",
       "model_family": "Crucial MX500",
       "sample_count": 2214,
-      "model_pattern": "^CT(250|500|1000|2000)MX500SSD1.*$",
+      "model_pattern": "^CT(250|500|1000|2000|4000)MX500SSD1.*$",
       "ata_counter_severity_overrides": {
         "5": { "low": 0, "moderate": 4, "high": 12, "critical": 32 },
         "196": { "low": 0, "moderate": 4, "high": 12, "critical": 32 },

--- a/webapp/backend/pkg/thresholds/consumer_drive_profiles_test.go
+++ b/webapp/backend/pkg/thresholds/consumer_drive_profiles_test.go
@@ -105,6 +105,16 @@ func TestLookupConsumerDriveProfileByCrucialMx500Alias(t *testing.T) {
 	}
 }
 
+func TestLookupConsumerDriveProfileByCrucialMx5004tbRegex(t *testing.T) {
+	profile, ok := LookupConsumerDriveProfile("ATA", "", "CT4000MX500SSD1")
+	if !ok || profile == nil {
+		t.Fatalf("expected Crucial MX500 4TB regex match")
+	}
+	if profile.ModelFamily != "Crucial MX500" {
+		t.Fatalf("unexpected model family: %s", profile.ModelFamily)
+	}
+}
+
 func TestLookupConsumerDriveProfileByCrucialMx300Alias(t *testing.T) {
 	profile, ok := LookupConsumerDriveProfile("ATA", "", "CT525MX300SSD1")
 	if !ok || profile == nil {


### PR DESCRIPTION
## Summary

The Crucial MX500 consumer drive profile regex only matches the 250GB, 500GB, 1TB and 2TB variants. 
The 4TB model (CT4000MX500SSD1) is missing, causing Scrutiny to fall back to generic ATA rules with the message "Using generic ATA rules. No vetted consumer drive profile matched this drive."

## Type of Change

[X] New feature (non-breaking change that adds functionality)

## Changes Made

`consumer_drive_profiles.json` — Crucial MX500 `model_pattern`:

Before: `^CT(250|500|1000|2000)MX500SSD1.*$`
After:  `^CT(250|500|1000|2000|4000)MX500SSD1.*$`

## Why this is safe

The 4TB was verified against hardware teardowns and the smarthdd.com
database (CT4000MX500SSD1/M3CR046):

- **NAND**: Micron 3D TLC 176-layer (B47R) — no QLC, same technology
  as later production runs of the 2TB
- **Firmware**: M3CR045/M3CR046 — same branch as all other MX500
  capacities; M3CR046 applies to all capacities without distinction
- **SMART attributes**: identical set across all MX500 capacities per
  Micron TN-FD-22
- **Controller**: SM2259H — newer than the SM2258 used in 2018 launch
  units, but later 2TB batches already migrated to SM2259H as well.
  The existing profile therefore already covers both controller
  generations; adding the 4TB introduces no new hardware split.

## Testing

<!-- Describe the testing you've done -->

- [X] I have tested this locally
- [/] I have added/updated tests that prove my fix/feature works
- [X] All existing tests pass

## Checklist

- [X] My code follows the project's code style
- [X] I have performed a self-review of my code
- [/] I have commented my code where necessary (particularly complex areas)
- [/] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [X] No console.log, debug statements, or commented-out code

## Additional Notes

The BX500 profile similarly omits the 4TB variant (CT4000BX500SSD1), but that exclusion is maybe intentional and grounded in truth, as the BX500 4TB uses 176-layer QLC NAND, whereas the smaller BX500 capacities use 96-layer TLC NAND. If this doesn't matter, the 4TB variant could also be added to its regex entry.
