### PR TITLE
refactor(database): reduce cognitive complexity in repository

### DIFF
--- a/webapp/backend/pkg/database/scrutiny_repository.go
+++ b/webapp/backend/pkg/database/scrutiny_repository.go
@@ -423,7 +423,7 @@ func (sr *scrutinyRepository) ensureRetentionBucket(ctx context.Context, org *do
 	if applyRetention {
 		// correctly set the retention period (may not be able to do it during setup/creation)
 		found.RetentionRules = domain.RetentionRules{retentionRule}
-		sr.influxClient.BucketsAPI().UpdateBucket(ctx, found)
+		_, _ = sr.influxClient.BucketsAPI().UpdateBucket(ctx, found)
 	}
 	return nil
 }

--- a/webapp/backend/pkg/database/scrutiny_repository.go
+++ b/webapp/backend/pkg/database/scrutiny_repository.go
@@ -68,12 +68,9 @@ func ResetMigrationGuardForTests() {
 	migrationOnceErr = nil
 }
 
-func newScrutinyRepository(appConfig config.Interface, globalLogger logrus.FieldLogger, runMigrations bool) (DeviceRepo, error) {
-	backgroundContext := context.Background()
-
-	////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-	// Gorm/SQLite setup
-	////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// openGormDatabase opens the SQLite database with the configured journal mode and pragmas,
+// returning a descriptive error for the common read-only/cap_drop Docker failure mode.
+func openGormDatabase(appConfig config.Interface, globalLogger logrus.FieldLogger) (*gorm.DB, error) {
 	globalLogger.Infof("Trying to connect to scrutiny sqlite db: %s\n", appConfig.GetString(cfgDatabaseLocation))
 
 	// When a transaction cannot lock the database, because it is already locked by another one,
@@ -140,11 +137,12 @@ func newScrutinyRepository(appConfig config.Interface, globalLogger logrus.Field
 		return nil, fmt.Errorf("Failed to connect to database! - %v", err)
 	}
 	globalLogger.Infof("Successfully connected to scrutiny sqlite db: %s\n", appConfig.GetString(cfgDatabaseLocation))
+	return database, nil
+}
 
-	////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-	// InfluxDB setup
-	////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
+// setupInfluxClient creates the InfluxDB client and runs first-time setup when the server is
+// un-initialized.
+func setupInfluxClient(ctx context.Context, appConfig config.Interface, globalLogger logrus.FieldLogger) (influxdb2.Client, error) {
 	// Create a new client using an InfluxDB server base URL and an authentication token
 	influxdbUrl := fmt.Sprintf("%s://%s:%s", appConfig.GetString("web.influxdb.scheme"), appConfig.GetString("web.influxdb.host"), appConfig.GetString("web.influxdb.port"))
 	globalLogger.Debugf("InfluxDB url: %s", influxdbUrl)
@@ -160,7 +158,6 @@ func newScrutinyRepository(appConfig config.Interface, globalLogger logrus.Field
 		influxdb2.DefaultOptions().SetTLSConfig(tlsConfig),
 	)
 
-	//if !appConfig.IsSet("web.influxdb.token") {
 	globalLogger.Debugf("Determine Influxdb setup status...")
 	influxSetupComplete, err := InfluxSetupComplete(influxdbUrl, tlsConfig)
 	if err != nil {
@@ -176,7 +173,7 @@ func newScrutinyRepository(appConfig config.Interface, globalLogger logrus.Field
 		// metrics bucket will have a retention period of 8 days (since it will be down-sampled once a week)
 		// in seconds (60seconds * 60minutes * 24hours * 15 days) = 1_296_000 (see EnsureBucket() function)
 		_, err := client.SetupWithToken(
-			backgroundContext,
+			ctx,
 			appConfig.GetString("web.influxdb.init_username"),
 			appConfig.GetString("web.influxdb.init_password"),
 			appConfig.GetString(cfgInfluxDBOrg),
@@ -187,6 +184,21 @@ func newScrutinyRepository(appConfig config.Interface, globalLogger logrus.Field
 		if err != nil {
 			return nil, err
 		}
+	}
+	return client, nil
+}
+
+func newScrutinyRepository(appConfig config.Interface, globalLogger logrus.FieldLogger, runMigrations bool) (DeviceRepo, error) {
+	backgroundContext := context.Background()
+
+	database, err := openGormDatabase(appConfig, globalLogger)
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := setupInfluxClient(backgroundContext, appConfig, globalLogger)
+	if err != nil {
+		return nil, err
 	}
 
 	// Use blocking write client for writes to desired bucket
@@ -366,68 +378,53 @@ func InfluxSetupComplete(influxEndpoint string, tlsConfig *tls.Config) (bool, er
 }
 
 func (sr *scrutinyRepository) EnsureBuckets(ctx context.Context, org *domain.Organization) error {
+	// in tests, we may not want to set a retention policy. If "false", we can set data with old timestamps,
+	// then manually run the down sampling scripts. This should be true for production environments.
+	applyRetention := sr.appConfig.GetBool(cfgInfluxDBRetentionPolicy)
 
-	var mainBucketRetentionRule domain.RetentionRule
-	var weeklyBucketRetentionRule domain.RetentionRule
-	var monthlyBucketRetentionRule domain.RetentionRule
-	if sr.appConfig.GetBool(cfgInfluxDBRetentionPolicy) {
-
-		// in tests, we may not want to set a retention policy. If "false", we can set data with old timestamps,
-		// then manually run the down sampling scripts. This should be true for production environments.
-		mainBucketRetentionRule = domain.RetentionRule{EverySeconds: int64(sr.appConfig.GetInt("web.influxdb.retention.daily"))}
-		weeklyBucketRetentionRule = domain.RetentionRule{EverySeconds: int64(sr.appConfig.GetInt("web.influxdb.retention.weekly"))}
-		monthlyBucketRetentionRule = domain.RetentionRule{EverySeconds: int64(sr.appConfig.GetInt("web.influxdb.retention.monthly"))}
+	var mainRule, weeklyRule, monthlyRule domain.RetentionRule
+	if applyRetention {
+		mainRule = domain.RetentionRule{EverySeconds: int64(sr.appConfig.GetInt("web.influxdb.retention.daily"))}
+		weeklyRule = domain.RetentionRule{EverySeconds: int64(sr.appConfig.GetInt("web.influxdb.retention.weekly"))}
+		monthlyRule = domain.RetentionRule{EverySeconds: int64(sr.appConfig.GetInt("web.influxdb.retention.monthly"))}
 	}
 
-	mainBucket := sr.appConfig.GetString(cfgInfluxDBBucket)
-	if foundMainBucket, foundErr := sr.influxClient.BucketsAPI().FindBucketByName(ctx, mainBucket); foundErr != nil {
-		// metrics bucket will have a retention period of 15 days (since it will be down-sampled once a week)
-		_, err := sr.influxClient.BucketsAPI().CreateBucketWithName(ctx, org, mainBucket, mainBucketRetentionRule)
-		if err != nil {
-			return err
-		}
-	} else if sr.appConfig.GetBool(cfgInfluxDBRetentionPolicy) {
-		//correctly set the retention period for the main bucket (cant do it during setup/creation)
-		foundMainBucket.RetentionRules = domain.RetentionRules{mainBucketRetentionRule}
-		sr.influxClient.BucketsAPI().UpdateBucket(ctx, foundMainBucket)
+	baseBucket := sr.appConfig.GetString(cfgInfluxDBBucket)
+	// main bucket plus the weekly/monthly down-sampling buckets
+	if err := sr.ensureRetentionBucket(ctx, org, baseBucket, mainRule, applyRetention); err != nil {
+		return err
+	}
+	if err := sr.ensureRetentionBucket(ctx, org, baseBucket+"_weekly", weeklyRule, applyRetention); err != nil {
+		return err
+	}
+	if err := sr.ensureRetentionBucket(ctx, org, baseBucket+"_monthly", monthlyRule, applyRetention); err != nil {
+		return err
 	}
 
-	//create buckets (used for downsampling)
-	weeklyBucket := fmt.Sprintf("%s_weekly", sr.appConfig.GetString(cfgInfluxDBBucket))
-	if foundWeeklyBucket, foundErr := sr.influxClient.BucketsAPI().FindBucketByName(ctx, weeklyBucket); foundErr != nil {
-		// metrics_weekly bucket will have a retention period of 8+1 weeks (since it will be down-sampled once a month)
-		_, err := sr.influxClient.BucketsAPI().CreateBucketWithName(ctx, org, weeklyBucket, weeklyBucketRetentionRule)
-		if err != nil {
-			return err
-		}
-	} else if sr.appConfig.GetBool(cfgInfluxDBRetentionPolicy) {
-		//correctly set the retention period for the bucket (may not be able to do it during setup/creation)
-		foundWeeklyBucket.RetentionRules = domain.RetentionRules{weeklyBucketRetentionRule}
-		sr.influxClient.BucketsAPI().UpdateBucket(ctx, foundWeeklyBucket)
-	}
-
-	monthlyBucket := fmt.Sprintf("%s_monthly", sr.appConfig.GetString(cfgInfluxDBBucket))
-	if foundMonthlyBucket, foundErr := sr.influxClient.BucketsAPI().FindBucketByName(ctx, monthlyBucket); foundErr != nil {
-		// metrics_monthly bucket will have a retention period of 24+1 months (since it will be down-sampled once a year)
-		_, err := sr.influxClient.BucketsAPI().CreateBucketWithName(ctx, org, monthlyBucket, monthlyBucketRetentionRule)
-		if err != nil {
-			return err
-		}
-	} else if sr.appConfig.GetBool(cfgInfluxDBRetentionPolicy) {
-		//correctly set the retention period for the bucket (may not be able to do it during setup/creation)
-		foundMonthlyBucket.RetentionRules = domain.RetentionRules{monthlyBucketRetentionRule}
-		sr.influxClient.BucketsAPI().UpdateBucket(ctx, foundMonthlyBucket)
-	}
-
-	yearlyBucket := fmt.Sprintf("%s_yearly", sr.appConfig.GetString(cfgInfluxDBBucket))
+	// metrics_yearly bucket will have an infinite retention period
+	yearlyBucket := baseBucket + "_yearly"
 	if _, foundErr := sr.influxClient.BucketsAPI().FindBucketByName(ctx, yearlyBucket); foundErr != nil {
-		// metrics_yearly bucket will have an infinite retention period
-		_, err := sr.influxClient.BucketsAPI().CreateBucketWithName(ctx, org, yearlyBucket)
-		if err != nil {
+		if _, err := sr.influxClient.BucketsAPI().CreateBucketWithName(ctx, org, yearlyBucket); err != nil {
 			return err
 		}
 	}
 
+	return nil
+}
+
+// ensureRetentionBucket creates bucketName with the given retention rule when it does not exist,
+// or (when applyRetention is set) updates the existing bucket's retention rule.
+func (sr *scrutinyRepository) ensureRetentionBucket(ctx context.Context, org *domain.Organization, bucketName string, retentionRule domain.RetentionRule, applyRetention bool) error {
+	found, foundErr := sr.influxClient.BucketsAPI().FindBucketByName(ctx, bucketName)
+	if foundErr != nil {
+		_, err := sr.influxClient.BucketsAPI().CreateBucketWithName(ctx, org, bucketName, retentionRule)
+		return err
+	}
+	if applyRetention {
+		// correctly set the retention period (may not be able to do it during setup/creation)
+		found.RetentionRules = domain.RetentionRules{retentionRule}
+		sr.influxClient.BucketsAPI().UpdateBucket(ctx, found)
+	}
 	return nil
 }
 
@@ -450,13 +447,28 @@ func (sr *scrutinyRepository) GetSummary(ctx context.Context) (map[string]*model
 		wwnToDeviceID[device.WWN] = device.DeviceID
 	}
 
-	// Get parser flux query result
-	// appConfig.GetString(cfgInfluxDBBucket)
-	// SSD health fields:
-	// - NVMe: attr.percentage_used.value (0-100%, higher = more worn)
-	// - ATA DevStats: attr.devstat_7_8.raw_value (0-100%, higher = more worn)
-	// - ATA Wearout: attr.177.value, attr.233.value, attr.231.value, attr.232.value (0-100%, higher = healthier)
-	queryStr := fmt.Sprintf(`
+	result, err := sr.influxQueryApi.Query(ctx, summaryFluxQuery(sr.appConfig.GetString(cfgInfluxDBBucket)))
+	if err != nil {
+		return nil, err
+	}
+	defer result.Close()
+	// Use Next() to iterate over query result lines
+	for result.Next() {
+		sr.applySummaryRecord(summaries, wwnToDeviceID, result.Record().Values())
+	}
+	if result.Err() != nil {
+		sr.logger.Errorf("Query error: %s", result.Err().Error())
+	}
+
+	sr.attachTemperatureHistory(ctx, summaries)
+
+	return summaries, nil
+}
+
+// summaryFluxQuery builds the flux query that fetches the latest summary metrics (basic metrics +
+// SSD health + risk indicator attributes) per device across the daily/weekly/monthly/yearly buckets.
+func summaryFluxQuery(bucketBaseName string) string {
+	return fmt.Sprintf(`
   	import "influxdata/influxdb/schema"
   	bucketBaseName = "%s"
 
@@ -515,80 +527,78 @@ func (sr *scrutinyRepository) GetSummary(ctx context.Context) (map[string]*model
 	|> tail(n: 1)
 	|> yield(name: "last")
 		`,
-		sr.appConfig.GetString(cfgInfluxDBBucket),
+		bucketBaseName,
 	)
+}
 
-	result, err := sr.influxQueryApi.Query(ctx, queryStr)
-	if err == nil {
-		defer result.Close()
-		// Use Next() to iterate over query result lines
-		for result.Next() {
-			//get summary data from Influxdb.
-			//result.Record().Values()
-			if deviceWWN, ok := result.Record().Values()["device_wwn"]; ok {
-				wwn := deviceWWN.(string)
-				devID, hasDevID := wwnToDeviceID[wwn]
-				if !hasDevID {
-					continue
-				}
-
-				// ensure summaries is initialized for this device_id
-				if _, exists := summaries[devID]; !exists {
-					summaries[devID] = &models.DeviceSummary{}
-				}
-
-				smartSummary := &models.SmartSummary{
-					Temp:          result.Record().Values()["temp"].(int64),
-					PowerOnHours:  result.Record().Values()["power_on_hours"].(int64),
-					CollectorDate: result.Record().Values()["_time"].(time.Time),
-				}
-
-				// Extract SSD health metrics
-				values := result.Record().Values()
-
-				// Check for percentage_used (NVMe) or devstat_7_8 (ATA device statistics)
-				// These represent "percentage used" where higher = more worn
-				if val, ok := values["attr.percentage_used.value"]; ok && val != nil {
-					if intVal, ok := val.(int64); ok {
-						smartSummary.PercentageUsed = &intVal
-					}
-				} else if val, ok := values["attr.devstat_7_8.raw_value"]; ok && val != nil {
-					if intVal, ok := val.(int64); ok {
-						smartSummary.PercentageUsed = &intVal
-					}
-				}
-
-				// Check for ATA wearout attributes (177, 233, 231, 232)
-				// These represent "health remaining" where higher = healthier
-				// Priority order: 177 (Samsung/Crucial), 233 (Intel), 231 (Life Left), 232 (Endurance)
-				var wearoutVal *int64
-				for _, attrId := range []string{"177", "233", "231", "232"} {
-					fieldName := fmt.Sprintf("attr.%s.value", attrId)
-					if val, ok := values[fieldName]; ok && val != nil {
-						if intVal, ok := val.(int64); ok {
-							wearoutVal = &intVal
-							break
-						}
-					}
-				}
-				smartSummary.WearoutValue = wearoutVal
-
-				// Compute simplified replacement risk from the fetched counter attrs.
-				protocol := summaries[devID].Device.DeviceProtocol
-				riskScore, riskCategory := summaryRiskScore(protocol, values)
-				smartSummary.RiskScore = &riskScore
-				smartSummary.RiskCategory = string(riskCategory)
-
-				summaries[devID].SmartResults = smartSummary
-			}
-		}
-		if result.Err() != nil {
-			sr.logger.Errorf("Query error: %s", result.Err().Error())
-		}
-	} else {
-		return nil, err
+// applySummaryRecord parses a single summary query record and populates the matching device summary.
+func (sr *scrutinyRepository) applySummaryRecord(summaries map[string]*models.DeviceSummary, wwnToDeviceID map[string]string, values map[string]interface{}) {
+	deviceWWN, ok := values["device_wwn"]
+	if !ok {
+		return
+	}
+	devID, hasDevID := wwnToDeviceID[deviceWWN.(string)]
+	if !hasDevID {
+		return
 	}
 
+	// ensure summaries is initialized for this device_id
+	if _, exists := summaries[devID]; !exists {
+		summaries[devID] = &models.DeviceSummary{}
+	}
+
+	smartSummary := &models.SmartSummary{
+		Temp:          values["temp"].(int64),
+		PowerOnHours:  values["power_on_hours"].(int64),
+		CollectorDate: values["_time"].(time.Time),
+	}
+	smartSummary.PercentageUsed = extractPercentageUsed(values)
+	smartSummary.WearoutValue = extractWearoutValue(values)
+
+	// Compute simplified replacement risk from the fetched counter attrs.
+	protocol := summaries[devID].Device.DeviceProtocol
+	riskScore, riskCategory := summaryRiskScore(protocol, values)
+	smartSummary.RiskScore = &riskScore
+	smartSummary.RiskCategory = string(riskCategory)
+
+	summaries[devID].SmartResults = smartSummary
+}
+
+// extractPercentageUsed returns the "percentage used" wear metric from NVMe (percentage_used) or
+// ATA device statistics (devstat_7_8), where higher means more worn. Returns nil when absent.
+func extractPercentageUsed(values map[string]interface{}) *int64 {
+	if val, ok := values["attr.percentage_used.value"]; ok && val != nil {
+		return asInt64Ptr(val)
+	}
+	if val, ok := values["attr.devstat_7_8.raw_value"]; ok && val != nil {
+		return asInt64Ptr(val)
+	}
+	return nil
+}
+
+// extractWearoutValue returns the first present ATA wearout "health remaining" attribute, in
+// priority order 177 (Samsung/Crucial), 233 (Intel), 231 (Life Left), 232 (Endurance).
+func extractWearoutValue(values map[string]interface{}) *int64 {
+	for _, attrId := range []string{"177", "233", "231", "232"} {
+		if val, ok := values[fmt.Sprintf("attr.%s.value", attrId)]; ok && val != nil {
+			if intVal, ok := val.(int64); ok {
+				return &intVal
+			}
+		}
+	}
+	return nil
+}
+
+// asInt64Ptr returns a pointer to val when it is an int64, otherwise nil.
+func asInt64Ptr(val interface{}) *int64 {
+	if intVal, ok := val.(int64); ok {
+		return &intVal
+	}
+	return nil
+}
+
+// attachTemperatureHistory loads forever-range temperature history and attaches it to each summary.
+func (sr *scrutinyRepository) attachTemperatureHistory(ctx context.Context, summaries map[string]*models.DeviceSummary) {
 	deviceTempHistory, err := sr.GetSmartTemperatureHistory(ctx, DURATION_KEY_FOREVER)
 	if err != nil {
 		sr.logger.Errorf("Error getting temperature history: %v", err)
@@ -598,8 +608,6 @@ func (sr *scrutinyRepository) GetSummary(ctx context.Context) (map[string]*model
 			summary.TempHistory = tempHistory
 		}
 	}
-
-	return summaries, nil
 }
 
 // GetDevicesLastSeenTimes returns a map of device WWN to the timestamp of their last SMART submission.
@@ -616,12 +624,29 @@ func (sr *scrutinyRepository) GetDevicesLastSeenTimes(ctx context.Context) (map[
 		wwnToDeviceID[devices[i].WWN] = devices[i].DeviceID
 	}
 
-	lastSeenTimes := map[string]time.Time{}
+	result, err := sr.influxQueryApi.Query(ctx, lastSeenFluxQuery(sr.appConfig.GetString(cfgInfluxDBBucket)))
+	if err != nil {
+		return nil, fmt.Errorf("failed to query last seen times: %w", err)
+	}
+	defer result.Close()
 
-	// Query to get the last submission time for each device from all buckets
-	// Note: We use "temp" field since it's always present in SMART data.
-	// The "date" field doesn't exist - Date is stored as the point timestamp (_time).
-	queryStr := fmt.Sprintf(`
+	lastSeenTimes := map[string]time.Time{}
+	for result.Next() {
+		applyLastSeenRecord(lastSeenTimes, wwnToDeviceID, result.Record().Values())
+	}
+
+	if result.Err() != nil {
+		return nil, fmt.Errorf("query result error: %w", result.Err())
+	}
+
+	return lastSeenTimes, nil
+}
+
+// lastSeenFluxQuery builds the flux query that returns the most recent SMART submission time per
+// device across all buckets. The "temp" field is used because it is always present in SMART data
+// (Date is stored as the point timestamp _time, not a field).
+func lastSeenFluxQuery(bucketBaseName string) string {
+	return fmt.Sprintf(`
 import "influxdata/influxdb/schema"
 bucketBaseName = "%s"
 
@@ -658,36 +683,31 @@ union(tables: [dailyData, weeklyData, monthlyData, yearlyData])
 |> sort(columns: ["_time"], desc: false)
 |> last()
 |> yield(name: "last_seen")
-	`, sr.appConfig.GetString(cfgInfluxDBBucket))
+	`, bucketBaseName)
+}
 
-	result, err := sr.influxQueryApi.Query(ctx, queryStr)
-	if err != nil {
-		return nil, fmt.Errorf("failed to query last seen times: %w", err)
+// applyLastSeenRecord re-keys a last-seen query record from WWN to DeviceID and keeps the most
+// recent timestamp seen for that device.
+func applyLastSeenRecord(lastSeenTimes map[string]time.Time, wwnToDeviceID map[string]string, values map[string]interface{}) {
+	deviceWWN, ok := values["device_wwn"].(string)
+	if !ok {
+		return
 	}
-	defer result.Close()
-
-	for result.Next() {
-		values := result.Record().Values()
-		if deviceWWN, ok := values["device_wwn"].(string); ok {
-			if lastTime, ok := values["_time"].(time.Time); ok {
-				// Re-key from WWN to DeviceID
-				key := deviceWWN
-				if devID, hasDevID := wwnToDeviceID[deviceWWN]; hasDevID {
-					key = devID
-				}
-				// Keep the most recent time if we've seen this device before
-				if existing, exists := lastSeenTimes[key]; !exists || lastTime.After(existing) {
-					lastSeenTimes[key] = lastTime
-				}
-			}
-		}
+	lastTime, ok := values["_time"].(time.Time)
+	if !ok {
+		return
 	}
 
-	if result.Err() != nil {
-		return nil, fmt.Errorf("query result error: %w", result.Err())
+	// Re-key from WWN to DeviceID
+	key := deviceWWN
+	if devID, hasDevID := wwnToDeviceID[deviceWWN]; hasDevID {
+		key = devID
 	}
 
-	return lastSeenTimes, nil
+	// Keep the most recent time if we've seen this device before
+	if existing, exists := lastSeenTimes[key]; !exists || lastTime.After(existing) {
+		lastSeenTimes[key] = lastTime
+	}
 }
 
 // GetAvailableInfluxDBBuckets returns a list of bucket names available in InfluxDB.

--- a/webapp/backend/pkg/database/scrutiny_repository_device.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_device.go
@@ -79,25 +79,35 @@ func (sr *scrutinyRepository) reconcileLegacyDeviceIdentity(tx *gorm.DB, incomin
 		return nil
 	}
 
-	var canonical *models.Device
-	legacyCandidates := make([]models.Device, 0, len(sameWWN))
-	for i := range sameWWN {
-		existing := sameWWN[i]
-		if existing.DeviceID == incoming.DeviceID {
-			canonical = &sameWWN[i]
-			continue
-		}
-		if isLegacyIdentityCandidate(&sameWWN[i], incoming) {
-			legacyCandidates = append(legacyCandidates, existing)
-		}
-	}
-
+	canonical, legacyCandidates := matchLegacyDeviceCandidates(sameWWN, incoming)
 	if len(legacyCandidates) != 1 {
 		return nil
 	}
 
-	legacy := legacyCandidates[0]
+	return sr.mergeLegacyDevice(tx, canonical, &legacyCandidates[0], incoming)
+}
 
+// matchLegacyDeviceCandidates partitions devices sharing the incoming WWN into the canonical row
+// (same DeviceID) and the legacy-identity candidates eligible for reconciliation.
+func matchLegacyDeviceCandidates(sameWWN []models.Device, incoming *models.Device) (*models.Device, []models.Device) {
+	var canonical *models.Device
+	legacyCandidates := make([]models.Device, 0, len(sameWWN))
+	for i := range sameWWN {
+		if sameWWN[i].DeviceID == incoming.DeviceID {
+			canonical = &sameWWN[i]
+			continue
+		}
+		if isLegacyIdentityCandidate(&sameWWN[i], incoming) {
+			legacyCandidates = append(legacyCandidates, sameWWN[i])
+		}
+	}
+	return canonical, legacyCandidates
+}
+
+// mergeLegacyDevice reconciles a single legacy device row against the incoming identity: when a
+// canonical row exists the legacy row is deleted (preserving the earlier created_at), otherwise the
+// legacy row is re-keyed to the incoming DeviceID.
+func (sr *scrutinyRepository) mergeLegacyDevice(tx *gorm.DB, canonical, legacy, incoming *models.Device) error {
 	if canonical != nil {
 		if legacy.CreatedAt.Before(canonical.CreatedAt) {
 			if err := tx.Model(&models.Device{}).

--- a/webapp/backend/pkg/database/scrutiny_repository_tasks.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_tasks.go
@@ -11,21 +11,21 @@ import (
 // //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 func (sr *scrutinyRepository) EnsureTasks(ctx context.Context, orgID string) error {
 	weeklyTaskName := "tsk-weekly-aggr"
-	//weekly on Sunday at 1:00am
+	// weekly on Sunday at 1:00am
 	weeklyTaskScript := sr.DownsampleScript("weekly", weeklyTaskName, "0 1 * * 0")
 	if err := sr.ensureDownsampleTask(ctx, orgID, weeklyTaskName, weeklyTaskScript, "weekly"); err != nil {
 		return err
 	}
 
 	monthlyTaskName := "tsk-monthly-aggr"
-	//monthly on first day of the month at 1:30am
+	// monthly on first day of the month at 1:30am
 	monthlyTaskScript := sr.DownsampleScript("monthly", monthlyTaskName, "30 1 1 * *")
 	if err := sr.ensureDownsampleTask(ctx, orgID, monthlyTaskName, monthlyTaskScript, "monthly"); err != nil {
 		return err
 	}
 
 	yearlyTaskName := "tsk-yearly-aggr"
-	//yearly on the first day of the year at 2:00am
+	// yearly on the first day of the year at 2:00am
 	yearlyTaskScript := sr.DownsampleScript("yearly", yearlyTaskName, "0 2 1 1 *")
 	if err := sr.ensureDownsampleTask(ctx, orgID, yearlyTaskName, yearlyTaskScript, "yearly"); err != nil {
 		return err

--- a/webapp/backend/pkg/database/scrutiny_repository_tasks.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_tasks.go
@@ -6,70 +6,48 @@ import (
 	"github.com/influxdata/influxdb-client-go/v2/api"
 )
 
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Tasks
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 func (sr *scrutinyRepository) EnsureTasks(ctx context.Context, orgID string) error {
 	weeklyTaskName := "tsk-weekly-aggr"
+	//weekly on Sunday at 1:00am
 	weeklyTaskScript := sr.DownsampleScript("weekly", weeklyTaskName, "0 1 * * 0")
-	if found, findErr := sr.influxTaskApi.FindTasks(ctx, &api.TaskFilter{Name: weeklyTaskName}); findErr == nil && len(found) == 0 {
-		//weekly on Sunday at 1:00am
-		_, err := sr.influxTaskApi.CreateTaskByFlux(ctx, weeklyTaskScript, orgID)
-		if err != nil {
-			return err
-		}
-	} else if len(found) == 1 {
-		//check if we should update
-		task := &found[0]
-		if weeklyTaskScript != task.Flux {
-			sr.logger.Infoln("updating weekly task script")
-			task.Flux = weeklyTaskScript
-			_, err := sr.influxTaskApi.UpdateTask(ctx, task)
-			if err != nil {
-				return err
-			}
-		}
+	if err := sr.ensureDownsampleTask(ctx, orgID, weeklyTaskName, weeklyTaskScript, "weekly"); err != nil {
+		return err
 	}
 
 	monthlyTaskName := "tsk-monthly-aggr"
+	//monthly on first day of the month at 1:30am
 	monthlyTaskScript := sr.DownsampleScript("monthly", monthlyTaskName, "30 1 1 * *")
-	if found, findErr := sr.influxTaskApi.FindTasks(ctx, &api.TaskFilter{Name: monthlyTaskName}); findErr == nil && len(found) == 0 {
-		//monthly on first day of the month at 1:30am
-		_, err := sr.influxTaskApi.CreateTaskByFlux(ctx, monthlyTaskScript, orgID)
-		if err != nil {
-			return err
-		}
-	} else if len(found) == 1 {
-		//check if we should update
-		task := &found[0]
-		if monthlyTaskScript != task.Flux {
-			sr.logger.Infoln("updating monthly task script")
-			task.Flux = monthlyTaskScript
-			_, err := sr.influxTaskApi.UpdateTask(ctx, task)
-			if err != nil {
-				return err
-			}
-		}
+	if err := sr.ensureDownsampleTask(ctx, orgID, monthlyTaskName, monthlyTaskScript, "monthly"); err != nil {
+		return err
 	}
 
 	yearlyTaskName := "tsk-yearly-aggr"
+	//yearly on the first day of the year at 2:00am
 	yearlyTaskScript := sr.DownsampleScript("yearly", yearlyTaskName, "0 2 1 1 *")
-	if found, findErr := sr.influxTaskApi.FindTasks(ctx, &api.TaskFilter{Name: yearlyTaskName}); findErr == nil && len(found) == 0 {
-		//yearly on the first day of the year at 2:00am
-		_, err := sr.influxTaskApi.CreateTaskByFlux(ctx, yearlyTaskScript, orgID)
-		if err != nil {
-			return err
-		}
+	if err := sr.ensureDownsampleTask(ctx, orgID, yearlyTaskName, yearlyTaskScript, "yearly"); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ensureDownsampleTask creates the named downsample task when it does not exist,
+// or updates its flux script when the single existing task differs.
+func (sr *scrutinyRepository) ensureDownsampleTask(ctx context.Context, orgID, taskName, taskScript, label string) error {
+	found, findErr := sr.influxTaskApi.FindTasks(ctx, &api.TaskFilter{Name: taskName})
+	if findErr == nil && len(found) == 0 {
+		_, err := sr.influxTaskApi.CreateTaskByFlux(ctx, taskScript, orgID)
+		return err
 	} else if len(found) == 1 {
 		//check if we should update
 		task := &found[0]
-		if yearlyTaskScript != task.Flux {
-			sr.logger.Infoln("updating yearly task script")
-			task.Flux = yearlyTaskScript
+		if taskScript != task.Flux {
+			sr.logger.Infoln("updating " + label + " task script")
+			task.Flux = taskScript
 			_, err := sr.influxTaskApi.UpdateTask(ctx, task)
-			if err != nil {
-				return err
-			}
+			return err
 		}
 	}
 	return nil

--- a/webapp/backend/pkg/database/scrutiny_repository_temperature.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_temperature.go
@@ -24,8 +24,8 @@ func (sr *scrutinyRepository) SaveSmartTemperature(ctx context.Context, wwn stri
 			}
 
 			intervalSec := collectorSmartData.AtaSctTemperatureHistory.LoggingIntervalMinutes * 60
-			datapointTime := collectorSmartData.LocalTime.TimeT - int64(ndx) * intervalSec
-			alignedDatapointTime := datapointTime - datapointTime % intervalSec
+			datapointTime := collectorSmartData.LocalTime.TimeT - int64(ndx)*intervalSec
+			alignedDatapointTime := datapointTime - datapointTime%intervalSec
 			smartTemp := measurements.SmartTemperature{
 				Date: time.Unix(alignedDatapointTime, 0),
 				Temp: temp,
@@ -45,8 +45,7 @@ func (sr *scrutinyRepository) SaveSmartTemperature(ctx context.Context, wwn stri
 		}
 	}
 
-
-        // Even if ata_sct_temperature_history is present, also add current temperature. See #824
+	// Even if ata_sct_temperature_history is present, also add current temperature. See #824
 	smartTemp := measurements.SmartTemperature{
 		Date: time.Unix(collectorSmartData.LocalTime.TimeT, 0),
 		Temp: measurements.CorrectedTemperature(collectorSmartData),
@@ -79,43 +78,46 @@ func (sr *scrutinyRepository) GetSmartTemperatureHistory(ctx context.Context, du
 	queryStr := sr.aggregateTempQuery(durationKey)
 
 	result, err := sr.influxQueryApi.Query(ctx, queryStr)
-	if err == nil {
-		defer result.Close()
-		// Use Next() to iterate over query result lines
-		for result.Next() {
-
-			if deviceWWN, ok := result.Record().Values()["device_wwn"]; ok {
-				wwn := deviceWWN.(string)
-				// Re-key from WWN to DeviceID
-				key := wwn
-				if devID, hasDevID := wwnToDeviceID[wwn]; hasDevID {
-					key = devID
-				}
-
-				// check if key has been seen and initialized already
-				if _, ok := deviceTempHistory[key]; !ok {
-					deviceTempHistory[key] = []measurements.SmartTemperature{}
-				}
-
-				currentTempHistory := deviceTempHistory[key]
-				smartTemp := measurements.SmartTemperature{}
-
-				for k, val := range result.Record().Values() {
-					smartTemp.Inflate(k, val)
-				}
-				smartTemp.Date = result.Record().Values()["_time"].(time.Time)
-				currentTempHistory = append(currentTempHistory, smartTemp)
-				deviceTempHistory[key] = currentTempHistory
-			}
-		}
-		if result.Err() != nil {
-			sr.logger.Errorf("Query error: %s", result.Err().Error())
-		}
-	} else {
+	if err != nil {
 		return nil, err
 	}
-	return deviceTempHistory, nil
+	defer result.Close()
 
+	// Use Next() to iterate over query result lines
+	for result.Next() {
+		appendTempRecord(deviceTempHistory, result.Record().Values(), wwnToDeviceID)
+	}
+	if result.Err() != nil {
+		sr.logger.Errorf("Query error: %s", result.Err().Error())
+	}
+	return deviceTempHistory, nil
+}
+
+// appendTempRecord re-keys a single InfluxDB temperature record from WWN to
+// DeviceID and appends the inflated SmartTemperature to the history map.
+func appendTempRecord(deviceTempHistory map[string][]measurements.SmartTemperature, values map[string]interface{}, wwnToDeviceID map[string]string) {
+	deviceWWN, ok := values["device_wwn"]
+	if !ok {
+		return
+	}
+	wwn := deviceWWN.(string)
+	// Re-key from WWN to DeviceID
+	key := wwn
+	if devID, hasDevID := wwnToDeviceID[wwn]; hasDevID {
+		key = devID
+	}
+
+	// check if key has been seen and initialized already
+	if _, ok := deviceTempHistory[key]; !ok {
+		deviceTempHistory[key] = []measurements.SmartTemperature{}
+	}
+
+	smartTemp := measurements.SmartTemperature{}
+	for k, val := range values {
+		smartTemp.Inflate(k, val)
+	}
+	smartTemp.Date = values["_time"].(time.Time)
+	deviceTempHistory[key] = append(deviceTempHistory[key], smartTemp)
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -188,7 +190,6 @@ func (sr *scrutinyRepository) aggregateTempQuery(durationKey string) string {
 			"|> schema.fieldsAsCols()",
 		}...)
 	}
-
 
 	return strings.Join(partialQueryStr, "\n")
 }

--- a/webapp/backend/pkg/database/scrutiny_repository_workload.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_workload.go
@@ -23,7 +23,6 @@ func (sr *scrutinyRepository) GetWorkloadInsights(ctx context.Context, durationK
 
 	insights := map[string]*models.WorkloadInsight{}
 	deviceProtocols := map[string]string{}
-	wwnToDeviceID := map[string]string{}
 	for i := range devices {
 		if devices[i].Archived {
 			continue
@@ -43,7 +42,6 @@ func (sr *scrutinyRepository) GetWorkloadInsights(ctx context.Context, durationK
 			Intensity:      "unknown",
 		}
 		deviceProtocols[devices[i].WWN] = devices[i].DeviceProtocol
-		wwnToDeviceID[devices[i].WWN] = devices[i].DeviceID
 	}
 
 	if len(insights) == 0 {
@@ -64,32 +62,41 @@ func (sr *scrutinyRepository) GetWorkloadInsights(ctx context.Context, durationK
 		// Non-fatal: continue without spike detection
 	}
 
-	// Compute insights per device
-	// InfluxDB results are keyed by WWN, so we look up by WWN using the reverse map
-	for devID, insight := range insights {
-		// Find WWN for this DeviceID to look up InfluxDB results
-		wwn := insight.DeviceWWN
-		_ = devID
-
-		first, hasFirst := firstPoints[wwn]
-		last, hasLast := lastPoints[wwn]
-
-		if !hasFirst || !hasLast {
-			continue
-		}
-
-		sr.computeWorkloadInsight(insight, first, last, deviceProtocols[wwn], maxTBWForDevice(devices, insight.DeviceID))
-
-		// Spike detection
-		if recent, ok := recentPoints[wwn]; ok && len(recent) >= 2 {
-			spike := sr.detectSpike(recent, insight.DailyWriteBytes, deviceProtocols[wwn])
-			if spike != nil {
-				insight.Spike = spike
-			}
-		}
+	// Compute insights per device.
+	// InfluxDB results are keyed by WWN, so we look up by WWN.
+	for _, insight := range insights {
+		sr.populateWorkloadInsight(insight, devices, deviceProtocols, firstPoints, lastPoints, recentPoints)
 	}
 
 	return insights, nil
+}
+
+// populateWorkloadInsight computes the rate/endurance/spike fields for a single
+// device's insight using the queried first/last/recent InfluxDB snapshots.
+func (sr *scrutinyRepository) populateWorkloadInsight(
+	insight *models.WorkloadInsight,
+	devices []models.Device,
+	deviceProtocols map[string]string,
+	firstPoints, lastPoints map[string]*workloadSnapshot,
+	recentPoints map[string][]*workloadSnapshot,
+) {
+	wwn := insight.DeviceWWN
+
+	first, hasFirst := firstPoints[wwn]
+	last, hasLast := lastPoints[wwn]
+	if !hasFirst || !hasLast {
+		return
+	}
+
+	sr.computeWorkloadInsight(insight, first, last, deviceProtocols[wwn], maxTBWForDevice(devices, insight.DeviceID))
+
+	// Spike detection
+	if recent, ok := recentPoints[wwn]; ok && len(recent) >= 2 {
+		spike := sr.detectSpike(recent, insight.DailyWriteBytes, deviceProtocols[wwn])
+		if spike != nil {
+			insight.Spike = spike
+		}
+	}
 }
 
 // workloadSnapshot holds extracted field values from a single InfluxDB data point
@@ -99,34 +106,34 @@ type workloadSnapshot struct {
 	LogicalBlockSize int64
 
 	// ATA
-	Attr241RawValue    int64 // Total LBAs Written
-	Attr242RawValue    int64 // Total LBAs Read
-	Devstat124Value    int64 // Logical Sectors Written
-	Devstat140Value    int64 // Logical Sectors Read
-	Devstat78Value     int64 // Percentage Used Endurance
-	Attr177Value       int64 // Wearout (Samsung/Crucial)
-	Attr231Value       int64 // Life Left
-	Attr232Value       int64 // Endurance Remaining
-	Attr233Value       int64 // Wearout (Intel)
+	Attr241RawValue int64 // Total LBAs Written
+	Attr242RawValue int64 // Total LBAs Read
+	Devstat124Value int64 // Logical Sectors Written
+	Devstat140Value int64 // Logical Sectors Read
+	Devstat78Value  int64 // Percentage Used Endurance
+	Attr177Value    int64 // Wearout (Samsung/Crucial)
+	Attr231Value    int64 // Life Left
+	Attr232Value    int64 // Endurance Remaining
+	Attr233Value    int64 // Wearout (Intel)
 
 	// NVMe
-	DataUnitsWritten   int64
-	DataUnitsRead      int64
-	PercentageUsed     int64
+	DataUnitsWritten int64
+	DataUnitsRead    int64
+	PercentageUsed   int64
 
 	// Track which fields were present
-	hasAttr241         bool
-	hasAttr242         bool
-	hasDevstat124      bool
-	hasDevstat140      bool
-	hasDevstat78       bool
-	hasAttr177         bool
-	hasAttr231         bool
-	hasAttr232         bool
-	hasAttr233         bool
-	hasDataUnitsW      bool
-	hasDataUnitsR      bool
-	hasPercentageUsed  bool
+	hasAttr241        bool
+	hasAttr242        bool
+	hasDevstat124     bool
+	hasDevstat140     bool
+	hasDevstat78      bool
+	hasAttr177        bool
+	hasAttr231        bool
+	hasAttr232        bool
+	hasAttr233        bool
+	hasDataUnitsW     bool
+	hasDataUnitsR     bool
+	hasPercentageUsed bool
 }
 
 // extractInt64 extracts an int64 value from InfluxDB result map.
@@ -489,42 +496,7 @@ func classifyIntensity(dailyTotalBytes int64) string {
 }
 
 func (sr *scrutinyRepository) computeEndurance(insight *models.WorkloadInsight, snap *workloadSnapshot, protocol string, cumulativeWriteBytes int64, maxTBW *float64) {
-	var percentageUsed int64
-	var hasPercentage bool
-
-	switch protocol {
-	case pkg.DeviceProtocolNvme:
-		if snap.hasPercentageUsed {
-			percentageUsed = snap.PercentageUsed
-			hasPercentage = true
-		}
-	case pkg.DeviceProtocolAta:
-		if snap.hasDevstat78 {
-			percentageUsed = snap.Devstat78Value
-			hasPercentage = true
-		} else {
-			// Check wearout attributes (higher = healthier, invert to get percentage used)
-			for _, info := range []struct {
-				has   bool
-				value int64
-			}{
-				{snap.hasAttr177, snap.Attr177Value},
-				{snap.hasAttr233, snap.Attr233Value},
-				{snap.hasAttr231, snap.Attr231Value},
-				{snap.hasAttr232, snap.Attr232Value},
-			} {
-				if info.has && info.value > 0 {
-					percentageUsed = 100 - info.value
-					if percentageUsed < 0 {
-						percentageUsed = 0
-					}
-					hasPercentage = true
-					break
-				}
-			}
-		}
-	}
-
+	percentageUsed, hasPercentage := endurancePercentageUsed(snap, protocol)
 	if !hasPercentage {
 		return
 	}
@@ -534,16 +506,7 @@ func (sr *scrutinyRepository) computeEndurance(insight *models.WorkloadInsight, 
 		PercentageUsed: percentageUsed,
 	}
 
-	if cumulativeWriteBytes > 0 {
-		estimate.TBWrittenSoFar = float64(cumulativeWriteBytes) / (1024 * 1024 * 1024 * 1024)
-		estimate.TBWrittenSoFar = math.Round(estimate.TBWrittenSoFar*100) / 100
-	}
-	if maxTBW != nil && *maxTBW > 0 {
-		estimate.TBWRated = math.Round(*maxTBW*100) / 100
-		if estimate.TBWrittenSoFar > 0 {
-			estimate.TBWUsedPercent = math.Round((estimate.TBWrittenSoFar/estimate.TBWRated)*10000) / 100
-		}
-	}
+	applyTBWEstimate(estimate, cumulativeWriteBytes, maxTBW)
 
 	if percentageUsed > 0 && snap.PowerOnHours > 0 {
 		totalLifespanHours := float64(snap.PowerOnHours) / (float64(percentageUsed) / 100.0)
@@ -554,6 +517,60 @@ func (sr *scrutinyRepository) computeEndurance(insight *models.WorkloadInsight, 
 	}
 
 	insight.Endurance = estimate
+}
+
+// endurancePercentageUsed derives the endurance "percentage used" value for the
+// given protocol from a snapshot, returning the value and whether one was found.
+func endurancePercentageUsed(snap *workloadSnapshot, protocol string) (percentageUsed int64, hasPercentage bool) {
+	switch protocol {
+	case pkg.DeviceProtocolNvme:
+		if snap.hasPercentageUsed {
+			return snap.PercentageUsed, true
+		}
+	case pkg.DeviceProtocolAta:
+		if snap.hasDevstat78 {
+			return snap.Devstat78Value, true
+		}
+		return ataWearoutPercentageUsed(snap)
+	}
+	return 0, false
+}
+
+// ataWearoutPercentageUsed inspects ATA wearout attributes (higher = healthier)
+// and inverts the first present value into a percentage used.
+func ataWearoutPercentageUsed(snap *workloadSnapshot) (percentageUsed int64, hasPercentage bool) {
+	for _, info := range []struct {
+		has   bool
+		value int64
+	}{
+		{snap.hasAttr177, snap.Attr177Value},
+		{snap.hasAttr233, snap.Attr233Value},
+		{snap.hasAttr231, snap.Attr231Value},
+		{snap.hasAttr232, snap.Attr232Value},
+	} {
+		if info.has && info.value > 0 {
+			percentageUsed = 100 - info.value
+			if percentageUsed < 0 {
+				percentageUsed = 0
+			}
+			return percentageUsed, true
+		}
+	}
+	return 0, false
+}
+
+// applyTBWEstimate fills in the terabytes-written and rated-TBW fields on the estimate.
+func applyTBWEstimate(estimate *models.EnduranceEstimate, cumulativeWriteBytes int64, maxTBW *float64) {
+	if cumulativeWriteBytes > 0 {
+		estimate.TBWrittenSoFar = float64(cumulativeWriteBytes) / (1024 * 1024 * 1024 * 1024)
+		estimate.TBWrittenSoFar = math.Round(estimate.TBWrittenSoFar*100) / 100
+	}
+	if maxTBW != nil && *maxTBW > 0 {
+		estimate.TBWRated = math.Round(*maxTBW*100) / 100
+		if estimate.TBWrittenSoFar > 0 {
+			estimate.TBWUsedPercent = math.Round((estimate.TBWrittenSoFar/estimate.TBWRated)*10000) / 100
+		}
+	}
 }
 
 func maxTBWForDevice(devices []models.Device, deviceID string) *float64 {

--- a/webapp/backend/pkg/database/summary_risk.go
+++ b/webapp/backend/pkg/database/summary_risk.go
@@ -22,29 +22,11 @@ func summaryRiskScore(protocol string, values map[string]interface{}) (int, mode
 
 	switch {
 	case strings.EqualFold(protocol, "NVMe"):
-		maxRaw = 60.0
-		if val := summaryInt64(values, "attr.percentage_used.value"); val > 0 {
-			raw += math.Min(float64(val)/100.0, 1.0) * 40.0
-		}
-		if val := summaryInt64(values, "attr.media_errors.value"); val > 0 {
-			raw += summaryCounterSeverity(val) * 20.0
-		}
+		maxRaw, raw = 60.0, nvmeRiskRaw(values)
 	case strings.EqualFold(protocol, "SCSI"):
-		maxRaw = 40.0
-		if val := summaryInt64(values, "attr.scsi_grown_defect_list.value"); val > 0 {
-			raw += summaryCounterSeverity(val) * 40.0
-		}
+		maxRaw, raw = 40.0, scsiRiskRaw(values)
 	default: // ATA
-		maxRaw = 65.0
-		if val := summaryInt64(values, "attr.5.raw_value"); val > 0 {
-			raw += summaryCounterSeverity(val) * 25.0
-		}
-		if val := summaryInt64(values, "attr.197.raw_value"); val > 0 {
-			raw += summaryCounterSeverity(val) * 20.0
-		}
-		if val := summaryInt64(values, "attr.198.raw_value"); val > 0 {
-			raw += summaryCounterSeverity(val) * 20.0
-		}
+		maxRaw, raw = 65.0, ataRiskRaw(values)
 	}
 
 	if maxRaw == 0 || raw == 0 {
@@ -56,6 +38,41 @@ func summaryRiskScore(protocol string, values map[string]interface{}) (int, mode
 		scaled = 100
 	}
 	return scaled, models.ScoreToRiskCategory(scaled)
+}
+
+// nvmeRiskRaw sums the NVMe partial risk weights (percentage_used 40pt, media_errors 20pt).
+func nvmeRiskRaw(values map[string]interface{}) float64 {
+	var raw float64
+	if val := summaryInt64(values, "attr.percentage_used.value"); val > 0 {
+		raw += math.Min(float64(val)/100.0, 1.0) * 40.0
+	}
+	if val := summaryInt64(values, "attr.media_errors.value"); val > 0 {
+		raw += summaryCounterSeverity(val) * 20.0
+	}
+	return raw
+}
+
+// scsiRiskRaw returns the SCSI partial risk weight (scsi_grown_defect_list 40pt).
+func scsiRiskRaw(values map[string]interface{}) float64 {
+	if val := summaryInt64(values, "attr.scsi_grown_defect_list.value"); val > 0 {
+		return summaryCounterSeverity(val) * 40.0
+	}
+	return 0
+}
+
+// ataRiskRaw sums the ATA partial risk weights (attr 5 25pt, attr 197 20pt, attr 198 20pt).
+func ataRiskRaw(values map[string]interface{}) float64 {
+	var raw float64
+	if val := summaryInt64(values, "attr.5.raw_value"); val > 0 {
+		raw += summaryCounterSeverity(val) * 25.0
+	}
+	if val := summaryInt64(values, "attr.197.raw_value"); val > 0 {
+		raw += summaryCounterSeverity(val) * 20.0
+	}
+	if val := summaryInt64(values, "attr.198.raw_value"); val > 0 {
+		raw += summaryCounterSeverity(val) * 20.0
+	}
+	return raw
 }
 
 // summaryInt64 extracts an int64 from the InfluxDB result values map.


### PR DESCRIPTION
## Summary

Reduces SonarQube cognitive complexity (go:S3776) across the database repository. Every flagged function (except the migration runner) now sits at or below the allowed limit of 15.

| Function | File | Before |
|----------|------|--------|
| GetSummary | scrutiny_repository.go | 56 |
| EnsureTasks | scrutiny_repository_tasks.go | 30 |
| computeEndurance | scrutiny_repository_workload.go | 26 |
| GetSmartTemperatureHistory | scrutiny_repository_temperature.go | 24 |
| newScrutinyRepository | scrutiny_repository.go | 19 |
| GetDevicesLastSeenTimes | scrutiny_repository.go | 19 |
| reconcileLegacyDeviceIdentity | scrutiny_repository_device.go | 17 |
| GetWorkloadInsights | scrutiny_repository_workload.go | 17 |
| summaryRiskScore | summary_risk.go | 16 |
| EnsureBuckets | scrutiny_repository.go | 16 |

All now ≤15.

## Changes

Pure extraction of helpers; no behavior change. Highlights:
- **GetSummary** — hoisted the flux query, extracted per-record handling and the SSD-wear/wearout value extractors
- **newScrutinyRepository** — split SQLite (`openGormDatabase`) and InfluxDB (`setupInfluxClient`) setup
- **EnsureTasks / EnsureBuckets** — collapsed the repeated find-or-create-or-update task/bucket blocks into one helper each
- **computeEndurance** — extracted protocol-specific "percentage used" derivation and the TBW estimate
- **reconcileLegacyDeviceIdentity** — split candidate matching from the merge step

The migration runner `Migrate` (complexity 166) is intentionally left for a dedicated, more careful change.

## Verification

Backend tests require InfluxDB; verified against a throwaway InfluxDB 2.2 instance:
- [x] `go build ./webapp/backend/...`
- [x] `go vet ./webapp/backend/pkg/database/`
- [x] `go test -count=1 ./webapp/backend/pkg/database/` — pass
- [x] `gocognit -over 15` reports zero non-migration functions over the limit
- [x] `gofmt` clean

## Notes

Continuation of SonarQube Group 5, after #616 (smart.go), #617 (collector cmds), #618 (notify), #619 (detect), #620 (frontend). Remaining: DB migrations (Migrate, 166) and web middleware/heartbeat functions.