### PR TITLE
refactor(collector): reduce cognitive complexity in collector commands

### DIFF
--- a/collector/cmd/collector-btrfs/collector-btrfs.go
+++ b/collector/cmd/collector-btrfs/collector-btrfs.go
@@ -37,27 +37,13 @@ func main() {
 		os.Exit(1)
 	}
 
-	configFilePath := "/opt/scrutiny/config/collector-btrfs.yaml"
-	configFilePathAlternative := "/opt/scrutiny/config/collector-btrfs.yml"
-	configFilePathFallback := "/opt/scrutiny/config/collector.yaml"
-	configFilePathFallbackAlt := "/opt/scrutiny/config/collector.yml"
-
-	if !utils.FileExists(configFilePath) && utils.FileExists(configFilePathAlternative) {
-		configFilePath = configFilePathAlternative
-	} else if !utils.FileExists(configFilePath) && !utils.FileExists(configFilePathAlternative) {
-		if utils.FileExists(configFilePathFallback) {
-			configFilePath = configFilePathFallback
-		} else if utils.FileExists(configFilePathFallbackAlt) {
-			configFilePath = configFilePathFallbackAlt
-		}
-	}
+	configFilePath := resolveConfigPath()
 
 	bootstrapLogger := logrus.WithFields(logrus.Fields{"type": "btrfs"})
 	bootstrapLogger.Logger.SetLevel(logrus.InfoLevel)
 
 	err = appConfig.ReadConfig(configFilePath, bootstrapLogger)
