### PR TITLE
feat(notify): limit heartbeat pings to specific notification URLs

### DIFF
--- a/webapp/backend/pkg/database/interface.go
+++ b/webapp/backend/pkg/database/interface.go
@@ -152,4 +152,5 @@ type DeviceRepo interface {
 	GetNotifyUrls(ctx context.Context) ([]models.NotifyUrl, error)
 	SaveNotifyUrl(ctx context.Context, notifyUrl *models.NotifyUrl) error
 	DeleteNotifyUrl(ctx context.Context, id uint) error
+	UpdateNotifyUrlHeartbeat(ctx context.Context, id uint, enabled bool) error
 }

--- a/webapp/backend/pkg/database/migrations/m20260608000000/notify_url.go
+++ b/webapp/backend/pkg/database/migrations/m20260608000000/notify_url.go
@@ -1,0 +1,17 @@
+package m20260608000000
+
+import "time"
+
+type NotifyUrl struct {
+	CreatedAt        time.Time
+	UpdatedAt        time.Time
+	URL              string `gorm:"not null"`
+	Label            string
+	Source           string `gorm:"default:'ui'"`
+	HeartbeatEnabled bool   `gorm:"default:true"`
+	ID               uint   `gorm:"primaryKey"`
+}
+
+func (NotifyUrl) TableName() string {
+	return "notify_urls"
+}

--- a/webapp/backend/pkg/database/mock/mock_database.go
+++ b/webapp/backend/pkg/database/mock/mock_database.go
@@ -125,6 +125,20 @@ func (mr *MockDeviceRepoMockRecorder) DeleteNotifyUrl(ctx, id interface{}) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNotifyUrl", reflect.TypeOf((*MockDeviceRepo)(nil).DeleteNotifyUrl), ctx, id)
 }
 
