### PR TITLE
refactor(frontend): reduce cognitive complexity in components

### DIFF
--- a/webapp/frontend/src/@treo/components/date-range/date-range.component.ts
+++ b/webapp/frontend/src/@treo/components/date-range/date-range.component.ts
@@ -213,55 +213,13 @@ export class TreoDateRangeComponent implements ControlValueAccessor, OnDestroy {
         const start = dayjs(value.start);
         const end = dayjs(value.end);
 
-        // If we are only setting the start date...
         if (whichDate === 'start') {
-            // Set the start date
+            this._applyStartDate(start);
+        } else if (whichDate === 'end') {
+            this._applyEndDate(end);
+        } else {
+            // Setting both dates: keep the end date unless it precedes the start date.
             this._range.start = start.clone();
-
-            // If the selected start date is after the end date...
-            if (this._range.start.isAfter(this._range.end)) {
-                // Set the end date to the start date but keep the end date's time
-                const endDate = start.clone().hour(this._range.end.hour()).minute(this._range.end.minute()).second(this._range.end.second());
-
-                // Test this new end date to see if it's ahead of the start date
-                if (this._range.start.isBefore(endDate)) {
-                    // If it's, set the new end date
-                    this._range.end = endDate;
-                } else {
-                    // Otherwise, set the end date same as the start date
-                    this._range.end = start.clone();
-                }
-            }
-        }
-
-        // If we are only setting the end date...
-        if (whichDate === 'end') {
-            // Set the end date
-            this._range.end = end.clone();
-
-            // If the selected end date is before the start date...
-            if (this._range.start.isAfter(this._range.end)) {
-                // Set the start date to the end date but keep the start date's time
-                const startDate = end.clone().hour(this._range.start.hour()).minute(this._range.start.minute()).second(this._range.start.second());
-
-                // Test this new end date to see if it's ahead of the start date
-                if (this._range.end.isAfter(startDate)) {
-                    // If it's, set the new start date
-                    this._range.start = startDate;
-                } else {
-                    // Otherwise, set the start date same as the end date
-                    this._range.start = end.clone();
-                }
-            }
-        }
-
-        // If we are setting both dates...
-        if (!whichDate) {
-            // Set the start date
-            this._range.start = start.clone();
-
-            // If the start date is before the end date, set the end date as normal.
-            // If the start date is after the end date, set the end date same as the start date.
             this._range.end = start.isBefore(end) ? end.clone() : start.clone();
         }
 
@@ -302,6 +260,38 @@ export class TreoDateRangeComponent implements ControlValueAccessor, OnDestroy {
 
         // Reset the programmatic change status
         this._programmaticChange = false;
+    }
+
+    /**
+     * Set the start date, clamping the end date forward when the new start moves past it
+     * (preserving the end date's time-of-day where possible).
+     */
+    private _applyStartDate(start: Dayjs): void {
+        this._range.start = start.clone();
+
+        if (!this._range.start.isAfter(this._range.end)) {
+            return;
+        }
+
+        // Set the end date to the start date but keep the end date's time
+        const endDate = start.clone().hour(this._range.end.hour()).minute(this._range.end.minute()).second(this._range.end.second());
+        this._range.end = this._range.start.isBefore(endDate) ? endDate : start.clone();
+    }
+
+    /**
+     * Set the end date, clamping the start date backward when the new end moves before it
+     * (preserving the start date's time-of-day where possible).
+     */
+    private _applyEndDate(end: Dayjs): void {
+        this._range.end = end.clone();
+
+        if (!this._range.start.isAfter(this._range.end)) {
+            return;
+        }
+
+        // Set the start date to the end date but keep the start date's time
+        const startDate = end.clone().hour(this._range.start.hour()).minute(this._range.start.minute()).second(this._range.start.second());
+        this._range.start = this._range.end.isAfter(startDate) ? startDate : end.clone();
     }
 
     get range(): any {

--- a/webapp/frontend/src/app/layout/common/dashboard-settings/dashboard-settings.component.ts
+++ b/webapp/frontend/src/app/layout/common/dashboard-settings/dashboard-settings.component.ts
@@ -432,33 +432,10 @@ export class DashboardSettingsComponent implements OnInit {
 
     buildAppriseUrl(): string {
         switch (this.selectedAppriseService) {
-            case 'custom': {
-                const rawUrl = this.newAppriseUrlRaw.trim();
-                if (!rawUrl) {
-                    return '';
-                }
-                return rawUrl.startsWith('apprise+') ? rawUrl : `apprise+${rawUrl}`;
-            }
-            case 'email': {
-                if (!this.smtpHost || !this.smtpFrom || !this.smtpTo) {
-                    return '';
-                }
-                const fromDomain = this.smtpFrom.includes('@') ? this.smtpFrom.split('@').pop() : '';
-                const domain = fromDomain || this.smtpHost;
-                const scheme = this.smtpPort === '25' ? 'mailto' : 'mailtos';
-                const params = new URLSearchParams();
-                params.set('smtp', this.smtpHost);
-                params.set('from', this.smtpFrom);
-                params.set('to', this.smtpTo);
-                if (this.smtpUsername) {
-                    params.set('user', this.smtpUsername);
-                }
-                if (this.smtpPassword) {
-                    params.set('pass', this.smtpPassword);
-                }
-                const port = this.smtpPort ? `:${this.smtpPort}` : '';
-                return `apprise+${scheme}://${domain}${port}?${params.toString()}`;
-            }
+            case 'custom':
+                return this.buildCustomAppriseUrl();
+            case 'email':
+                return this.buildEmailAppriseUrl();
             case 'discord':
                 return this.discordWebhookUrl.trim() ? `apprise+${this.discordWebhookUrl.trim()}` : '';
             case 'slack':
@@ -468,6 +445,35 @@ export class DashboardSettingsComponent implements OnInit {
             default:
                 return '';
         }
+    }
+
+    private buildCustomAppriseUrl(): string {
+        const rawUrl = this.newAppriseUrlRaw.trim();
+        if (!rawUrl) {
+            return '';
+        }
+        return rawUrl.startsWith('apprise+') ? rawUrl : `apprise+${rawUrl}`;
+    }
+
+    private buildEmailAppriseUrl(): string {
+        if (!this.smtpHost || !this.smtpFrom || !this.smtpTo) {
+            return '';
+        }
+        const fromDomain = this.smtpFrom.includes('@') ? this.smtpFrom.split('@').pop() : '';
+        const domain = fromDomain || this.smtpHost;
+        const scheme = this.smtpPort === '25' ? 'mailto' : 'mailtos';
+        const params = new URLSearchParams();
+        params.set('smtp', this.smtpHost);
+        params.set('from', this.smtpFrom);
+        params.set('to', this.smtpTo);
+        if (this.smtpUsername) {
+            params.set('user', this.smtpUsername);
+        }
+        if (this.smtpPassword) {
+            params.set('pass', this.smtpPassword);
+        }
+        const port = this.smtpPort ? `:${this.smtpPort}` : '';
+        return `apprise+${scheme}://${domain}${port}?${params.toString()}`;
     }
 
     buildNotifyUrl(): string {

--- a/webapp/frontend/src/app/modules/detail/detail.component.ts
+++ b/webapp/frontend/src/app/modules/detail/detail.component.ts
@@ -560,54 +560,20 @@ export class DetailComponent implements OnInit, AfterViewInit, OnDestroy {
             return smartAttributeDataSource;
         }
         const latestSmartResult = smartResults[0];
-        let attributes: { [p: string]: SmartAttributeModel } = {};
-        if (this.isScsi()) {
-            this.smartAttributeTableColumns = ['status', 'name', 'value', 'thresh', 'history', 'actions'];
-            attributes = latestSmartResult.attrs;
-        } else if (this.isNvme()) {
-            this.smartAttributeTableColumns = ['status', 'name', 'value', 'thresh', 'ideal', 'history', 'actions'];
-            attributes = latestSmartResult.attrs;
-        } else {
-            // ATA
-            attributes = latestSmartResult.attrs;
-            // Only show 'worst' column in scrutiny or normalized mode (worst is meaningless for raw values)
-            if (this.displayMode === 'raw') {
-                this.smartAttributeTableColumns = ['status', 'id', 'name', 'value', 'thresh', 'ideal', 'failure', 'history', 'actions'];
-            } else {
-                this.smartAttributeTableColumns = ['status', 'id', 'name', 'value', 'worst', 'thresh', 'ideal', 'failure', 'history', 'actions'];
-            }
-        }
+        const attributes: { [p: string]: SmartAttributeModel } = latestSmartResult.attrs;
+        this._setSmartAttributeTableColumns();
 
         for (const attrId in attributes) {
             const attr = attributes[attrId];
 
             // chart history data
             if (!attr.chartData) {
-                const attrHistory = [];
-                for (const smartResult of smartResults) {
-                    // attrHistory.push(this.getAttributeValue(smart_result.attrs[attrId]))
-
-                    const chartDatapoint = {
-                        x: formatDate(smartResult.date, angularLongDateTime(this.config.time_format), this.locale),
-                        y: this.getAttributeValue(smartResult.attrs[attrId]),
-                    };
-                    const attributeStatusName = this.getAttributeStatusName(smartResult.attrs[attrId].status);
-                    if (attributeStatusName === 'failed') {
-                        chartDatapoint['strokeColor'] = '#F05252';
-                        chartDatapoint['fillColor'] = '#F05252';
-                    } else if (attributeStatusName === 'warn') {
-                        chartDatapoint['strokeColor'] = '#C27803';
-                        chartDatapoint['fillColor'] = '#C27803';
-                    }
-                    attrHistory.push(chartDatapoint);
-                }
-
                 attributes[attrId].chartData = [
                     {
                         name: 'chart-line-sparkline',
                         // attrHistory needs to be reversed, so the newest data is on the right
                         // fixes #339
-                        data: attrHistory.reverse(),
+                        data: this._buildAttributeChartHistory(attrId, smartResults).reverse(),
                     },
                 ];
             }
@@ -618,6 +584,41 @@ export class DetailComponent implements OnInit, AfterViewInit, OnDestroy {
             }
         }
         return smartAttributeDataSource;
+    }
+
+    // Selects which SMART attribute table columns to show based on device protocol and display mode.
+    private _setSmartAttributeTableColumns(): void {
+        if (this.isScsi()) {
+            this.smartAttributeTableColumns = ['status', 'name', 'value', 'thresh', 'history', 'actions'];
+        } else if (this.isNvme()) {
+            this.smartAttributeTableColumns = ['status', 'name', 'value', 'thresh', 'ideal', 'history', 'actions'];
+        } else if (this.displayMode === 'raw') {
+            // ATA: 'worst' column is omitted in raw mode (worst is meaningless for raw values)
+            this.smartAttributeTableColumns = ['status', 'id', 'name', 'value', 'thresh', 'ideal', 'failure', 'history', 'actions'];
+        } else {
+            this.smartAttributeTableColumns = ['status', 'id', 'name', 'value', 'worst', 'thresh', 'ideal', 'failure', 'history', 'actions'];
+        }
+    }
+
+    // Builds the sparkline datapoints (oldest-first) for a single attribute across all results.
+    private _buildAttributeChartHistory(attrId: string, smartResults: SmartModel[]): any[] {
+        const attrHistory = [];
+        for (const smartResult of smartResults) {
+            const chartDatapoint = {
+                x: formatDate(smartResult.date, angularLongDateTime(this.config.time_format), this.locale),
+                y: this.getAttributeValue(smartResult.attrs[attrId]),
+            };
+            const attributeStatusName = this.getAttributeStatusName(smartResult.attrs[attrId].status);
+            if (attributeStatusName === 'failed') {
+                chartDatapoint['strokeColor'] = '#F05252';
+                chartDatapoint['fillColor'] = '#F05252';
+            } else if (attributeStatusName === 'warn') {
+                chartDatapoint['strokeColor'] = '#C27803';
+                chartDatapoint['fillColor'] = '#C27803';
+            }
+            attrHistory.push(chartDatapoint);
+        }
+        return attrHistory;
     }
 
     /**


### PR DESCRIPTION
## Summary

Reduces SonarQube cognitive complexity (typescript:S3776) for all three flagged frontend functions. Each now sits well below the allowed limit of 15.

| Function | File | Before | After |
|----------|------|--------|-------|
| buildAppriseUrl | dashboard-settings.component.ts | 24 | <15 |
| set range | @treo/date-range.component.ts | 22 | <15 |
| _generateSmartAttributeTableDataSource | detail.component.ts | 21 | <15 |

## Changes

Pure extraction of helpers; no behavior change.

- **dashboard-settings** — `buildCustomAppriseUrl`, `buildEmailAppriseUrl` (the email case carried all the nesting)
- **date-range** — `_applyStartDate`, `_applyEndDate`; the three independent `whichDate` `if` blocks become an if/else-if/else, inner clamping logic moved into the helpers
- **detail** — `_setSmartAttributeTableColumns` (protocol/display-mode column selection) and `_buildAttributeChartHistory` (per-attribute sparkline datapoints)

## Verification

- [x] `npx eslint` on the three files — clean
- [x] `npm run build:prod` — compiles
- [x] `npm test -- --watch=false --browsers=ChromeHeadless` — 153/153 pass

## Notes

Continuation of SonarQube Group 5 (cognitive complexity), after #616 (smart.go), #617 (collector commands), #618 (notify), #619 (detect). Remaining clusters need InfluxDB to test locally: repository, DB migrations, and the web middleware/heartbeat functions.