### PR TITLE
fix(web): preserve zero temperature readings

### DIFF
--- a/webapp/backend/pkg/models/device_summary.go
+++ b/webapp/backend/pkg/models/device_summary.go
@@ -24,6 +24,6 @@ type SmartSummary struct {
 	WearoutValue   *int64    `json:"wearout_value,omitempty"`
 	RiskScore      *int      `json:"risk_score,omitempty"`
 	RiskCategory   string    `json:"risk_category,omitempty"`
-	Temp           int64     `json:"temp,omitempty"`
+	Temp           int64     `json:"temp"`
 	PowerOnHours   int64     `json:"power_on_hours,omitempty"`
 }

--- a/webapp/backend/pkg/models/device_summary_test.go
+++ b/webapp/backend/pkg/models/device_summary_test.go
@@ -1,0 +1,15 @@
+package models
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSmartSummaryJSONIncludesZeroTemperature(t *testing.T) {
+	payload, err := json.Marshal(SmartSummary{Temp: 0})
+
+	require.NoError(t, err)
+	require.Contains(t, string(payload), `"temp":0`)
+}

--- a/webapp/frontend/src/app/layout/common/dashboard-device-archive-dialog/dashboard-device-archive-dialog.component.spec.ts
+++ b/webapp/frontend/src/app/layout/common/dashboard-device-archive-dialog/dashboard-device-archive-dialog.component.spec.ts
@@ -4,7 +4,7 @@ import { DashboardDeviceArchiveDialogComponent } from './dashboard-device-archiv
 import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
 import { MAT_DIALOG_DATA, MatDialogModule as MatDialogModule, MatDialogRef as MatDialogRef } from '@angular/material/dialog';
 import { MatButtonModule as MatButtonModule } from '@angular/material/button';
-import { MatIconModule } from '@angular/material/icon';
+import { MatIconModule, MatIconRegistry } from '@angular/material/icon';
 import { SharedModule } from '../../../shared/shared.module';
 import { DashboardDeviceArchiveDialogService } from './dashboard-device-archive-dialog.service';
 import { of } from 'rxjs';