+// UpdateNotifyUrlHeartbeat mocks base method.
+func (m *MockDeviceRepo) UpdateNotifyUrlHeartbeat(ctx context.Context, id uint, enabled bool) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateNotifyUrlHeartbeat", ctx, id, enabled)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateNotifyUrlHeartbeat indicates an expected call of UpdateNotifyUrlHeartbeat.
+func (mr *MockDeviceRepoMockRecorder) UpdateNotifyUrlHeartbeat(ctx, id, enabled interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateNotifyUrlHeartbeat", reflect.TypeOf((*MockDeviceRepo)(nil).UpdateNotifyUrlHeartbeat), ctx, id, enabled)
+}
+
 // DeleteZFSPool mocks base method.
 func (m *MockDeviceRepo) DeleteZFSPool(ctx context.Context, guid string) error {
 	m.ctrl.T.Helper()

--- a/webapp/backend/pkg/database/scrutiny_repository_migrations.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_migrations.go
@@ -31,6 +31,7 @@ import (
 	"github.com/analogj/scrutiny/webapp/backend/pkg/database/migrations/m20260514000000"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/database/migrations/m20260516000000"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/database/migrations/m20260523000000"
+	m20260608000000 "github.com/analogj/scrutiny/webapp/backend/pkg/database/migrations/m20260608000000"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/deviceid"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/models"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/models/collector"
@@ -1115,6 +1116,12 @@ missed_ping_timeout_override INTEGER DEFAULT 0
 					  AND (serial_number IS NULL OR TRIM(serial_number) = '')
 					  AND (wwn IS NULL OR TRIM(wwn) = '')
 				`).Error
+			},
+		},
+		{
+			ID: "m20260608000000", // add heartbeat_enabled to notify_urls table
+			Migrate: func(tx *gorm.DB) error {
+				return tx.AutoMigrate(&m20260608000000.NotifyUrl{})
 			},
 		},
 	})

--- a/webapp/backend/pkg/database/scrutiny_repository_notify_urls.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_notify_urls.go
@@ -25,3 +25,12 @@ func (sr *scrutinyRepository) SaveNotifyUrl(ctx context.Context, notifyUrl *mode
 func (sr *scrutinyRepository) DeleteNotifyUrl(ctx context.Context, id uint) error {
 	return sr.gormClient.WithContext(ctx).Delete(&models.NotifyUrl{}, id).Error
 }
+
+// UpdateNotifyUrlHeartbeat updates the heartbeat_enabled flag for a notification URL
+func (sr *scrutinyRepository) UpdateNotifyUrlHeartbeat(ctx context.Context, id uint, enabled bool) error {
+	return sr.gormClient.WithContext(ctx).
+		Model(&models.NotifyUrl{}).
+		Where("id = ?", id).
+		Update("heartbeat_enabled", enabled).
+		Error
+}

--- a/webapp/backend/pkg/database/scrutiny_repository_notify_urls.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_notify_urls.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/analogj/scrutiny/webapp/backend/pkg/models"
+	"gorm.io/gorm"
 )
 
 // GetNotifyUrls retrieves all UI-sourced notification URLs from the database
@@ -28,9 +29,15 @@ func (sr *scrutinyRepository) DeleteNotifyUrl(ctx context.Context, id uint) erro
 
 // UpdateNotifyUrlHeartbeat updates the heartbeat_enabled flag for a notification URL
 func (sr *scrutinyRepository) UpdateNotifyUrlHeartbeat(ctx context.Context, id uint, enabled bool) error {
-	return sr.gormClient.WithContext(ctx).
+	result := sr.gormClient.WithContext(ctx).
 		Model(&models.NotifyUrl{}).
 		Where("id = ?", id).
-		Update("heartbeat_enabled", enabled).
-		Error
+		Update("heartbeat_enabled", enabled)
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected == 0 {
+		return gorm.ErrRecordNotFound
+	}
+	return nil
 }

--- a/webapp/backend/pkg/models/notify_url.go
+++ b/webapp/backend/pkg/models/notify_url.go
@@ -5,12 +5,13 @@ import "time"
 // NotifyUrl represents a user-configured notification endpoint stored in the database.
 // Only UI-sourced URLs are persisted here. Config/env URLs are read from Viper at runtime.
 type NotifyUrl struct {
-	CreatedAt time.Time `json:"created_at"`
-	UpdatedAt time.Time `json:"updated_at"`
-	URL       string    `json:"url" gorm:"not null"`
-	Label     string    `json:"label"`
-	Source    string    `json:"source" gorm:"default:'ui'"`
-	ID        uint      `json:"id" gorm:"primaryKey"`
+	CreatedAt        time.Time `json:"created_at"`
+	UpdatedAt        time.Time `json:"updated_at"`
+	URL              string    `json:"url" gorm:"not null"`
+	Label            string    `json:"label"`
+	Source           string    `json:"source" gorm:"default:'ui'"`
+	HeartbeatEnabled bool      `json:"heartbeat_enabled" gorm:"default:true"`
+	ID               uint      `json:"id" gorm:"primaryKey"`
 }
 
 func (NotifyUrl) TableName() string {

--- a/webapp/backend/pkg/notify/notify.go
+++ b/webapp/backend/pkg/notify/notify.go
@@ -415,6 +415,22 @@ func (n *Notify) LoadDatabaseUrls(ctx context.Context, repo database.DeviceRepo)
 	}
 }
 
+// LoadHeartbeatDatabaseUrls populates n.DatabaseUrls with only the URLs that
+// have HeartbeatEnabled set to true. Used by the heartbeat monitor so users
+// can choose which endpoints receive periodic health pings.
+func (n *Notify) LoadHeartbeatDatabaseUrls(ctx context.Context, repo database.DeviceRepo) {
+	dbUrls, err := repo.GetNotifyUrls(ctx)
+	if err != nil {
+		n.Logger.Warnf("Could not load database notification URLs for heartbeat: %v", err)
+		return
+	}
+	for _, u := range dbUrls {
+		if u.HeartbeatEnabled {
+			n.DatabaseUrls = append(n.DatabaseUrls, u.URL)
+		}
+	}
+}
+
 // Send dispatches notifications to all configured URLs (config/env + database).
 func (n *Notify) Send() error {
 	// Retrieve list of notification endpoints from config file / env var

--- a/webapp/backend/pkg/notify/notify_test.go
+++ b/webapp/backend/pkg/notify/notify_test.go
@@ -1083,3 +1083,41 @@ func writeSMTPLine(t *testing.T, writer *bufio.Writer, line string) {
 	require.NoError(t, err)
 	require.NoError(t, writer.Flush())
 }
+
+func TestLoadHeartbeatDatabaseUrls_FiltersDisabled(t *testing.T) {
+	t.Parallel()
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	fakeDatabase := mock_database.NewMockDeviceRepo(mockCtrl)
+
+	fakeDatabase.EXPECT().
+		GetNotifyUrls(gomock.Any()).
+		Return([]models.NotifyUrl{
+			{ID: 1, URL: "slack://token", HeartbeatEnabled: true},
+			{ID: 2, URL: "discord://token", HeartbeatEnabled: false},
+			{ID: 3, URL: "generic://healthchecks.io", HeartbeatEnabled: true},
+		}, nil).
+		Times(1)
+
+	n := Notify{Logger: logrus.StandardLogger()}
+	n.LoadHeartbeatDatabaseUrls(context.Background(), fakeDatabase)
+
+	require.Equal(t, []string{"slack://token", "generic://healthchecks.io"}, n.DatabaseUrls)
+}
+
+func TestLoadHeartbeatDatabaseUrls_RepoError_Degrades(t *testing.T) {
+	t.Parallel()
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	fakeDatabase := mock_database.NewMockDeviceRepo(mockCtrl)
+
+	fakeDatabase.EXPECT().
+		GetNotifyUrls(gomock.Any()).
+		Return(nil, errors.New("db error")).
+		Times(1)
+
+	n := Notify{Logger: logrus.StandardLogger()}
+	n.LoadHeartbeatDatabaseUrls(context.Background(), fakeDatabase)
+
+	require.Empty(t, n.DatabaseUrls)
+}

--- a/webapp/backend/pkg/web/handler/notify_urls.go
+++ b/webapp/backend/pkg/web/handler/notify_urls.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"errors"
 	"net/http"
 	"strconv"
 
@@ -11,6 +12,7 @@ import (
 	"github.com/analogj/scrutiny/webapp/backend/pkg/notify"
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 )
 
 const errInvalidIDFormat = "Invalid ID format"
@@ -153,6 +155,10 @@ func UpdateNotifyUrlHeartbeat(c *gin.Context) {
 	}
 
 	if err := deviceRepo.UpdateNotifyUrlHeartbeat(c, uint(id), input.Enabled); err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"success": false, "error": "Notification URL not found"})
+			return
+		}
 		logger.Errorln("Error updating notification URL heartbeat:", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": "Failed to update notification URL"})
 		return

--- a/webapp/backend/pkg/web/handler/notify_urls.go
+++ b/webapp/backend/pkg/web/handler/notify_urls.go
@@ -13,11 +13,14 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const errInvalidIDFormat = "Invalid ID format"
+
 type notifyUrlResponse struct {
-	URL    string `json:"url"`
-	Label  string `json:"label,omitempty"`
-	Source string `json:"source"`
-	ID     uint   `json:"id,omitempty"`
+	URL              string `json:"url"`
+	Label            string `json:"label,omitempty"`
+	Source           string `json:"source"`
+	HeartbeatEnabled bool   `json:"heartbeat_enabled"`
+	ID               uint   `json:"id,omitempty"`
 }
 
 // GetNotifyUrls returns a merged list of notification URLs from all sources.
@@ -48,10 +51,11 @@ func GetNotifyUrls(c *gin.Context) {
 	}
 	for _, u := range dbUrls {
 		result = append(result, notifyUrlResponse{
-			ID:     u.ID,
-			URL:    notify.MaskNotifyUrl(u.URL),
-			Label:  u.Label,
-			Source: u.Source,
+			ID:               u.ID,
+			URL:              notify.MaskNotifyUrl(u.URL),
+			Label:            u.Label,
+			Source:           u.Source,
+			HeartbeatEnabled: u.HeartbeatEnabled,
 		})
 	}
 
@@ -68,8 +72,9 @@ func SaveNotifyUrl(c *gin.Context) {
 	deviceRepo := c.MustGet("DEVICE_REPOSITORY").(database.DeviceRepo)
 
 	var input struct {
-		URL   string `json:"url"`
-		Label string `json:"label"`
+		URL              string `json:"url"`
+		Label            string `json:"label"`
+		HeartbeatEnabled bool   `json:"heartbeat_enabled"`
 	}
 	if err := c.BindJSON(&input); err != nil {
 		logger.Errorln("Cannot parse notification URL:", err)
@@ -83,8 +88,9 @@ func SaveNotifyUrl(c *gin.Context) {
 	}
 
 	entry := &models.NotifyUrl{
-		URL:   input.URL,
-		Label: input.Label,
+		URL:              input.URL,
+		Label:            input.Label,
+		HeartbeatEnabled: input.HeartbeatEnabled,
 	}
 
 	if err := deviceRepo.SaveNotifyUrl(c, entry); err != nil {
@@ -96,10 +102,11 @@ func SaveNotifyUrl(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{
 		"success": true,
 		"data": notifyUrlResponse{
-			ID:     entry.ID,
-			URL:    notify.MaskNotifyUrl(entry.URL),
-			Label:  entry.Label,
-			Source: entry.Source,
+			ID:               entry.ID,
+			URL:              notify.MaskNotifyUrl(entry.URL),
+			Label:            entry.Label,
+			Source:           entry.Source,
+			HeartbeatEnabled: entry.HeartbeatEnabled,
 		},
 	})
 }
@@ -112,13 +119,42 @@ func DeleteNotifyUrl(c *gin.Context) {
 	idStr := c.Param("id")
 	id, err := strconv.ParseUint(idStr, 10, 32)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": "Invalid ID format"})
+		c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": errInvalidIDFormat})
 		return
 	}
 
 	if err := deviceRepo.DeleteNotifyUrl(c, uint(id)); err != nil {
 		logger.Errorln("Error deleting notification URL:", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": "Failed to delete notification URL"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"success": true})
+}
+
+// UpdateNotifyUrlHeartbeat toggles heartbeat_enabled for a notification URL by ID
+func UpdateNotifyUrlHeartbeat(c *gin.Context) {
+	logger := c.MustGet("LOGGER").(*logrus.Entry)
+	deviceRepo := c.MustGet("DEVICE_REPOSITORY").(database.DeviceRepo)
+
+	idStr := c.Param("id")
+	id, err := strconv.ParseUint(idStr, 10, 32)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": errInvalidIDFormat})
+		return
+	}
+
+	var input struct {
+		Enabled bool `json:"enabled"`
+	}
+	if err := c.BindJSON(&input); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": "Invalid request body"})
+		return
+	}
+
+	if err := deviceRepo.UpdateNotifyUrlHeartbeat(c, uint(id), input.Enabled); err != nil {
+		logger.Errorln("Error updating notification URL heartbeat:", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": "Failed to update notification URL"})
 		return
 	}
 
@@ -135,7 +171,7 @@ func TestNotifyUrl(c *gin.Context) {
 	idStr := c.Param("id")
 	id, err := strconv.ParseUint(idStr, 10, 32)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": "Invalid ID format"})
+		c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": errInvalidIDFormat})
 		return
 	}
 

--- a/webapp/backend/pkg/web/handler/notify_urls_test.go
+++ b/webapp/backend/pkg/web/handler/notify_urls_test.go
@@ -1,0 +1,117 @@
+package handler_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	mock_config "github.com/analogj/scrutiny/webapp/backend/pkg/config/mock"
+	mock_database "github.com/analogj/scrutiny/webapp/backend/pkg/database/mock"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/models"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/web/handler"
+	"github.com/gin-gonic/gin"
+	"github.com/golang/mock/gomock"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func setupNotifyUrlsRouter(t *testing.T, mockRepo *mock_database.MockDeviceRepo, mockCfg *mock_config.MockInterface) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	logger := logrus.WithField("test", t.Name())
+
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("LOGGER", logger)
+		c.Set("DEVICE_REPOSITORY", mockRepo)
+		c.Set("CONFIG", mockCfg)
+		c.Next()
+	})
+	r.GET("/api/settings/notify-urls", handler.GetNotifyUrls)
+	r.POST("/api/settings/notify-urls", handler.SaveNotifyUrl)
+	r.PATCH("/api/settings/notify-urls/:id", handler.UpdateNotifyUrlHeartbeat)
+	return r
+}
+
+func TestGetNotifyUrls_IncludesHeartbeatEnabled(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	t.Cleanup(mockCtrl.Finish)
+	mockRepo := mock_database.NewMockDeviceRepo(mockCtrl)
+	mockCfg := mock_config.NewMockInterface(mockCtrl)
+
+	mockCfg.EXPECT().GetStringSlice("notify.urls").Return([]string{})
+	mockRepo.EXPECT().GetNotifyUrls(gomock.Any()).Return([]models.NotifyUrl{
+		{ID: 1, URL: "slack://token", Label: "Slack", Source: "ui", HeartbeatEnabled: false},
+	}, nil)
+
+	router := setupNotifyUrlsRouter(t, mockRepo, mockCfg)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/api/settings/notify-urls", nil)
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp struct {
+		Success bool `json:"success"`
+		Data    []struct {
+			HeartbeatEnabled bool `json:"heartbeat_enabled"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.True(t, resp.Success)
+	require.Len(t, resp.Data, 1)
+	require.False(t, resp.Data[0].HeartbeatEnabled)
+}
+
+func TestSaveNotifyUrl_PersistsHeartbeatEnabled(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	t.Cleanup(mockCtrl.Finish)
+	mockRepo := mock_database.NewMockDeviceRepo(mockCtrl)
+	mockCfg := mock_config.NewMockInterface(mockCtrl)
+
+	mockRepo.EXPECT().SaveNotifyUrl(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ interface{}, u *models.NotifyUrl) error {
+			require.True(t, u.HeartbeatEnabled)
+			u.ID = 42
+			return nil
+		},
+	)
+
+	router := setupNotifyUrlsRouter(t, mockRepo, mockCfg)
+
+	body, _ := json.Marshal(map[string]interface{}{
+		"url":               "generic://healthchecks.io/ping/abc",
+		"label":             "HC",
+		"heartbeat_enabled": true,
+	})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/api/settings/notify-urls", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestUpdateNotifyUrlHeartbeat_Success(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	t.Cleanup(mockCtrl.Finish)
+	mockRepo := mock_database.NewMockDeviceRepo(mockCtrl)
+	mockCfg := mock_config.NewMockInterface(mockCtrl)
+
+	mockRepo.EXPECT().UpdateNotifyUrlHeartbeat(gomock.Any(), uint(1), false).Return(nil)
+
+	router := setupNotifyUrlsRouter(t, mockRepo, mockCfg)
+
+	body, _ := json.Marshal(map[string]bool{"enabled": false})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("PATCH", "/api/settings/notify-urls/1", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Equal(t, true, resp["success"])
+}

--- a/webapp/backend/pkg/web/heartbeat_monitor.go
+++ b/webapp/backend/pkg/web/heartbeat_monitor.go
@@ -260,7 +260,7 @@ func (m *HeartbeatMonitor) checkAndSendHeartbeat() {
 	m.logger.Infof("All %d monitored drives healthy, sending heartbeat notification", monitoredCount)
 
 	notification := notify.NewHeartbeat(m.logger, m.appEngine.Config, monitoredCount, totalCount)
-	notification.LoadDatabaseUrls(m.ctx, m.deviceRepo)
+	notification.LoadHeartbeatDatabaseUrls(m.ctx, m.deviceRepo)
 
 	// Route through notification gate (bypass quiet hours -- heartbeats are informational)
 	if gate := m.appEngine.NotificationGate; gate != nil {

--- a/webapp/backend/pkg/web/server.go
+++ b/webapp/backend/pkg/web/server.go
@@ -168,6 +168,7 @@ func (ae *AppEngine) Setup(logger *logrus.Entry) *gin.Engine {
 			api.POST("/settings/notify-urls", handler.SaveNotifyUrl)
 			api.DELETE("/settings/notify-urls/:id", handler.DeleteNotifyUrl)
 			api.POST("/settings/notify-urls/:id/test", handler.TestNotifyUrl)
+			api.PATCH("/settings/notify-urls/:id", handler.UpdateNotifyUrlHeartbeat)
 
 			// Scheduled report endpoints
 			api.GET("/reports/generate", handler.GenerateReport)

--- a/webapp/frontend/src/app/core/config/app.config.ts
+++ b/webapp/frontend/src/app/core/config/app.config.ts
@@ -82,6 +82,7 @@ export interface NotifyUrlEntry {
     url: string;
     label?: string;
     source: NotifyUrlSource;
+    heartbeatEnabled?: boolean;
 }
 
 /**

--- a/webapp/frontend/src/app/core/config/notify-url.service.ts
+++ b/webapp/frontend/src/app/core/config/notify-url.service.ts
@@ -7,12 +7,12 @@ import { NotifyUrlEntry } from './app.config';
 
 interface NotifyUrlsResponse {
     success: boolean;
-    data: NotifyUrlEntry[];
+    data: any[];
 }
 
 interface NotifyUrlResponse {
     success: boolean;
-    data: NotifyUrlEntry;
+    data: any;
 }
 
 interface SimpleResponse {
@@ -26,11 +26,41 @@ export class NotifyUrlService {
     private readonly http = inject(HttpClient);
 
     getNotifyUrls(): Observable<NotifyUrlEntry[]> {
-        return this.http.get<NotifyUrlsResponse>(getBasePath() + '/api/settings/notify-urls').pipe(map((response) => response.data || []));
+        return this.http.get<NotifyUrlsResponse>(getBasePath() + '/api/settings/notify-urls').pipe(
+            map((response) =>
+                (response.data || []).map(
+                    (e: any) =>
+                        ({
+                            id: e.id,
+                            url: e.url,
+                            label: e.label,
+                            source: e.source,
+                            heartbeatEnabled: e.heartbeat_enabled,
+                        } as NotifyUrlEntry)
+                )
+            )
+        );
     }
 
-    addNotifyUrl(url: string, label: string): Observable<NotifyUrlEntry> {
-        return this.http.post<NotifyUrlResponse>(getBasePath() + '/api/settings/notify-urls', { url, label }).pipe(map((response) => response.data));
+    addNotifyUrl(url: string, label: string, heartbeatEnabled: boolean = false): Observable<NotifyUrlEntry> {
+        return this.http
+            .post<NotifyUrlResponse>(getBasePath() + '/api/settings/notify-urls', {
+                url,
+                label,
+                heartbeat_enabled: heartbeatEnabled,
+            })
+            .pipe(
+                map(
+                    (response) =>
+                        ({
+                            id: response.data.id,
+                            url: response.data.url,
+                            label: response.data.label,
+                            source: response.data.source,
+                            heartbeatEnabled: response.data.heartbeat_enabled,
+                        } as NotifyUrlEntry)
+                )
+            );
     }
 
     deleteNotifyUrl(id: number): Observable<void> {
@@ -39,5 +69,9 @@ export class NotifyUrlService {
 
     testNotifyUrl(id: number): Observable<void> {
         return this.http.post<SimpleResponse>(getBasePath() + '/api/settings/notify-urls/' + id + '/test', {}).pipe(map(() => undefined));
+    }
+
+    setHeartbeatEnabled(id: number, enabled: boolean): Observable<void> {
+        return this.http.patch<SimpleResponse>(getBasePath() + '/api/settings/notify-urls/' + id, { enabled }).pipe(map(() => void 0));
     }
 }

--- a/webapp/frontend/src/app/layout/common/dashboard-settings/dashboard-settings.component.html
+++ b/webapp/frontend/src/app/layout/common/dashboard-settings/dashboard-settings.component.html
@@ -587,6 +587,18 @@
                         </td>
                     </ng-container>
 
+                    <ng-container matColumnDef="heartbeat">
+                        <th mat-header-cell *matHeaderCellDef>Heartbeat</th>
+                        <td mat-cell *matCellDef="let entry">
+                            <mat-slide-toggle
+                                [checked]="entry.heartbeatEnabled"
+                                [disabled]="entry.source !== 'ui'"
+                                (change)="toggleHeartbeat(entry)"
+                                color="primary">
+                            </mat-slide-toggle>
+                        </td>
+                    </ng-container>
+
                     <ng-container matColumnDef="actions">
                         <th mat-header-cell *matHeaderCellDef></th>
                         <td mat-cell *matCellDef="let entry">
@@ -780,6 +792,15 @@
                         </mat-form-field>
                     </div>
                     }
+
+                    <div class="mt-4">
+                        <mat-slide-toggle
+                            [(ngModel)]="newUrlHeartbeatEnabled"
+                            color="primary"
+                            name="newUrlHeartbeatEnabled">
+                            Send heartbeat pings to this URL
+                        </mat-slide-toggle>
+                    </div>
 
                     <div class="flex gap-2 mt-4">
                         <button mat-raised-button color="primary" (click)="addNotifyUrl()" [disabled]="!buildNotifyUrl()">Save</button>

--- a/webapp/frontend/src/app/layout/common/dashboard-settings/dashboard-settings.component.ts
+++ b/webapp/frontend/src/app/layout/common/dashboard-settings/dashboard-settings.component.ts
@@ -36,6 +36,7 @@ import { MatIcon } from '@angular/material/icon';
 import { MatExpansionPanel, MatExpansionPanelHeader, MatExpansionPanelTitle, MatExpansionPanelDescription } from '@angular/material/expansion';
 import { MatTable, MatColumnDef, MatHeaderCellDef, MatHeaderCell, MatCellDef, MatCell, MatHeaderRowDef, MatHeaderRow, MatRowDef, MatRow } from '@angular/material/table';
 import { MatTooltip } from '@angular/material/tooltip';
+import { MatSlideToggle } from '@angular/material/slide-toggle';
 
 @Component({
     selector: 'app-dashboard-settings',
@@ -73,6 +74,7 @@ import { MatTooltip } from '@angular/material/tooltip';
         MatRow,
         MatDialogActions,
         MatDialogClose,
+        MatSlideToggle,
     ],
 })
 export class DashboardSettingsComponent implements OnInit {
@@ -156,7 +158,7 @@ export class DashboardSettingsComponent implements OnInit {
 
     // Notification URL management
     notifyUrls: NotifyUrlEntry[] = [];
-    notifyUrlColumns: string[] = ['label', 'url', 'source', 'actions'];
+    notifyUrlColumns: string[] = ['label', 'url', 'source', 'heartbeat', 'actions'];
     showAddUrlForm = false;
     selectedEngine: 'shoutrrr' | 'apprise' = 'shoutrrr';
     selectedShoutrrrService: 'custom' | 'smtp' | 'discord' | 'slack' | 'telegram' = 'custom';
@@ -164,6 +166,7 @@ export class DashboardSettingsComponent implements OnInit {
     newUrlRaw = '';
     newAppriseUrlRaw = '';
     newUrlLabel = '';
+    newUrlHeartbeatEnabled = false;
     // SMTP fields
     smtpHost = '';
     smtpPort = '587';
@@ -367,6 +370,24 @@ export class DashboardSettingsComponent implements OnInit {
             });
     }
 
+    toggleHeartbeat(entry: NotifyUrlEntry): void {
+        if (!entry.id) {
+            return;
+        }
+        const newValue = !entry.heartbeatEnabled;
+        this._notifyUrlService
+            .setHeartbeatEnabled(entry.id, newValue)
+            .pipe(takeUntil(this._unsubscribeAll))
+            .subscribe({
+                next: () => {
+                    entry.heartbeatEnabled = newValue;
+                },
+                error: () => {
+                    this.loadNotifyUrls();
+                },
+            });
+    }
+
     buildShoutrrrUrl(): string {
         switch (this.selectedShoutrrrService) {
             case 'custom':
@@ -447,7 +468,7 @@ export class DashboardSettingsComponent implements OnInit {
         const label = this.newUrlLabel.trim();
 
         this._notifyUrlService
-            .addNotifyUrl(url, label)
+            .addNotifyUrl(url, label, this.newUrlHeartbeatEnabled)
             .pipe(takeUntil(this._unsubscribeAll))
             .subscribe((saved) => {
                 this.notifyUrls = [...this.notifyUrls, saved];
@@ -463,6 +484,7 @@ export class DashboardSettingsComponent implements OnInit {
         this.newUrlRaw = '';
         this.newAppriseUrlRaw = '';
         this.newUrlLabel = '';
+        this.newUrlHeartbeatEnabled = false;
         this.smtpHost = '';
         this.smtpPort = '587';
         this.smtpUsername = '';


### PR DESCRIPTION
## Summary

- Adds `heartbeat_enabled` field to `notify_urls` table (DB default `true` — existing URLs unaffected)
- Heartbeat monitor now filters to only heartbeat-enabled URLs; other notification types (alerts, missed ping) unchanged
- New `PATCH /api/settings/notify-urls/:id` endpoint to toggle the flag per URL
- Frontend: per-URL `mat-slide-toggle` in the notification URL table and in the add-URL form (default off for new URLs)

Closes #521

## Test Plan

- [ ] Add a notification URL (e.g. Slack), verify heartbeat toggle defaults to off
- [ ] Enable heartbeat on a healthchecks.io URL, verify heartbeat pings reach it but not the Slack URL
- [ ] Disable heartbeat on existing URL (was true after migration), verify it no longer receives heartbeat pings
- [ ] Config/env-sourced URLs show disabled toggle (read-only)
- [ ] `PATCH /api/settings/notify-urls/:id` returns 404 for non-existent ID
- [ ] All backend tests pass: `go test ./webapp/backend/...`