-	if _, ok := err.(errors.ConfigFileMissingError); ok {
-	} else if err != nil {
+	if _, missing := err.(errors.ConfigFileMissingError); err != nil && !missing {
 		os.Exit(1)
 	}
 
@@ -91,66 +77,9 @@ func main() {
 		},
 		Commands: []*cli.Command{
 			{
-				Name:  "run",
-				Usage: "Run the scrutiny Btrfs filesystem collector",
-				Action: func(c *cli.Context) error {
-					if c.IsSet("config") {
-						err = appConfig.ReadConfig(c.String("config"), bootstrapLogger)
-						if err != nil {
-							fmt.Printf("Could not find config file at specified path: %s", c.String("config"))
-							return err
-						}
-					}
-
-					if c.IsSet(flagHostID) {
-						appConfig.Set("host.id", c.String(flagHostID))
-					}
-					if c.Bool("debug") {
-						appConfig.Set("log.level", "DEBUG")
-					}
-					if c.IsSet(flagLogFile) {
-						appConfig.Set(configKeyLogFile, c.String(flagLogFile))
-					}
-					if c.IsSet(flagAPIEndpoint) {
-						apiEndpoint := strings.TrimSuffix(c.String(flagAPIEndpoint), "/") + "/"
-						appConfig.Set("api.endpoint", apiEndpoint)
-					}
-					if c.IsSet(flagAPIToken) {
-						appConfig.Set("api.token", c.String(flagAPIToken))
-					}
-
-					collectorLogger, logFile, loggerErr := CreateLogger(appConfig)
-					if logFile != nil {
-						defer logFile.Close()
-					}
-					if loggerErr != nil {
-						return loggerErr
-					}
-
-					settingsMap := appConfig.AllSettings()
-					if apiMap, ok := settingsMap["api"].(map[string]interface{}); ok {
-						if _, hasToken := apiMap["token"]; hasToken && apiMap["token"] != "" {
-							apiMap["token"] = "[REDACTED]"
-						}
-					}
-					settingsData, settingsErr := json.MarshalIndent(settingsMap, "", "\t")
-					if settingsErr != nil {
-						collectorLogger.Warnf("Failed to marshal settings for debug logging: %v", settingsErr)
-					} else {
-						collectorLogger.Debug(string(settingsData))
-					}
-
-					btrfsCollector, collectorErr := btrfs.CreateCollector(
-						appConfig,
-						collectorLogger,
-						appConfig.GetString("api.endpoint"),
-					)
-					if collectorErr != nil {
-						return collectorErr
-					}
-
-					return btrfsCollector.Run()
-				},
+				Name:   "run",
+				Usage:  "Run the scrutiny Btrfs filesystem collector",
+				Action: runCollectorAction(appConfig, bootstrapLogger),
 				Flags: []cli.Flag{
 					&cli.StringFlag{Name: "config", Usage: "Specify the path to the config file"},
 					&cli.StringFlag{Name: flagAPIEndpoint, Usage: "The api server endpoint", EnvVars: []string{"COLLECTOR_BTRFS_API_ENDPOINT", "COLLECTOR_API_ENDPOINT"}},
@@ -166,6 +95,96 @@ func main() {
 	err = app.Run(os.Args)
 	if err != nil {
 		log.Fatal(color.HiRedString("ERROR: %v", err))
+	}
+}
+
+// resolveConfigPath returns the first existing collector config file, preferring the
+// btrfs-specific config and falling back to the shared collector config. Defaults to the
+// primary btrfs path when none exist.
+func resolveConfigPath() string {
+	candidates := []string{
+		"/opt/scrutiny/config/collector-btrfs.yaml",
+		"/opt/scrutiny/config/collector-btrfs.yml",
+		"/opt/scrutiny/config/collector.yaml",
+		"/opt/scrutiny/config/collector.yml",
+	}
+	for _, path := range candidates {
+		if utils.FileExists(path) {
+			return path
+		}
+	}
+	return candidates[0]
+}
+
+// applyRunFlags reads an explicit --config file (if set) and overlays CLI flag values onto appConfig.
+func applyRunFlags(c *cli.Context, appConfig config.Interface, bootstrapLogger *logrus.Entry) error {
+	if c.IsSet("config") {
+		if err := appConfig.ReadConfig(c.String("config"), bootstrapLogger); err != nil {
+			fmt.Printf("Could not find config file at specified path: %s", c.String("config"))
+			return err
+		}
+	}
+	if c.IsSet(flagHostID) {
+		appConfig.Set("host.id", c.String(flagHostID))
+	}
+	if c.Bool("debug") {
+		appConfig.Set("log.level", "DEBUG")
+	}
+	if c.IsSet(flagLogFile) {
+		appConfig.Set(configKeyLogFile, c.String(flagLogFile))
+	}
+	if c.IsSet(flagAPIEndpoint) {
+		appConfig.Set("api.endpoint", strings.TrimSuffix(c.String(flagAPIEndpoint), "/")+"/")
+	}
+	if c.IsSet(flagAPIToken) {
+		appConfig.Set("api.token", c.String(flagAPIToken))
+	}
+	return nil
+}
+
+// logRedactedSettings debug-logs the effective settings with the API token redacted.
+func logRedactedSettings(logger *logrus.Entry, appConfig config.Interface) {
+	settingsMap := appConfig.AllSettings()
+	if apiMap, ok := settingsMap["api"].(map[string]interface{}); ok {
+		if token, hasToken := apiMap["token"]; hasToken && token != "" {
+			apiMap["token"] = "[REDACTED]"
+		}
+	}
+	settingsData, err := json.MarshalIndent(settingsMap, "", "\t")
+	if err != nil {
+		logger.Warnf("Failed to marshal settings for debug logging: %v", err)
+		return
+	}
+	logger.Debug(string(settingsData))
+}
+
+// runCollectorAction builds the cli action that configures and runs the Btrfs collector.
+func runCollectorAction(appConfig config.Interface, bootstrapLogger *logrus.Entry) cli.ActionFunc {
+	return func(c *cli.Context) error {
+		if err := applyRunFlags(c, appConfig, bootstrapLogger); err != nil {
+			return err
+		}
+
+		collectorLogger, logFile, loggerErr := CreateLogger(appConfig)
+		if logFile != nil {
+			defer logFile.Close()
+		}
+		if loggerErr != nil {
+			return loggerErr
+		}
+
+		logRedactedSettings(collectorLogger, appConfig)
+
+		btrfsCollector, collectorErr := btrfs.CreateCollector(
+			appConfig,
+			collectorLogger,
+			appConfig.GetString("api.endpoint"),
+		)
+		if collectorErr != nil {
+			return collectorErr
+		}
+
+		return btrfsCollector.Run()
 	}
 }
 

--- a/collector/cmd/collector-filesystem/collector-filesystem.go
+++ b/collector/cmd/collector-filesystem/collector-filesystem.go
@@ -37,27 +37,13 @@ func main() {
 		os.Exit(1)
 	}
 
-	configFilePath := "/opt/scrutiny/config/collector-filesystem.yaml"
-	configFilePathAlternative := "/opt/scrutiny/config/collector-filesystem.yml"
-	configFilePathFallback := "/opt/scrutiny/config/collector.yaml"
-	configFilePathFallbackAlt := "/opt/scrutiny/config/collector.yml"
-
-	if !utils.FileExists(configFilePath) && utils.FileExists(configFilePathAlternative) {
-		configFilePath = configFilePathAlternative
-	} else if !utils.FileExists(configFilePath) && !utils.FileExists(configFilePathAlternative) {
-		if utils.FileExists(configFilePathFallback) {
-			configFilePath = configFilePathFallback
-		} else if utils.FileExists(configFilePathFallbackAlt) {
-			configFilePath = configFilePathFallbackAlt
-		}
-	}
+	configFilePath := resolveConfigPath()
 
 	bootstrapLogger := logrus.WithFields(logrus.Fields{"type": "filesystem"})
 	bootstrapLogger.Logger.SetLevel(logrus.InfoLevel)
 
 	err = appConfig.ReadConfig(configFilePath, bootstrapLogger)
-	if _, ok := err.(errors.ConfigFileMissingError); ok {
-	} else if err != nil {
+	if _, missing := err.(errors.ConfigFileMissingError); err != nil && !missing {
 		os.Exit(1)
 	}
 
@@ -91,69 +77,9 @@ func main() {
 		},
 		Commands: []*cli.Command{
 			{
-				Name:  "run",
-				Usage: "Run the scrutiny filesystem capacity collector",
-				Action: func(c *cli.Context) error {
-					if c.IsSet("config") {
-						err = appConfig.ReadConfig(c.String("config"), bootstrapLogger)
-						if err != nil {
-							fmt.Printf("Could not find config file at specified path: %s", c.String("config"))
-							return err
-						}
-					}
-
-					if c.IsSet(flagHostID) {
-						appConfig.Set("host.id", c.String(flagHostID))
-					}
-					if c.Bool("debug") {
-						appConfig.Set("log.level", "DEBUG")
-					}
-					if c.IsSet(flagLogFile) {
-						appConfig.Set(configKeyLogFile, c.String(flagLogFile))
-					}
-					if c.IsSet(flagAPIEndpoint) {
-						apiEndpoint := strings.TrimSuffix(c.String(flagAPIEndpoint), "/") + "/"
-						appConfig.Set("api.endpoint", apiEndpoint)
-					}
-					if c.IsSet(flagAPIToken) {
-						appConfig.Set("api.token", c.String(flagAPIToken))
-					}
-
-					var collectorLogger *logrus.Entry
-					var logFile *os.File
-					collectorLogger, logFile, err = CreateLogger(appConfig)
-					if logFile != nil {
-						defer logFile.Close()
-					}
-					if err != nil {
-						return err
-					}
-
-					settingsMap := appConfig.AllSettings()
-					if apiMap, ok := settingsMap["api"].(map[string]interface{}); ok {
-						if _, hasToken := apiMap["token"]; hasToken && apiMap["token"] != "" {
-							apiMap["token"] = "[REDACTED]"
-						}
-					}
-					settingsData, settingsErr := json.MarshalIndent(settingsMap, "", "\t")
-					if settingsErr != nil {
-						collectorLogger.Warnf("Failed to marshal settings for debug logging: %v", settingsErr)
-					} else {
-						collectorLogger.Debug(string(settingsData))
-					}
-
-					var filesystemCollector *filesystem.Collector
-					filesystemCollector, err = filesystem.CreateCollector(
-						appConfig,
-						collectorLogger,
-						appConfig.GetString("api.endpoint"),
-					)
-					if err != nil {
-						return err
-					}
-
-					return filesystemCollector.Run()
-				},
+				Name:   "run",
+				Usage:  "Run the scrutiny filesystem capacity collector",
+				Action: runCollectorAction(appConfig, bootstrapLogger),
 				Flags: []cli.Flag{
 					&cli.StringFlag{Name: "config", Usage: "Specify the path to the config file"},
 					&cli.StringFlag{Name: flagAPIEndpoint, Usage: "The api server endpoint", EnvVars: []string{"COLLECTOR_FILESYSTEM_API_ENDPOINT", "COLLECTOR_API_ENDPOINT"}},
@@ -169,6 +95,96 @@ func main() {
 	err = app.Run(os.Args)
 	if err != nil {
 		log.Fatal(color.HiRedString("ERROR: %v", err))
+	}
+}
+
+// resolveConfigPath returns the first existing collector config file, preferring the
+// filesystem-specific config and falling back to the shared collector config. Defaults to the
+// primary filesystem path when none exist.
+func resolveConfigPath() string {
+	candidates := []string{
+		"/opt/scrutiny/config/collector-filesystem.yaml",
+		"/opt/scrutiny/config/collector-filesystem.yml",
+		"/opt/scrutiny/config/collector.yaml",
+		"/opt/scrutiny/config/collector.yml",
+	}
+	for _, path := range candidates {
+		if utils.FileExists(path) {
+			return path
+		}
+	}
+	return candidates[0]
+}
+
+// applyRunFlags reads an explicit --config file (if set) and overlays CLI flag values onto appConfig.
+func applyRunFlags(c *cli.Context, appConfig config.Interface, bootstrapLogger *logrus.Entry) error {
+	if c.IsSet("config") {
+		if err := appConfig.ReadConfig(c.String("config"), bootstrapLogger); err != nil {
+			fmt.Printf("Could not find config file at specified path: %s", c.String("config"))
+			return err
+		}
+	}
+	if c.IsSet(flagHostID) {
+		appConfig.Set("host.id", c.String(flagHostID))
+	}
+	if c.Bool("debug") {
+		appConfig.Set("log.level", "DEBUG")
+	}
+	if c.IsSet(flagLogFile) {
+		appConfig.Set(configKeyLogFile, c.String(flagLogFile))
+	}
+	if c.IsSet(flagAPIEndpoint) {
+		appConfig.Set("api.endpoint", strings.TrimSuffix(c.String(flagAPIEndpoint), "/")+"/")
+	}
+	if c.IsSet(flagAPIToken) {
+		appConfig.Set("api.token", c.String(flagAPIToken))
+	}
+	return nil
+}
+
+// logRedactedSettings debug-logs the effective settings with the API token redacted.
+func logRedactedSettings(logger *logrus.Entry, appConfig config.Interface) {
+	settingsMap := appConfig.AllSettings()
+	if apiMap, ok := settingsMap["api"].(map[string]interface{}); ok {
+		if token, hasToken := apiMap["token"]; hasToken && token != "" {
+			apiMap["token"] = "[REDACTED]"
+		}
+	}
+	settingsData, err := json.MarshalIndent(settingsMap, "", "\t")
+	if err != nil {
+		logger.Warnf("Failed to marshal settings for debug logging: %v", err)
+		return
+	}
+	logger.Debug(string(settingsData))
+}
+
+// runCollectorAction builds the cli action that configures and runs the filesystem collector.
+func runCollectorAction(appConfig config.Interface, bootstrapLogger *logrus.Entry) cli.ActionFunc {
+	return func(c *cli.Context) error {
+		if err := applyRunFlags(c, appConfig, bootstrapLogger); err != nil {
+			return err
+		}
+
+		collectorLogger, logFile, loggerErr := CreateLogger(appConfig)
+		if logFile != nil {
+			defer logFile.Close()
+		}
+		if loggerErr != nil {
+			return loggerErr
+		}
+
+		logRedactedSettings(collectorLogger, appConfig)
+
+		filesystemCollector, collectorErr := filesystem.CreateCollector(
+			appConfig,
+			collectorLogger,
+			appConfig.GetString("api.endpoint"),
+		)
+		if collectorErr != nil {
+			return collectorErr
+		}
+
+		return filesystemCollector.Run()
 	}
 }
 

--- a/collector/cmd/collector-mdadm/collector-mdadm.go
+++ b/collector/cmd/collector-mdadm/collector-mdadm.go
@@ -64,44 +64,9 @@ func main() {
 
 		Commands: []*cli.Command{
 			{
-				Name:  "run",
-				Usage: "Run the scrutiny MDADM RAID array collector",
-				Action: func(c *cli.Context) error {
-					if c.IsSet("config") {
-						if err := cfg.ReadConfig(c.String("config"), bootstrapLogger); err != nil {
-							fmt.Printf("Could not find config file at specified path: %s", c.String("config"))
-							return err
-						}
-					}
-
-					applyCollectorOverrides(c, cfg)
-
-					collectorLogger, logFile, err := CreateLogger(cfg)
-					if logFile != nil {
-						defer logFile.Close()
-					}
-					if err != nil {
-						return err
-					}
-
-					settingsData, settingsErr := redactCollectorSettings(cfg)
-					if settingsErr != nil {
-						collectorLogger.Warnf("Failed to marshal settings for debug logging: %v", settingsErr)
-					} else {
-						collectorLogger.Debug(string(settingsData))
-					}
-
-					mdadmCollector, err := mdadm.CreateCollector(
-						cfg,
-						collectorLogger,
-						cfg.GetString("api.endpoint"),
-					)
-					if err != nil {
-						return err
-					}
-
-					return mdadmCollector.Run()
-				},
+				Name:   "run",
+				Usage:  "Run the scrutiny MDADM RAID array collector",
+				Action: runCollectorAction(cfg, bootstrapLogger),
 
 				Flags: []cli.Flag{
 					&cli.StringFlag{
@@ -141,6 +106,46 @@ func main() {
 
 	if err := app.Run(os.Args); err != nil {
 		log.Fatal(color.HiRedString("ERROR: %v", err))
+	}
+}
+
+// runCollectorAction builds the cli action that configures and runs the MDADM RAID array collector.
+func runCollectorAction(cfg config.Interface, bootstrapLogger *logrus.Entry) cli.ActionFunc {
+	return func(c *cli.Context) error {
+		if c.IsSet("config") {
+			if err := cfg.ReadConfig(c.String("config"), bootstrapLogger); err != nil {
+				fmt.Printf("Could not find config file at specified path: %s", c.String("config"))
+				return err
+			}
+		}
+
+		applyCollectorOverrides(c, cfg)
+
+		collectorLogger, logFile, err := CreateLogger(cfg)
+		if logFile != nil {
+			defer logFile.Close()
+		}
+		if err != nil {
+			return err
+		}
+
+		settingsData, settingsErr := redactCollectorSettings(cfg)
+		if settingsErr != nil {
+			collectorLogger.Warnf("Failed to marshal settings for debug logging: %v", settingsErr)
+		} else {
+			collectorLogger.Debug(string(settingsData))
+		}
+
+		mdadmCollector, err := mdadm.CreateCollector(
+			cfg,
+			collectorLogger,
+			cfg.GetString("api.endpoint"),
+		)
+		if err != nil {
+			return err
+		}
+
+		return mdadmCollector.Run()
 	}
 }
 

--- a/collector/cmd/collector-performance/collector-performance.go
+++ b/collector/cmd/collector-performance/collector-performance.go
@@ -38,32 +38,16 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Use separate config file for performance collector
-	configFilePath := "/opt/scrutiny/config/collector-performance.yaml"
-	configFilePathAlternative := "/opt/scrutiny/config/collector-performance.yml"
-	// Fall back to main collector config if performance-specific config doesn't exist
-	configFilePathFallback := "/opt/scrutiny/config/collector.yaml"
-	configFilePathFallbackAlt := "/opt/scrutiny/config/collector.yml"
-
-	if !utils.FileExists(configFilePath) && utils.FileExists(configFilePathAlternative) {
-		configFilePath = configFilePathAlternative
-	} else if !utils.FileExists(configFilePath) && !utils.FileExists(configFilePathAlternative) {
-		if utils.FileExists(configFilePathFallback) {
-			configFilePath = configFilePathFallback
-		} else if utils.FileExists(configFilePathFallbackAlt) {
-			configFilePath = configFilePathFallbackAlt
-		}
-	}
+	// Use separate config file for performance collector, falling back to the shared collector config
+	configFilePath := resolveConfigPath()
 
 	// Create a bootstrap logger for config loading
 	bootstrapLogger := logrus.WithFields(logrus.Fields{"type": "performance"})
 	bootstrapLogger.Logger.SetLevel(logrus.InfoLevel)
 
-	// Load the config file
+	// Load the config file (ignore "could not find config file")
 	err = config.ReadConfig(configFilePath, bootstrapLogger)
-	if _, ok := err.(errors.ConfigFileMissingError); ok {
-		// Ignore "could not find config file"
-	} else if err != nil {
+	if _, missing := err.(errors.ConfigFileMissingError); err != nil && !missing {
 		os.Exit(1)
 	}
 
@@ -119,78 +103,9 @@ OPTIONS:
 
 		Commands: []*cli.Command{
 			{
-				Name:  "run",
-				Usage: "Run the scrutiny performance benchmark collector",
-				Action: func(c *cli.Context) error {
-					if c.IsSet("config") {
-						err = config.ReadConfig(c.String("config"), bootstrapLogger)
-						if err != nil {
-							fmt.Printf("Could not find config file at specified path: %s", c.String("config"))
-							return err
-						}
-					}
-
-					// Override config with flags if set
-					if c.IsSet(flagHostId) {
-						config.Set("host.id", c.String(flagHostId))
-					}
-
-					if c.Bool("debug") {
-						config.Set("log.level", "DEBUG")
-					}
-
-					if c.IsSet(flagLogFile) {
-						config.Set(configKeyLogFile, c.String(flagLogFile))
-					}
-
-					if c.IsSet(flagApiEndpoint) {
-						apiEndpoint := strings.TrimSuffix(c.String(flagApiEndpoint), "/") + "/"
-						config.Set("api.endpoint", apiEndpoint)
-					}
-
-					if c.IsSet(flagApiToken) {
-						config.Set("api.token", c.String(flagApiToken))
-					}
-
-					if c.IsSet("profile") {
-						config.Set("performance.profile", c.String("profile"))
-					}
-
-					var collectorLogger *logrus.Entry
-					var logFile *os.File
-					collectorLogger, logFile, err = CreateLogger(config)
-					if logFile != nil {
-						defer logFile.Close()
-					}
-					if err != nil {
-						return err
-					}
-
-					settingsMap := config.AllSettings()
-					if apiMap, ok := settingsMap["api"].(map[string]interface{}); ok {
-						if _, hasToken := apiMap["token"]; hasToken && apiMap["token"] != "" {
-							apiMap["token"] = "[REDACTED]"
-						}
-					}
-					settingsData, settingsErr := json.MarshalIndent(settingsMap, "", "\t")
-					if settingsErr != nil {
-						collectorLogger.Warnf("Failed to marshal settings for debug logging: %v", settingsErr)
-					} else {
-						collectorLogger.Debug(string(settingsData))
-					}
-
-					var perfCollector *performance.Collector
-					perfCollector, err = performance.CreateCollector(
-						config,
-						collectorLogger,
-						config.GetString("api.endpoint"),
-					)
-					if err != nil {
-						return err
-					}
-
-					return perfCollector.Run()
-				},
+				Name:   "run",
+				Usage:  "Run the scrutiny performance benchmark collector",
+				Action: runCollectorAction(config, bootstrapLogger),
 
 				Flags: []cli.Flag{
 					&cli.StringFlag{
@@ -237,6 +152,99 @@ OPTIONS:
 	err = app.Run(os.Args)
 	if err != nil {
 		log.Fatal(color.HiRedString("ERROR: %v", err))
+	}
+}
+
+// resolveConfigPath returns the first existing collector config file, preferring the
+// performance-specific config and falling back to the shared collector config. Defaults to the
+// primary performance path when none exist.
+func resolveConfigPath() string {
+	candidates := []string{
+		"/opt/scrutiny/config/collector-performance.yaml",
+		"/opt/scrutiny/config/collector-performance.yml",
+		"/opt/scrutiny/config/collector.yaml",
+		"/opt/scrutiny/config/collector.yml",
+	}
+	for _, path := range candidates {
+		if utils.FileExists(path) {
+			return path
+		}
+	}
+	return candidates[0]
+}
+
+// applyRunFlags reads an explicit --config file (if set) and overlays CLI flag values onto appConfig.
+func applyRunFlags(c *cli.Context, appConfig config.Interface, bootstrapLogger *logrus.Entry) error {
+	if c.IsSet("config") {
+		if err := appConfig.ReadConfig(c.String("config"), bootstrapLogger); err != nil {
+			fmt.Printf("Could not find config file at specified path: %s", c.String("config"))
+			return err
+		}
+	}
+	if c.IsSet(flagHostId) {
+		appConfig.Set("host.id", c.String(flagHostId))
+	}
+	if c.Bool("debug") {
+		appConfig.Set("log.level", "DEBUG")
+	}
+	if c.IsSet(flagLogFile) {
+		appConfig.Set(configKeyLogFile, c.String(flagLogFile))
+	}
+	if c.IsSet(flagApiEndpoint) {
+		appConfig.Set("api.endpoint", strings.TrimSuffix(c.String(flagApiEndpoint), "/")+"/")
+	}
+	if c.IsSet(flagApiToken) {
+		appConfig.Set("api.token", c.String(flagApiToken))
+	}
+	if c.IsSet("profile") {
+		appConfig.Set("performance.profile", c.String("profile"))
+	}
+	return nil
+}
+
+// logRedactedSettings debug-logs the effective settings with the API token redacted.
+func logRedactedSettings(logger *logrus.Entry, appConfig config.Interface) {
+	settingsMap := appConfig.AllSettings()
+	if apiMap, ok := settingsMap["api"].(map[string]interface{}); ok {
+		if token, hasToken := apiMap["token"]; hasToken && token != "" {
+			apiMap["token"] = "[REDACTED]"
+		}
+	}
+	settingsData, err := json.MarshalIndent(settingsMap, "", "\t")
+	if err != nil {
+		logger.Warnf("Failed to marshal settings for debug logging: %v", err)
+		return
+	}
+	logger.Debug(string(settingsData))
+}
+
+// runCollectorAction builds the cli action that configures and runs the performance collector.
+func runCollectorAction(appConfig config.Interface, bootstrapLogger *logrus.Entry) cli.ActionFunc {
+	return func(c *cli.Context) error {
+		if err := applyRunFlags(c, appConfig, bootstrapLogger); err != nil {
+			return err
+		}
+
+		collectorLogger, logFile, loggerErr := CreateLogger(appConfig)
+		if logFile != nil {
+			defer logFile.Close()
+		}
+		if loggerErr != nil {
+			return loggerErr
+		}
+
+		logRedactedSettings(collectorLogger, appConfig)
+
+		perfCollector, collectorErr := performance.CreateCollector(
+			appConfig,
+			collectorLogger,
+			appConfig.GetString("api.endpoint"),
+		)
+		if collectorErr != nil {
+			return collectorErr
+		}
+
+		return perfCollector.Run()
 	}
 }
 

--- a/collector/cmd/collector-zfs/collector-zfs.go
+++ b/collector/cmd/collector-zfs/collector-zfs.go
@@ -77,44 +77,9 @@ OPTIONS:
 
 		Commands: []*cli.Command{
 			{
-				Name:  "run",
-				Usage: "Run the scrutiny ZFS pool collector",
-				Action: func(c *cli.Context) error {
-					if c.IsSet("config") {
-						if err := cfg.ReadConfig(c.String("config"), bootstrapLogger); err != nil {
-							fmt.Printf("Could not find config file at specified path: %s", c.String("config"))
-							return err
-						}
-					}
-
-					applyCollectorOverrides(c, cfg)
-
-					collectorLogger, logFile, err := CreateLogger(cfg)
-					if logFile != nil {
-						defer logFile.Close()
-					}
-					if err != nil {
-						return err
-					}
-
-					settingsData, settingsErr := redactCollectorSettings(cfg)
-					if settingsErr != nil {
-						collectorLogger.Warnf("Failed to marshal settings for debug logging: %v", settingsErr)
-					} else {
-						collectorLogger.Debug(string(settingsData))
-					}
-
-					zfsCollector, err := zfs.CreateCollector(
-						cfg,
-						collectorLogger,
-						cfg.GetString("api.endpoint"),
-					)
-					if err != nil {
-						return err
-					}
-
-					return zfsCollector.Run()
-				},
+				Name:   "run",
+				Usage:  "Run the scrutiny ZFS pool collector",
+				Action: runCollectorAction(cfg, bootstrapLogger),
 
 				Flags: []cli.Flag{
 					&cli.StringFlag{
@@ -154,6 +119,46 @@ OPTIONS:
 
 	if err := app.Run(os.Args); err != nil {
 		log.Fatal(color.HiRedString("ERROR: %v", err))
+	}
+}
+
+// runCollectorAction builds the cli action that configures and runs the ZFS pool collector.
+func runCollectorAction(cfg config.Interface, bootstrapLogger *logrus.Entry) cli.ActionFunc {
+	return func(c *cli.Context) error {
+		if c.IsSet("config") {
+			if err := cfg.ReadConfig(c.String("config"), bootstrapLogger); err != nil {
+				fmt.Printf("Could not find config file at specified path: %s", c.String("config"))
+				return err
+			}
+		}
+
+		applyCollectorOverrides(c, cfg)
+
+		collectorLogger, logFile, err := CreateLogger(cfg)
+		if logFile != nil {
+			defer logFile.Close()
+		}
+		if err != nil {
+			return err
+		}
+
+		settingsData, settingsErr := redactCollectorSettings(cfg)
+		if settingsErr != nil {
+			collectorLogger.Warnf("Failed to marshal settings for debug logging: %v", settingsErr)
+		} else {
+			collectorLogger.Debug(string(settingsData))
+		}
+
+		zfsCollector, err := zfs.CreateCollector(
+			cfg,
+			collectorLogger,
+			cfg.GetString("api.endpoint"),
+		)
+		if err != nil {
+			return err
+		}
+
+		return zfsCollector.Run()
 	}
 }
 


### PR DESCRIPTION
## Summary

Reduces SonarQube cognitive complexity (go:S3776) in `main()` across all five collector command entrypoints. They ranged from complexity 17 to 47; all functions now sit at or below the allowed limit of 15.

| Command | Before | After |
|---------|--------|-------|
| collector-performance | 47 | ≤15 |
| collector-filesystem | 45 | ≤15 |
| collector-btrfs | 45 | ≤15 |
| collector-zfs | 17 | ≤15 |
| collector-mdadm | 17 | ≤15 |

## Why

Each `main()` inlined the entire cli "run" action closure plus config-path resolution and per-flag overrides, concentrating all branching in one giant function.

## Changes

- **btrfs / filesystem / performance** — extract `resolveConfigPath`, `applyRunFlags`, `logRedactedSettings`, and `runCollectorAction` helpers, mirroring the structure zfs/mdadm already used
- **zfs / mdadm** — extract the inline action into `runCollectorAction` (the other helpers already existed)
- collapse the empty `ConfigFileMissingError` branch (S108) in btrfs/filesystem

Behavior unchanged. The performance collector keeps its extra `profile` flag handling.

## Verification

- [x] `go build ./collector/cmd/...`
- [x] `go vet ./collector/cmd/...`
- [x] `go test ./collector/...` (all pass)
- [x] `gocognit -over 15` reports zero functions over the limit
- [x] `gofmt` clean

## Notes

Continuation of SonarQube Group 5 (cognitive complexity), after #616 (smart.go). Remaining clusters: notify, repository, DB migrations, detect.