@@ -15,14 +15,18 @@ describe('DashboardDeviceArchiveDialogComponent', () => {
 
     const matDialogRefSpy = jasmine.createSpyObj('MatDialogRef', ['closeDialog', 'close']);
     const dashboardDeviceArchiveDialogServiceSpy = jasmine.createSpyObj('DashboardDeviceArchiveDialogService', ['archiveDevice']);
+    const matIconRegistrySpy = jasmine.createSpyObj('MatIconRegistry', ['getNamedSvgIcon']);
 
     beforeEach(() => {
+        matIconRegistrySpy.getNamedSvgIcon.and.returnValue(of(document.createElementNS('http://www.w3.org/2000/svg', 'svg')));
+
         TestBed.configureTestingModule({
             imports: [MatDialogModule, MatButtonModule, MatIconModule, SharedModule, DashboardDeviceArchiveDialogComponent],
             providers: [
                 { provide: MatDialogRef, useValue: matDialogRefSpy },
                 { provide: MAT_DIALOG_DATA, useValue: { deviceId: 'test-device-id', title: 'my-test-device-title' } },
                 { provide: DashboardDeviceArchiveDialogService, useValue: dashboardDeviceArchiveDialogServiceSpy },
+                { provide: MatIconRegistry, useValue: matIconRegistrySpy },
                 provideHttpClient(withInterceptorsFromDi()),
             ],
         }).compileComponents();

--- a/webapp/frontend/src/app/layout/common/dashboard-device-delete-dialog/dashboard-device-delete-dialog.component.spec.ts
+++ b/webapp/frontend/src/app/layout/common/dashboard-device-delete-dialog/dashboard-device-delete-dialog.component.spec.ts
@@ -4,7 +4,7 @@ import { DashboardDeviceDeleteDialogComponent } from './dashboard-device-delete-
 import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
 import { MAT_DIALOG_DATA, MatDialogModule as MatDialogModule, MatDialogRef as MatDialogRef } from '@angular/material/dialog';
 import { MatButtonModule as MatButtonModule } from '@angular/material/button';
-import { MatIconModule } from '@angular/material/icon';
+import { MatIconModule, MatIconRegistry } from '@angular/material/icon';
 import { SharedModule } from '../../../shared/shared.module';
 import { DashboardDeviceDeleteDialogService } from './dashboard-device-delete-dialog.service';
 import { of } from 'rxjs';
@@ -15,14 +15,18 @@ describe('DashboardDeviceDeleteDialogComponent', () => {
 
     const matDialogRefSpy = jasmine.createSpyObj('MatDialogRef', ['closeDialog', 'close']);
     const dashboardDeviceDeleteDialogServiceSpy = jasmine.createSpyObj('DashboardDeviceDeleteDialogService', ['deleteDevice']);
+    const matIconRegistrySpy = jasmine.createSpyObj('MatIconRegistry', ['getNamedSvgIcon']);
 
     beforeEach(() => {
+        matIconRegistrySpy.getNamedSvgIcon.and.returnValue(of(document.createElementNS('http://www.w3.org/2000/svg', 'svg')));
+
         TestBed.configureTestingModule({
             imports: [MatDialogModule, MatButtonModule, MatIconModule, SharedModule, DashboardDeviceDeleteDialogComponent],
             providers: [
                 { provide: MatDialogRef, useValue: matDialogRefSpy },
                 { provide: MAT_DIALOG_DATA, useValue: { deviceId: 'test-device-id', title: 'my-test-device-title' } },
                 { provide: DashboardDeviceDeleteDialogService, useValue: dashboardDeviceDeleteDialogServiceSpy },
+                { provide: MatIconRegistry, useValue: matIconRegistrySpy },
                 provideHttpClient(withInterceptorsFromDi()),
             ],
         }).compileComponents();

--- a/webapp/frontend/src/app/shared/temperature.pipe.spec.ts
+++ b/webapp/frontend/src/app/shared/temperature.pipe.spec.ts
@@ -57,6 +57,12 @@ describe('TemperaturePipe', () => {
     describe('#formatTemperature', () => {
         const testCases = [
             {
+                c: 0,
+                unit: 'celsius',
+                includeUnits: true,
+                result: '0°C',
+            },
+            {
                 c: 26.67,
                 unit: 'celsius',
                 includeUnits: true,
@@ -99,6 +105,29 @@ describe('TemperaturePipe', () => {
                 const formatted = TemperaturePipe.formatTemperature(test.c, test.unit, test.includeUnits);
                 expect(formatted).toEqual(test.result);
             });
+        });
+
+        it('should display a placeholder for missing temperature values', () => {
+            expect(TemperaturePipe.formatTemperature(undefined, 'celsius', true)).toEqual('--');
+            expect(TemperaturePipe.formatTemperature(null, 'celsius', true)).toEqual('--');
+            expect(TemperaturePipe.formatTemperature(Number.NaN, 'celsius', true)).toEqual('--');
+        });
+    });
+
+    describe('#transform', () => {
+        it('should preserve zero celsius readings', () => {
+            const pipe = new TemperaturePipe();
+
+            expect(pipe.transform(0, 'celsius', true)).toEqual('0°C');
+            expect(pipe.transform(0, 'fahrenheit', true)).toEqual('32°F');
+        });
+
+        it('should display a placeholder for missing temperature values', () => {
+            const pipe = new TemperaturePipe();
+
+            expect(pipe.transform(undefined, 'celsius', true)).toEqual('--');
+            expect(pipe.transform(null, 'celsius', true)).toEqual('--');
+            expect(pipe.transform(Number.POSITIVE_INFINITY, 'celsius', true)).toEqual('--');
         });
     });
 });

--- a/webapp/frontend/src/app/shared/temperature.pipe.ts
+++ b/webapp/frontend/src/app/shared/temperature.pipe.ts
@@ -6,7 +6,11 @@ export class TemperaturePipe implements PipeTransform {
     static celsiusToFahrenheit(celsiusTemp: number): number {
         return (celsiusTemp * 9) / 5 + 32;
     }
-    static formatTemperature(temp: number, unit: string, includeUnits: boolean): number | string {
+    static formatTemperature(temp: number | null | undefined, unit: string, includeUnits: boolean): number | string {
+        if (temp == null || !Number.isFinite(temp)) {
+            return '--';
+        }
+
         let unitSuffix;
         switch (unit) {
             case 'celsius':
@@ -23,7 +27,11 @@ export class TemperaturePipe implements PipeTransform {
         }
     }
 
-    transform(celsiusTemp: number, unit = 'celsius', includeUnits = false): number | string {
+    transform(celsiusTemp: number | null | undefined, unit = 'celsius', includeUnits = false): number | string {
+        if (celsiusTemp == null || !Number.isFinite(celsiusTemp)) {
+            return '--';
+        }
+
         let temperature;
         switch (unit) {
             case 'celsius':


### PR DESCRIPTION
## Summary
- Promote `develop` to `master` for the next production release.
- Includes the zero-temperature summary and frontend display fix for issue #587.
- Includes frontend dialog test stabilization for the current Angular Material behavior.

## Linked Issues
Refs #587

## Test plan
- GitHub `Docker` workflow for `develop` passed on commit `955f01cb`.
- GitHub `Publish Testing Image` workflow for `develop` passed on commit `955f01cb`.
- Zeus testing rebuilt from `ghcr.io/starosdev/scrutiny:develop-omnibus` containing `5809ebf3` and `955f01cb`.
- Zeus `/api/health` returned healthy on the testing stack.
- Synthetic zero-temperature SMART upload returned `temp_present: true`, `temp: 0`, and `device_status: 0` from `/api/summary`.
- Testing-stack Uptime Kuma localhost push noise was disabled after validation; no new `localhost:9445` connection-refused line appeared past the push interval.

## Release notes
- After merge to `master`, Docker images rebuild automatically.
- The release workflow remains a manual follow-up when production release notes are ready.