### PR TITLE
refactor(models): reduce cognitive complexity in measurement models

### DIFF
--- a/webapp/backend/pkg/models/measurements/btrfs_metrics.go
+++ b/webapp/backend/pkg/models/measurements/btrfs_metrics.go
@@ -50,60 +50,25 @@ func (m *BtrfsMetrics) Flatten() (map[string]string, map[string]interface{}) {
 }
 
 func NewBtrfsMetricsFromInfluxDB(attrs map[string]interface{}) (*BtrfsMetrics, error) {
-	m := BtrfsMetrics{
-		Date:           attrs["_time"].(time.Time),
-		FilesystemUUID: attrs["filesystem_uuid"].(string),
-	}
-	if val, ok := attrs["host_id"]; ok && val != nil {
-		m.HostID = val.(string)
-	}
-	if val, ok := attrs["label"]; ok && val != nil {
-		m.Label = val.(string)
-	}
-	if val, ok := attrs["device_size"]; ok && val != nil {
-		m.DeviceSize = val.(int64)
-	}
-	if val, ok := attrs["device_allocated"]; ok && val != nil {
-		m.DeviceAllocated = val.(int64)
-	}
-	if val, ok := attrs["device_unallocated"]; ok && val != nil {
-		m.DeviceUnallocated = val.(int64)
-	}
-	if val, ok := attrs["device_missing"]; ok && val != nil {
-		m.DeviceMissing = val.(int64)
-	}
-	if val, ok := attrs["used"]; ok && val != nil {
-		m.Used = val.(int64)
-	}
-	if val, ok := attrs["free_estimated"]; ok && val != nil {
-		m.FreeEstimated = val.(int64)
-	}
-	if val, ok := attrs["free_statfs"]; ok && val != nil {
-		m.FreeStatfs = val.(int64)
-	}
-	if val, ok := attrs["data_ratio"]; ok && val != nil {
-		m.DataRatio = val.(float64)
-	}
-	if val, ok := attrs["metadata_ratio"]; ok && val != nil {
-		m.MetadataRatio = val.(float64)
-	}
-	if val, ok := attrs["status"]; ok && val != nil {
-		m.Status = val.(string)
-	}
-	if val, ok := attrs["scrub_state"]; ok && val != nil {
-		m.ScrubState = val.(string)
-	}
-	if val, ok := attrs["scrub_read_errors"]; ok && val != nil {
-		m.ScrubReadErrors = val.(int64)
-	}
-	if val, ok := attrs["scrub_csum_errors"]; ok && val != nil {
-		m.ScrubCsumErrors = val.(int64)
-	}
-	if val, ok := attrs["scrub_verify_errors"]; ok && val != nil {
-		m.ScrubVerifyErrors = val.(int64)
-	}
-	if val, ok := attrs["scrub_super_errors"]; ok && val != nil {
-		m.ScrubSuperErrors = val.(int64)
-	}
-	return &m, nil
+	return &BtrfsMetrics{
+		Date:              attrs["_time"].(time.Time),
+		FilesystemUUID:    attrs["filesystem_uuid"].(string),
+		HostID:            influxString(attrs, "host_id"),
+		Label:             influxString(attrs, "label"),
+		DeviceSize:        influxInt64(attrs, "device_size"),
+		DeviceAllocated:   influxInt64(attrs, "device_allocated"),
+		DeviceUnallocated: influxInt64(attrs, "device_unallocated"),
+		DeviceMissing:     influxInt64(attrs, "device_missing"),
+		Used:              influxInt64(attrs, "used"),
+		FreeEstimated:     influxInt64(attrs, "free_estimated"),
+		FreeStatfs:        influxInt64(attrs, "free_statfs"),
+		DataRatio:         influxFloat64(attrs, "data_ratio"),
+		MetadataRatio:     influxFloat64(attrs, "metadata_ratio"),
+		Status:            influxString(attrs, "status"),
+		ScrubState:        influxString(attrs, "scrub_state"),
+		ScrubReadErrors:   influxInt64(attrs, "scrub_read_errors"),
+		ScrubCsumErrors:   influxInt64(attrs, "scrub_csum_errors"),
+		ScrubVerifyErrors: influxInt64(attrs, "scrub_verify_errors"),
+		ScrubSuperErrors:  influxInt64(attrs, "scrub_super_errors"),
+	}, nil
 }

