### PR TITLE
Update AppArmor profile for scrutiny-collector, for Ubuntu 26.04

### DIFF
--- a/docker/apparmor-profile
+++ b/docker/apparmor-profile
@@ -20,41 +20,57 @@
 profile scrutiny-collector flags=(attach_disconnected,mediate_deleted) {
   #include <abstractions/base>
 
-  # ---------- filesystem access ----------
-
-  # Standard container filesystem (read/write)
+# ---------- filesystem access ----------
   / r,
   /** rwlk,
 
-  # Block device nodes passed via --device (read-only)
-  /dev/sd*   r,
-  /dev/hd*   r,
+  # Binaries needed by entrypoint
+  /usr/bin/su ix,
+  /usr/bin/sed ix,
+  /usr/bin/sleep ix,
+  /usr/sbin/smartctl ix,
+  /opt/scrutiny/bin/scrutiny-collector-metrics ix,
+  /bin/sh ix,
+  /bin/bash ix,
+  /usr/bin/sh ix,
+  /usr/bin/bash ix,
+  /usr/sbin/cron ix,
+  /usr/sbin/crond ix,
+
+  # Auth/User Resolution (Required for su)
+  /etc/passwd r,
+  /etc/group r,
+  /etc/nsswitch.conf r,
+  /etc/pam.d/** r,
+  /etc/login.defs r,
+  /lib/**/*.so* mr,
+  /usr/lib/**/*.so* mr,
+  /etc/shadow r,
+  /var/log/btmp rw,
+  /var/log/wtmp rw,
+  /var/log/lastlog rw,
+  /usr/sbin/unix_chkpwd ix,
+
+  # Block devices & Metadata
+  /dev/sd* r,
+  /dev/hd* r,
   /dev/nvme* r,
-  /dev/sg*   r,
+  /dev/sg* r,
   /dev/bsg/** r,
   /dev/disk/** r,
-
-  # sysfs device metadata used by smartctl for device identification
   /sys/block/** r,
   /sys/class/block/** r,
   /sys/class/scsi_generic/** r,
   /sys/class/nvme/** r,
   /sys/devices/** r,
-
-  # proc entries used by smartctl / the collector
   /proc/*/mounts r,
   /proc/devices r,
 
   # ---------- capabilities ----------
-
-  # Required for ATA/SCSI passthrough ioctls (SMART data retrieval)
   capability sys_rawio,
-
-  # Required for NVMe ioctl access
   capability sys_admin,
-
-  # Standard capabilities expected by container processes
   capability dac_override,
+  capability dac_read_search,
   capability fowner,
   capability fsetid,
   capability kill,
@@ -67,24 +83,20 @@ profile scrutiny-collector flags=(attach_disconnected,mediate_deleted) {
   capability mknod,
   capability audit_write,
   capability setfcap,
+  capability sys_ptrace,
+  ptrace,
+  capability audit_control,
+  capability sys_resource,
 
-  # ---------- network ----------
-
+  # ---------- network & signals ----------
   network,
-
-  # ---------- signals ----------
-
   signal (receive) peer=unconfined,
   signal (send,receive) peer=scrutiny-collector,
-
+  signal (receive) peer=runc,
   # ---------- deny rules ----------
-
-  # Prevent writes to block devices (collector only reads SMART data)
   deny /dev/sd* w,
   deny /dev/hd* w,
   deny /dev/nvme* w,
   deny /dev/sg* w,
-
-  # Prevent mounting filesystems
   deny mount,
 }


### PR DESCRIPTION
Latest Ubuntu release appears to have changed some aspects of how apparmor profiles are being applied.

This updated profile fixes the example profile accordingly, as of Ubuntu 26.04, with v1.62.3-collector.

## Summary

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues
n/a  

## Changes Made
Updated apparmor profile, to take into account changes in Ubuntu 26.04.

## Testing

<!-- Describe the testing you've done -->

- [X] I have tested this locally
- [ ] I have added/updated tests that prove my fix/feature works
- [ ] All existing tests pass

## Checklist
- [ ] My code follows the project's code style - 
- [X] I have performed a self-review of my code
- [X] I have commented my code where necessary (particularly complex areas)
- [ ] I have updated the documentation if needed
- [X] My changes generate no new warnings
- [X] No console.log, debug statements, or commented-out code

## Screenshots (if applicable)
n/a  

## Additional Notes
n/a  
