### PR TITLE
Update a drive profile entry to include 4TB variant of the BX500

### DIFF
--- a/webapp/backend/pkg/thresholds/consumer_drive_profiles.json
+++ b/webapp/backend/pkg/thresholds/consumer_drive_profiles.json
@@ -323,7 +323,7 @@
       "vendor": "Crucial",
       "model_family": "Crucial BX500",
       "sample_count": 481,
-      "model_pattern": "^CT(120|240|480|500|1000|2000)BX500SSD1.*$",
+      "model_pattern": "^CT(120|240|480|500|1000|2000|4000)BX500SSD1.*$",
       "ata_counter_severity_overrides": {
         "5": { "low": 0, "moderate": 4, "high": 12, "critical": 32 },
         "196": { "low": 0, "moderate": 4, "high": 12, "critical": 32 },

--- a/webapp/backend/pkg/thresholds/consumer_drive_profiles_test.go
+++ b/webapp/backend/pkg/thresholds/consumer_drive_profiles_test.go
@@ -125,6 +125,16 @@ func TestLookupConsumerDriveProfileByCrucialMx300Alias(t *testing.T) {
 	}
 }
 
+func TestLookupConsumerDriveProfileByCrucialBx500Regex4TB(t *testing.T) {
+	profile, ok := LookupConsumerDriveProfile("ATA", "", "CT4000BX500SSD1")
+	if !ok || profile == nil {
+		t.Fatalf("expected Crucial BX500 4TB regex match")
+	}
+	if profile.ModelFamily != "Crucial BX500" {
+		t.Fatalf("unexpected model family: %s", profile.ModelFamily)
+	}
+}
+
 func TestLookupConsumerDriveProfileBySamsung870QvoRegex(t *testing.T) {
 	profile, ok := LookupConsumerDriveProfile("ATA", "", "Samsung SSD 870 QVO 2TB")
 	if !ok || profile == nil {


### PR DESCRIPTION
## Summary

Following our discussion on the simimar PR  #581.

The Crucial BX500 consumer drive profile regex only matches the 250GB, 500GB, 1TB and 2TB variants. 
The 4TB model (CT4000BX500SSD1) is missing, causing Scrutiny to fall back to generic ATA rules with the message "Using generic ATA rules. No vetted consumer drive profile matched this drive."


## Type of Change

[X] New feature (non-breaking change that adds functionality)

## Changes Made

`consumer_drive_profiles.json` — Crucial BX500 `model_pattern`:

Before: `^CT(250|500|1000|2000)BX500SSD1.*$`
After:  `^CT(250|500|1000|2000|4000)BX500SSD1.*$`

## Testing

<!-- Describe the testing you've done -->

- [X] I have tested this locally
- [X] I have added/updated tests that prove my fix/feature works
- [x] All existing tests pass

## Checklist

- [X] My code follows the project's code style
- [X] I have performed a self-review of my code
- [/] I have commented my code where necessary (particularly complex areas)
- [/] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [X] No console.log, debug statements, or commented-out code