--- a/webapp/backend/pkg/models/measurements/mdadm_metrics.go
+++ b/webapp/backend/pkg/models/measurements/mdadm_metrics.go
@@ -51,40 +51,18 @@ func (m *MDADMMetrics) Flatten() (tags map[string]string, fields map[string]inte
 
 // NewMDADMMetricsFromInfluxDB creates an MDADMMetrics from InfluxDB query result
 func NewMDADMMetricsFromInfluxDB(attrs map[string]interface{}) (*MDADMMetrics, error) {
-	m := MDADMMetrics{
-		Date:      attrs["_time"].(time.Time),
-		ArrayUUID: attrs["array_uuid"].(string),
-		ArrayName: attrs["array_name"].(string),
-	}
-
-	// Parse optional fields
-	if val, ok := attrs["active_devices"]; ok && val != nil {
-		m.ActiveDevices = int(val.(int64))
-	}
-	if val, ok := attrs["working_devices"]; ok && val != nil {
-		m.WorkingDevices = int(val.(int64))
-	}
-	if val, ok := attrs["failed_devices"]; ok && val != nil {
-		m.FailedDevices = int(val.(int64))
-	}
-	if val, ok := attrs["spare_devices"]; ok && val != nil {
-		m.SpareDevices = int(val.(int64))
-	}
-	if val, ok := attrs["state"]; ok && val != nil {
-		m.State = val.(string)
-	}
-	if val, ok := attrs["sync_progress"]; ok && val != nil {
-		m.SyncProgress = val.(float64)
-	}
-	if val, ok := attrs["raw_mdstat"]; ok && val != nil {
-		m.RawMdstat = val.(string)
-	}
-	if val, ok := attrs["array_size"]; ok && val != nil {
-		m.ArraySize = val.(int64)
-	}
-	if val, ok := attrs["used_bytes"]; ok && val != nil {
-		m.UsedBytes = val.(int64)
-	}
-
-	return &m, nil
+	return &MDADMMetrics{
+		Date:           attrs["_time"].(time.Time),
+		ArrayUUID:      attrs["array_uuid"].(string),
+		ArrayName:      attrs["array_name"].(string),
+		ActiveDevices:  int(influxInt64(attrs, "active_devices")),
+		WorkingDevices: int(influxInt64(attrs, "working_devices")),
+		FailedDevices:  int(influxInt64(attrs, "failed_devices")),
+		SpareDevices:   int(influxInt64(attrs, "spare_devices")),
+		State:          influxString(attrs, "state"),
+		SyncProgress:   influxFloat64(attrs, "sync_progress"),
+		RawMdstat:      influxString(attrs, "raw_mdstat"),
+		ArraySize:      influxInt64(attrs, "array_size"),
+		UsedBytes:      influxInt64(attrs, "used_bytes"),
+	}, nil
 }

--- a/webapp/backend/pkg/models/measurements/performance.go
+++ b/webapp/backend/pkg/models/measurements/performance.go
@@ -38,21 +38,21 @@ func (p *Performance) Flatten() (tags map[string]string, fields map[string]inter
 	}
 
 	fields = map[string]interface{}{
-		"seq_read_bw_bytes":      p.SeqReadBwBytes,
-		"seq_write_bw_bytes":     p.SeqWriteBwBytes,
-		"rand_read_iops":         p.RandReadIOPS,
-		"rand_write_iops":        p.RandWriteIOPS,
-		"rand_read_lat_ns_avg":   p.RandReadLatAvgNs,
-		"rand_read_lat_ns_p50":   p.RandReadLatP50Ns,
-		"rand_read_lat_ns_p95":   p.RandReadLatP95Ns,
-		"rand_read_lat_ns_p99":   p.RandReadLatP99Ns,
-		"rand_write_lat_ns_avg":  p.RandWriteLatAvgNs,
-		"rand_write_lat_ns_p50":  p.RandWriteLatP50Ns,
-		"rand_write_lat_ns_p95":  p.RandWriteLatP95Ns,
-		"rand_write_lat_ns_p99":  p.RandWriteLatP99Ns,
-		"mixed_rw_iops":          p.MixedRwIOPS,
-		"fio_version":            p.FioVersion,
-		"test_duration_sec":      p.TestDurationSec,
+		"seq_read_bw_bytes":     p.SeqReadBwBytes,
+		"seq_write_bw_bytes":    p.SeqWriteBwBytes,
+		"rand_read_iops":        p.RandReadIOPS,
+		"rand_write_iops":       p.RandWriteIOPS,
+		"rand_read_lat_ns_avg":  p.RandReadLatAvgNs,
+		"rand_read_lat_ns_p50":  p.RandReadLatP50Ns,
+		"rand_read_lat_ns_p95":  p.RandReadLatP95Ns,
+		"rand_read_lat_ns_p99":  p.RandReadLatP99Ns,
+		"rand_write_lat_ns_avg": p.RandWriteLatAvgNs,
+		"rand_write_lat_ns_p50": p.RandWriteLatP50Ns,
+		"rand_write_lat_ns_p95": p.RandWriteLatP95Ns,
+		"rand_write_lat_ns_p99": p.RandWriteLatP99Ns,
+		"mixed_rw_iops":         p.MixedRwIOPS,
+		"fio_version":           p.FioVersion,
+		"test_duration_sec":     p.TestDurationSec,
 	}
 
 	return tags, fields
@@ -60,62 +60,27 @@ func (p *Performance) Flatten() (tags map[string]string, fields map[string]inter
 
 // NewPerformanceFromInfluxDB creates a Performance from InfluxDB query result
 func NewPerformanceFromInfluxDB(attrs map[string]interface{}) (*Performance, error) {
-	p := Performance{
-		Date:           attrs["_time"].(time.Time),
-		DeviceWWN:      attrs["device_wwn"].(string),
-		DeviceProtocol: attrs["device_protocol"].(string),
-	}
-
-	if val, ok := attrs["profile"]; ok && val != nil {
-		p.Profile = val.(string)
-	}
-	if val, ok := attrs["seq_read_bw_bytes"]; ok && val != nil {
-		p.SeqReadBwBytes = val.(float64)
-	}
-	if val, ok := attrs["seq_write_bw_bytes"]; ok && val != nil {
-		p.SeqWriteBwBytes = val.(float64)
-	}
-	if val, ok := attrs["rand_read_iops"]; ok && val != nil {
-		p.RandReadIOPS = val.(float64)
-	}
-	if val, ok := attrs["rand_write_iops"]; ok && val != nil {
-		p.RandWriteIOPS = val.(float64)
-	}
-	if val, ok := attrs["rand_read_lat_ns_avg"]; ok && val != nil {
-		p.RandReadLatAvgNs = val.(float64)
-	}
-	if val, ok := attrs["rand_read_lat_ns_p50"]; ok && val != nil {
-		p.RandReadLatP50Ns = val.(float64)
-	}
-	if val, ok := attrs["rand_read_lat_ns_p95"]; ok && val != nil {
-		p.RandReadLatP95Ns = val.(float64)
-	}
-	if val, ok := attrs["rand_read_lat_ns_p99"]; ok && val != nil {
-		p.RandReadLatP99Ns = val.(float64)
-	}
-	if val, ok := attrs["rand_write_lat_ns_avg"]; ok && val != nil {
-		p.RandWriteLatAvgNs = val.(float64)
-	}
-	if val, ok := attrs["rand_write_lat_ns_p50"]; ok && val != nil {
-		p.RandWriteLatP50Ns = val.(float64)
-	}
-	if val, ok := attrs["rand_write_lat_ns_p95"]; ok && val != nil {
-		p.RandWriteLatP95Ns = val.(float64)
-	}
-	if val, ok := attrs["rand_write_lat_ns_p99"]; ok && val != nil {
-		p.RandWriteLatP99Ns = val.(float64)
-	}
-	if val, ok := attrs["mixed_rw_iops"]; ok && val != nil {
-		p.MixedRwIOPS = val.(float64)
-	}
-	if val, ok := attrs["fio_version"]; ok && val != nil {
-		p.FioVersion = val.(string)
-	}
-	if val, ok := attrs["test_duration_sec"]; ok && val != nil {
-		p.TestDurationSec = val.(float64)
-	}
-
-	return &p, nil
+	return &Performance{
+		Date:              attrs["_time"].(time.Time),
+		DeviceWWN:         attrs["device_wwn"].(string),
+		DeviceProtocol:    attrs["device_protocol"].(string),
+		Profile:           influxString(attrs, "profile"),
+		SeqReadBwBytes:    influxFloat64(attrs, "seq_read_bw_bytes"),
+		SeqWriteBwBytes:   influxFloat64(attrs, "seq_write_bw_bytes"),
+		RandReadIOPS:      influxFloat64(attrs, "rand_read_iops"),
+		RandWriteIOPS:     influxFloat64(attrs, "rand_write_iops"),
+		RandReadLatAvgNs:  influxFloat64(attrs, "rand_read_lat_ns_avg"),
+		RandReadLatP50Ns:  influxFloat64(attrs, "rand_read_lat_ns_p50"),
+		RandReadLatP95Ns:  influxFloat64(attrs, "rand_read_lat_ns_p95"),
+		RandReadLatP99Ns:  influxFloat64(attrs, "rand_read_lat_ns_p99"),
+		RandWriteLatAvgNs: influxFloat64(attrs, "rand_write_lat_ns_avg"),
+		RandWriteLatP50Ns: influxFloat64(attrs, "rand_write_lat_ns_p50"),
+		RandWriteLatP95Ns: influxFloat64(attrs, "rand_write_lat_ns_p95"),
+		RandWriteLatP99Ns: influxFloat64(attrs, "rand_write_lat_ns_p99"),
+		MixedRwIOPS:       influxFloat64(attrs, "mixed_rw_iops"),
+		FioVersion:        influxString(attrs, "fio_version"),
+		TestDurationSec:   influxFloat64(attrs, "test_duration_sec"),
+	}, nil
 }
 
 // PerformanceBaseline represents averaged performance metrics used as a comparison baseline

--- a/webapp/backend/pkg/models/measurements/smart_ata_attribute.go
+++ b/webapp/backend/pkg/models/measurements/smart_ata_attribute.go
@@ -135,13 +135,13 @@ func (sa *SmartAtaAttribute) ValidateThreshold(smartMetadata thresholds.AtaAttri
 	value := sa.thresholdValue(smartMetadata.DisplayType)
 
 	for _, obsThresh := range smartMetadata.ObservedThresholds {
-		//check if "value" is in this bucket
+		// check if "value" is in this bucket
 		if !observedThresholdContains(obsThresh, value) {
 			continue
 		}
 		sa.FailureRate = observedFailureRate(obsThresh)
 		sa.applyFailureRateStatus(smartMetadata.Critical)
-		//we've found the correct bucket, we can drop out of this loop
+		// we've found the correct bucket, we can drop out of this loop
 		return
 	}
 

--- a/webapp/backend/pkg/models/measurements/smart_ata_attribute.go
+++ b/webapp/backend/pkg/models/measurements/smart_ata_attribute.go
@@ -132,53 +132,72 @@ func (sa *SmartAtaAttribute) ValidateThreshold(smartMetadata thresholds.AtaAttri
 	// 		- if failure rate is above 10 but below 20 - set to warn
 
 	//update the smart attribute status based on Observed thresholds.
-	var value int64
-	if smartMetadata.DisplayType == thresholds.AtaSmartAttributeDisplayTypeNormalized {
-		value = int64(sa.Value)
-	} else if smartMetadata.DisplayType == thresholds.AtaSmartAttributeDisplayTypeTransformed {
-		value = sa.TransformedValue
-	} else {
-		value = sa.RawValue
-	}
+	value := sa.thresholdValue(smartMetadata.DisplayType)
 
 	for _, obsThresh := range smartMetadata.ObservedThresholds {
-
 		//check if "value" is in this bucket
-		if ((obsThresh.Low == obsThresh.High) && value == obsThresh.Low) ||
-			(obsThresh.Low < value && value <= obsThresh.High) {
-			sa.FailureRate = obsThresh.AnnualFailureRate
-
-			// When AnnualFailureRate is 0 but ErrorInterval has real values,
-			// estimate the failure rate from the midpoint of the error interval.
-			if sa.FailureRate == 0 && len(obsThresh.ErrorInterval) == 2 &&
-				(obsThresh.ErrorInterval[0] != 0 || obsThresh.ErrorInterval[1] != 0) {
-				sa.FailureRate = (obsThresh.ErrorInterval[0] + obsThresh.ErrorInterval[1]) / 2.0
-			}
-
-			if smartMetadata.Critical {
-				if sa.FailureRate >= 0.10 {
-					sa.Status = pkg.AttributeStatusSet(sa.Status, pkg.AttributeStatusFailedScrutiny)
-					sa.StatusReason += "Observed Failure Rate for Critical Attribute is greater than 10%"
-				}
-			} else {
-				if sa.FailureRate >= 0.20 {
-					sa.Status = pkg.AttributeStatusSet(sa.Status, pkg.AttributeStatusFailedScrutiny)
-					sa.StatusReason += "Observed Failure Rate for Non-Critical Attribute is greater than 20%"
-				} else if sa.FailureRate >= 0.10 {
-					sa.Status = pkg.AttributeStatusSet(sa.Status, pkg.AttributeStatusWarningScrutiny)
-					sa.StatusReason += "Observed Failure Rate for Non-Critical Attribute is greater than 10%"
-				}
-			}
-
-			//we've found the correct bucket, we can drop out of this loop
-			return
+		if !observedThresholdContains(obsThresh, value) {
+			continue
 		}
+		sa.FailureRate = observedFailureRate(obsThresh)
+		sa.applyFailureRateStatus(smartMetadata.Critical)
+		//we've found the correct bucket, we can drop out of this loop
+		return
 	}
+
 	// no bucket found
 	if smartMetadata.Critical {
 		sa.Status = pkg.AttributeStatusSet(sa.Status, pkg.AttributeStatusWarningScrutiny)
 		sa.StatusReason = "Could not determine Observed Failure Rate for Critical Attribute"
 	}
+}
 
-	return
+// thresholdValue returns the attribute value to compare against observed thresholds, selected by
+// the metadata display type (normalized, transformed, or raw).
+func (sa *SmartAtaAttribute) thresholdValue(displayType string) int64 {
+	switch displayType {
+	case thresholds.AtaSmartAttributeDisplayTypeNormalized:
+		return int64(sa.Value)
+	case thresholds.AtaSmartAttributeDisplayTypeTransformed:
+		return sa.TransformedValue
+	default:
+		return sa.RawValue
+	}
+}
+
+// observedThresholdContains reports whether value falls within an observed-threshold bucket.
+func observedThresholdContains(obsThresh thresholds.ObservedThreshold, value int64) bool {
+	return ((obsThresh.Low == obsThresh.High) && value == obsThresh.Low) ||
+		(obsThresh.Low < value && value <= obsThresh.High)
+}
+
+// observedFailureRate returns the bucket's annual failure rate, falling back to the midpoint of
+// the error interval when the annual rate is 0 but the interval carries real values.
+func observedFailureRate(obsThresh thresholds.ObservedThreshold) float64 {
+	rate := obsThresh.AnnualFailureRate
+	if rate == 0 && len(obsThresh.ErrorInterval) == 2 &&
+		(obsThresh.ErrorInterval[0] != 0 || obsThresh.ErrorInterval[1] != 0) {
+		rate = (obsThresh.ErrorInterval[0] + obsThresh.ErrorInterval[1]) / 2.0
+	}
+	return rate
+}
+
+// applyFailureRateStatus sets the attribute status/reason from its failure rate, using stricter
+// thresholds for critical attributes (fail >= 10%) than non-critical ones (fail >= 20%, warn >= 10%).
+func (sa *SmartAtaAttribute) applyFailureRateStatus(critical bool) {
+	if critical {
+		if sa.FailureRate >= 0.10 {
+			sa.Status = pkg.AttributeStatusSet(sa.Status, pkg.AttributeStatusFailedScrutiny)
+			sa.StatusReason += "Observed Failure Rate for Critical Attribute is greater than 10%"
+		}
+		return
+	}
+
+	if sa.FailureRate >= 0.20 {
+		sa.Status = pkg.AttributeStatusSet(sa.Status, pkg.AttributeStatusFailedScrutiny)
+		sa.StatusReason += "Observed Failure Rate for Non-Critical Attribute is greater than 20%"
+	} else if sa.FailureRate >= 0.10 {
+		sa.Status = pkg.AttributeStatusSet(sa.Status, pkg.AttributeStatusWarningScrutiny)
+		sa.StatusReason += "Observed Failure Rate for Non-Critical Attribute is greater than 10%"
+	}
 }

--- a/webapp/backend/pkg/thresholds/consumer_drive_profiles.go
+++ b/webapp/backend/pkg/thresholds/consumer_drive_profiles.go
@@ -82,50 +82,66 @@ func parseConsumerDriveProfiles(data []byte) (map[string]ConsumerDriveProfile, m
 	}
 
 	byFamily := make(map[string]ConsumerDriveProfile, len(catalog.Profiles))
-	byModel := make(map[string]ConsumerDriveProfile, len(catalog.Aliases))
 	regexProfiles := make([]ConsumerDriveProfile, 0)
-
 	for i := range catalog.Profiles {
-		profile := &catalog.Profiles[i]
-		if profile.ModelFamily == "" {
-			return nil, nil, nil, fmt.Errorf("profile missing model_family")
+		if err := addConsumerDriveProfile(&catalog.Profiles[i], byFamily, &regexProfiles); err != nil {
+			return nil, nil, nil, err
 		}
-		familyKey := normalizeConsumerDriveKey(profile.ModelFamily)
-		if familyKey == "" {
-			return nil, nil, nil, fmt.Errorf("profile has empty normalized family for %q", profile.ModelFamily)
-		}
-		if _, exists := byFamily[familyKey]; exists {
-			return nil, nil, nil, fmt.Errorf("duplicate profile family %q", profile.ModelFamily)
-		}
-		if profile.ModelPattern != "" {
-			compiled, err := regexp.Compile(profile.ModelPattern)
-			if err != nil {
-				return nil, nil, nil, fmt.Errorf("compile model_pattern for %q: %w", profile.ModelFamily, err)
-			}
-			profile.compiledPattern = compiled
-			regexProfiles = append(regexProfiles, *profile)
-		}
-		byFamily[familyKey] = *profile
 	}
 
+	byModel := make(map[string]ConsumerDriveProfile, len(catalog.Aliases))
 	for modelAlias, family := range catalog.Aliases {
-		profile, ok := byFamily[normalizeConsumerDriveKey(family)]
-		if !ok {
-			return nil, nil, nil, fmt.Errorf("alias %q points to unknown family %q", modelAlias, family)
+		if err := addConsumerDriveAlias(modelAlias, family, byFamily, byModel); err != nil {
+			return nil, nil, nil, err
 		}
-		modelKey := normalizeConsumerDriveKey(modelAlias)
-		if modelKey == "" {
-			return nil, nil, nil, fmt.Errorf("alias %q normalizes to empty key", modelAlias)
-		}
-		if existing, exists := byModel[modelKey]; exists {
-			if normalizeConsumerDriveKey(existing.ModelFamily) != normalizeConsumerDriveKey(profile.ModelFamily) {
-				return nil, nil, nil, fmt.Errorf("duplicate model alias %q", modelAlias)
-			}
-			continue
-		}
-		byModel[modelKey] = profile
 	}
 	return byFamily, byModel, regexProfiles, nil
+}
+
+// addConsumerDriveProfile validates a single profile and registers it under its normalized family
+// key, also appending it to regexProfiles when it carries a model pattern.
+func addConsumerDriveProfile(profile *ConsumerDriveProfile, byFamily map[string]ConsumerDriveProfile, regexProfiles *[]ConsumerDriveProfile) error {
+	if profile.ModelFamily == "" {
+		return fmt.Errorf("profile missing model_family")
+	}
+	familyKey := normalizeConsumerDriveKey(profile.ModelFamily)
+	if familyKey == "" {
+		return fmt.Errorf("profile has empty normalized family for %q", profile.ModelFamily)
+	}
+	if _, exists := byFamily[familyKey]; exists {
+		return fmt.Errorf("duplicate profile family %q", profile.ModelFamily)
+	}
+	if profile.ModelPattern != "" {
+		compiled, err := regexp.Compile(profile.ModelPattern)
+		if err != nil {
+			return fmt.Errorf("compile model_pattern for %q: %w", profile.ModelFamily, err)
+		}
+		profile.compiledPattern = compiled
+		*regexProfiles = append(*regexProfiles, *profile)
+	}
+	byFamily[familyKey] = *profile
+	return nil
+}
+
+// addConsumerDriveAlias resolves an alias to its family profile and registers it under the
+// normalized model key, tolerating duplicate aliases that point to the same family.
+func addConsumerDriveAlias(modelAlias, family string, byFamily, byModel map[string]ConsumerDriveProfile) error {
+	profile, ok := byFamily[normalizeConsumerDriveKey(family)]
+	if !ok {
+		return fmt.Errorf("alias %q points to unknown family %q", modelAlias, family)
+	}
+	modelKey := normalizeConsumerDriveKey(modelAlias)
+	if modelKey == "" {
+		return fmt.Errorf("alias %q normalizes to empty key", modelAlias)
+	}
+	if existing, exists := byModel[modelKey]; exists {
+		if normalizeConsumerDriveKey(existing.ModelFamily) != normalizeConsumerDriveKey(profile.ModelFamily) {
+			return fmt.Errorf("duplicate model alias %q", modelAlias)
+		}
+		return nil
+	}
+	byModel[modelKey] = profile
+	return nil
 }
 
 func LookupConsumerDriveProfile(protocol, modelFamily, modelName string) (*ConsumerDriveProfile, bool) {


### PR DESCRIPTION
## Summary

Reduces SonarQube cognitive complexity (go:S3776) across the measurement models and threshold parsing. All flagged functions now sit at or below the allowed limit of 15.

| Function | File | Before |
|----------|------|--------|
| NewBtrfsMetricsFromInfluxDB | measurements/btrfs_metrics.go | 34 |
| NewPerformanceFromInfluxDB | measurements/performance.go | 32 |
| ValidateThreshold | measurements/smart_ata_attribute.go | 27 |
| parseConsumerDriveProfiles | thresholds/consumer_drive_profiles.go | 23 |
| NewMDADMMetricsFromInfluxDB | measurements/mdadm_metrics.go | 18 |

## Changes

Pure refactor; no behavior change.

- The three `NewXFromInfluxDB` constructors had long runs of `if val, ok := attrs[k]; ok && val != nil { ... }` optional-field blocks. These now use the package's existing `influxString` / `influxInt64` / `influxFloat64` helpers (defined in `zfs_pool_metrics.go`). Assigning the helper's zero value for an absent key is equivalent to leaving the field unset, and the helpers keep the same panic-on-type-mismatch behavior as the original direct assertions.
- **ValidateThreshold** — extracted `thresholdValue` (display-type selection), `observedThresholdContains`, `observedFailureRate`, and `applyFailureRateStatus`.
- **parseConsumerDriveProfiles** — extracted `addConsumerDriveProfile` and `addConsumerDriveAlias` per-entry handlers.

## Verification

- [x] `go build ./webapp/backend/...`
- [x] `go vet` on both packages
- [x] `go test -count=1 ./webapp/backend/pkg/models/measurements/... ./webapp/backend/pkg/thresholds/...` — pass (no InfluxDB needed)
- [x] `gocognit -over 15` reports zero functions over the limit
- [x] `gofmt` clean

## Notes

Continuation of SonarQube Group 5, after #616/#617/#618/#619/#620/#621. Remaining: web middleware/monitors (auth, logger, heartbeat, missed-ping) and the DB migration runner (Migrate, 166).