### PR TITLE
feat(thresholds): detect Power-On Hours 16-bit counter rollover (#595)

### DIFF
--- a/webapp/backend/pkg/database/scrutiny_repository_device_smart_attributes.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_device_smart_attributes.go
@@ -40,12 +40,18 @@ func (sr *scrutinyRepository) SaveSmartAttributes(ctx context.Context, wwn strin
 	// If a cumulative counter hasn't increased, suppress the warning since the underlying issue
 	// may have been resolved.
 	previousSmartData, prevErr := sr.GetLatestSmartSubmission(ctx, wwn)
+	var previousSmart *measurements.Smart
 	if prevErr != nil || len(previousSmartData) < 1 {
 		sr.logger.Debugln("No previous SMART submission available for delta evaluation (expected for first submission)")
 	} else {
-		previousValues := extractPreviousRawValues(&previousSmartData[0])
+		previousSmart = &previousSmartData[0]
+		previousValues := extractPreviousRawValues(previousSmart)
 		deviceSmartData.ApplyDeltaEvaluation(previousValues)
 	}
+
+	// Flag Power-On Hours rollover (16-bit counter wrap) on attribute 9. Uses the previous
+	// submission (when available) plus cross-attribute hour-counters; safe with a nil previous.
+	deviceSmartData.DetectPowerOnHoursRollover(previousSmart)
 
 	tags, fields := deviceSmartData.Flatten()
 

--- a/webapp/backend/pkg/models/measurements/smart.go
+++ b/webapp/backend/pkg/models/measurements/smart.go
@@ -743,6 +743,155 @@ func (sm *Smart) recalculateDeviceStatus() {
 	sm.Status = newStatus
 }
 
+// rolloverCrossCheckMarginHours is the slack allowed when comparing Power-On Hours against
+// other hour-counters (FARM, Head Flying Hours). Differences smaller than this are treated as
+// normal unit/rounding noise rather than a rollover, to avoid false positives across vendors.
+const rolloverCrossCheckMarginHours = 100
+
+// parseHoursFromRaw extracts an hours value from a SMART raw value/string. It mirrors the
+// parsing used by the attribute 9 (Power-On Hours) Transform: smartctl "h+m+s" form
+// (e.g. "1730h+05m+02.453s"), the parenthetical "(NNNN hours)" form, and falls back to the
+// numeric raw value (masking the lower 32 bits when extra data is packed in the upper bytes).
+func parseHoursFromRaw(rawValue int64, rawString string) int64 {
+	if hours, ok := parseHoursFromHmsString(rawString); ok {
+		return hours
+	}
+	if hours, ok := parseHoursFromParenString(rawString); ok {
+		return hours
+	}
+
+	// Packed 48-bit raw value with extra data in the upper bytes; hours are the lower 32 bits.
+	if rawValue > 0xFFFFFFFF {
+		return rawValue & 0xFFFFFFFF
+	}
+
+	return rawValue
+}
+
+// parseHoursFromHmsString parses the smartctl "h+m+s" form (e.g. "1730h+05m+02.453s").
+func parseHoursFromHmsString(rawString string) (int64, bool) {
+	hIdx := strings.Index(rawString, "h+")
+	if hIdx <= 0 {
+		return 0, false
+	}
+	hours, err := strconv.ParseInt(rawString[:hIdx], 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return hours, true
+}
+
+// parseHoursFromParenString parses the smartctl parenthetical form (e.g. "103800 (1730 hours)").
+func parseHoursFromParenString(rawString string) (int64, bool) {
+	if !strings.Contains(rawString, "hours)") {
+		return 0, false
+	}
+	parenStart := strings.Index(rawString, "(")
+	if parenStart < 0 {
+		return 0, false
+	}
+	inner := rawString[parenStart+1:]
+	spaceIdx := strings.Index(inner, " ")
+	if spaceIdx <= 0 {
+		return 0, false
+	}
+	hours, err := strconv.ParseInt(inner[:spaceIdx], 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return hours, true
+}
+
+// DetectPowerOnHoursRollover flags attribute 9 (Power-On Hours) with a Scrutiny warning when
+// the value appears to have rolled over. Older ATA drives store Power-On Hours in a 16-bit
+// counter that wraps to 0 after 65535 hours (~7.5 years), silently corrupting the value.
+//
+// Two signals are used:
+//  1. History: Power-On Hours is monotonic in normal operation, so a decrease since the previous
+//     submission indicates a wrap/reset (catches the wrap moment). previousSmart may be nil.
+//  2. Cross-attribute: hour-counters that should never exceed true Power-On Hours (Seagate FARM
+//     power-on/spindle/head-flight hours, and ATA Head Flying Hours). If any exceeds the current
+//     Power-On Hours by more than rolloverCrossCheckMarginHours, the counter has wrapped (persists
+//     after the wrap moment).
+//
+// The detection only raises a warning (data artifact, not a failure) and never changes device
+// status; recalculateDeviceStatus only reacts to FailedScrutiny.
+func (sm *Smart) DetectPowerOnHoursRollover(previousSmart *Smart) {
+	if sm.DeviceProtocol != pkg.DeviceProtocolAta {
+		return
+	}
+
+	poh, ok := sm.Attributes["9"].(*SmartAtaAttribute)
+	if !ok {
+		return
+	}
+	currentPoH := poh.TransformedValue
+	if currentPoH <= 0 {
+		return
+	}
+
+	reason := sm.rolloverReasonFromHistory(currentPoH, previousSmart)
+	if reason == "" {
+		reason = sm.rolloverReasonFromCrossCheck(currentPoH)
+	}
+	if reason == "" {
+		return
+	}
+
+	poh.Status = pkg.AttributeStatusSet(poh.Status, pkg.AttributeStatusWarningScrutiny)
+	if poh.StatusReason != "" {
+		poh.StatusReason += "; " + reason
+	} else {
+		poh.StatusReason = reason
+	}
+}
+
+// rolloverReasonFromHistory returns a rollover reason when Power-On Hours decreased since the
+// previous submission (a monotonic violation), or "" otherwise.
+func (sm *Smart) rolloverReasonFromHistory(currentPoH int64, previousSmart *Smart) string {
+	if previousSmart == nil {
+		return ""
+	}
+	prevPoH, ok := previousSmart.Attributes["9"].(*SmartAtaAttribute)
+	if !ok || prevPoH.TransformedValue <= 0 || currentPoH >= prevPoH.TransformedValue {
+		return ""
+	}
+	return fmt.Sprintf("Power-On Hours decreased from %dh to %dh (possible 16-bit counter rollover)", prevPoH.TransformedValue, currentPoH)
+}
+
+// rolloverReasonFromCrossCheck returns a rollover reason when an hours-counter that should never
+// exceed true Power-On Hours (FARM power-on/spindle/head-flight hours, or ATA Head Flying Hours)
+// exceeds the current Power-On Hours by more than the margin, or "" otherwise.
+func (sm *Smart) rolloverReasonFromCrossCheck(currentPoH int64) string {
+	bestSource := ""
+	var bestHours int64
+	consider := func(source string, hours int64) {
+		if hours > bestHours {
+			bestHours = hours
+			bestSource = source
+		}
+	}
+
+	farmSources := []struct{ id, source string }{
+		{"farm_poh", "FARM Power-On Hours"},
+		{"farm_spoh", "FARM Spindle Power-On Hours"},
+		{"farm_head_flight_hours", "FARM Head Flight Hours"},
+	}
+	for _, c := range farmSources {
+		if farmAttr, ok := sm.Attributes[c.id].(*SmartFarmAttribute); ok {
+			consider(c.source, farmAttr.Value)
+		}
+	}
+	if headFlying, ok := sm.Attributes["240"].(*SmartAtaAttribute); ok {
+		consider("Head Flying Hours", parseHoursFromRaw(headFlying.RawValue, headFlying.RawString))
+	}
+
+	if bestHours > currentPoH+rolloverCrossCheckMarginHours {
+		return fmt.Sprintf("Power-On Hours (%dh) is below %s (%dh); possible 16-bit counter rollover", currentPoH, bestSource, bestHours)
+	}
+	return ""
+}
+
 // processScsiSmartInfoWithOverrides generates SmartScsiAttribute entries using pre-merged overrides.
 func (sm *Smart) processScsiSmartInfoWithOverrides(cfg config.Interface, defectGrownList int64, scsiErrorCounterLog collector.ScsiErrorCounterLog, temperature map[string]collector.ScsiTemperatureData, mergedOverrides []overrides.AttributeOverride) {
 	sm.Attributes = map[string]SmartAttribute{

--- a/webapp/backend/pkg/models/measurements/smart_rollover_test.go
+++ b/webapp/backend/pkg/models/measurements/smart_rollover_test.go
@@ -1,0 +1,145 @@
+package measurements_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/analogj/scrutiny/webapp/backend/pkg"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/models/measurements"
+	"github.com/stretchr/testify/require"
+)
+
+// ataSmart builds an ATA Smart measurement with the given attributes for rollover tests.
+func ataSmart(attrs map[string]measurements.SmartAttribute) measurements.Smart {
+	return measurements.Smart{
+		Date:           time.Now(),
+		DeviceWWN:      "test-wwn",
+		DeviceProtocol: pkg.DeviceProtocolAta,
+		Attributes:     attrs,
+	}
+}
+
+// TestDetectPowerOnHoursRollover_HistoryDecrease flags a wrap when Power-On Hours drops.
+func TestDetectPowerOnHoursRollover_HistoryDecrease(t *testing.T) {
+	current := ataSmart(map[string]measurements.SmartAttribute{
+		"9": &measurements.SmartAtaAttribute{AttributeId: 9, TransformedValue: 12},
+	})
+	previous := ataSmart(map[string]measurements.SmartAttribute{
+		"9": &measurements.SmartAtaAttribute{AttributeId: 9, TransformedValue: 65000},
+	})
+
+	current.DetectPowerOnHoursRollover(&previous)
+
+	attr := current.Attributes["9"].(*measurements.SmartAtaAttribute)
+	require.True(t, pkg.AttributeStatusHas(attr.Status, pkg.AttributeStatusWarningScrutiny))
+	require.Contains(t, attr.StatusReason, "decreased from 65000h to 12h")
+}
+
+// TestDetectPowerOnHoursRollover_FarmExceeds flags a wrap when tamper-proof FARM hours exceed PoH.
+func TestDetectPowerOnHoursRollover_FarmExceeds(t *testing.T) {
+	current := ataSmart(map[string]measurements.SmartAttribute{
+		"9":        &measurements.SmartAtaAttribute{AttributeId: 9, TransformedValue: 12},
+		"farm_poh": &measurements.SmartFarmAttribute{AttributeId: "farm_poh", Value: 65548},
+	})
+
+	current.DetectPowerOnHoursRollover(nil)
+
+	attr := current.Attributes["9"].(*measurements.SmartAtaAttribute)
+	require.True(t, pkg.AttributeStatusHas(attr.Status, pkg.AttributeStatusWarningScrutiny))
+	require.Contains(t, attr.StatusReason, "FARM Power-On Hours (65548h)")
+}
+
+// TestDetectPowerOnHoursRollover_HeadFlyingExceeds flags a wrap when Head Flying Hours exceed PoH.
+func TestDetectPowerOnHoursRollover_HeadFlyingExceeds(t *testing.T) {
+	current := ataSmart(map[string]measurements.SmartAttribute{
+		"9":   &measurements.SmartAtaAttribute{AttributeId: 9, TransformedValue: 12},
+		"240": &measurements.SmartAtaAttribute{AttributeId: 240, RawString: "70000h+00m+00.000s"},
+	})
+
+	current.DetectPowerOnHoursRollover(nil)
+
+	attr := current.Attributes["9"].(*measurements.SmartAtaAttribute)
+	require.True(t, pkg.AttributeStatusHas(attr.Status, pkg.AttributeStatusWarningScrutiny))
+	require.Contains(t, attr.StatusReason, "Head Flying Hours (70000h)")
+}
+
+// TestDetectPowerOnHoursRollover_NormalIncrease leaves a normally-increasing PoH untouched.
+func TestDetectPowerOnHoursRollover_NormalIncrease(t *testing.T) {
+	current := ataSmart(map[string]measurements.SmartAttribute{
+		"9": &measurements.SmartAtaAttribute{AttributeId: 9, TransformedValue: 1100},
+	})
+	previous := ataSmart(map[string]measurements.SmartAttribute{
+		"9": &measurements.SmartAtaAttribute{AttributeId: 9, TransformedValue: 1000},
+	})
+
+	current.DetectPowerOnHoursRollover(&previous)
+
+	attr := current.Attributes["9"].(*measurements.SmartAtaAttribute)
+	require.Equal(t, pkg.AttributeStatusPassed, attr.Status)
+	require.Empty(t, attr.StatusReason)
+}
+
+// TestDetectPowerOnHoursRollover_WithinMargin does not flag small cross-attribute differences.
+func TestDetectPowerOnHoursRollover_WithinMargin(t *testing.T) {
+	current := ataSmart(map[string]measurements.SmartAttribute{
+		"9":        &measurements.SmartAtaAttribute{AttributeId: 9, TransformedValue: 1000},
+		"farm_poh": &measurements.SmartFarmAttribute{AttributeId: "farm_poh", Value: 1050}, // +50, below 100 margin
+	})
+
+	current.DetectPowerOnHoursRollover(nil)
+
+	attr := current.Attributes["9"].(*measurements.SmartAtaAttribute)
+	require.Equal(t, pkg.AttributeStatusPassed, attr.Status)
+	require.Empty(t, attr.StatusReason)
+}
+
+// TestDetectPowerOnHoursRollover_NilPreviousNoCrossAttrs is a no-op without history or cross-attrs.
+func TestDetectPowerOnHoursRollover_NilPreviousNoCrossAttrs(t *testing.T) {
+	current := ataSmart(map[string]measurements.SmartAttribute{
+		"9": &measurements.SmartAtaAttribute{AttributeId: 9, TransformedValue: 1000},
+	})
+
+	current.DetectPowerOnHoursRollover(nil)
+
+	attr := current.Attributes["9"].(*measurements.SmartAtaAttribute)
+	require.Equal(t, pkg.AttributeStatusPassed, attr.Status)
+	require.Empty(t, attr.StatusReason)
+}
+
+// TestDetectPowerOnHoursRollover_NonAta is a no-op for non-ATA protocols.
+func TestDetectPowerOnHoursRollover_NonAta(t *testing.T) {
+	current := measurements.Smart{
+		Date:           time.Now(),
+		DeviceWWN:      "test-wwn",
+		DeviceProtocol: pkg.DeviceProtocolNvme,
+		Attributes: map[string]measurements.SmartAttribute{
+			"power_on_hours": &measurements.SmartNvmeAttribute{AttributeId: "power_on_hours", Value: 12},
+		},
+	}
+
+	current.DetectPowerOnHoursRollover(nil)
+
+	attr := current.Attributes["power_on_hours"].(*measurements.SmartNvmeAttribute)
+	require.Equal(t, pkg.AttributeStatusPassed, attr.Status)
+}
+
+// TestDetectPowerOnHoursRollover_PreservesExistingReason appends to an existing status reason.
+func TestDetectPowerOnHoursRollover_PreservesExistingReason(t *testing.T) {
+	current := ataSmart(map[string]measurements.SmartAttribute{
+		"9": &measurements.SmartAtaAttribute{
+			AttributeId:      9,
+			TransformedValue: 12,
+			Status:           pkg.AttributeStatusWarningScrutiny,
+			StatusReason:     "Attribute has previously failed manufacturer SMART threshold",
+		},
+	})
+	previous := ataSmart(map[string]measurements.SmartAttribute{
+		"9": &measurements.SmartAtaAttribute{AttributeId: 9, TransformedValue: 65000},
+	})
+
+	current.DetectPowerOnHoursRollover(&previous)
+
+	attr := current.Attributes["9"].(*measurements.SmartAtaAttribute)
+	require.Contains(t, attr.StatusReason, "Attribute has previously failed manufacturer SMART threshold")
+	require.Contains(t, attr.StatusReason, "possible 16-bit counter rollover")
+}


### PR DESCRIPTION
## Summary

Detects Power-On Hours (SMART attr 9) 16-bit counter rollover and flags it as a Scrutiny warning. Older ATA drives store PoH in a 16-bit counter that wraps to 0 after 65535 hours (~7.5 years), silently corrupting the displayed value with no indication. Fixes #595.

## Detection (two signals)

1. **History decrease** — PoH is monotonic; a drop since the previous submission indicates a wrap/reset (catches the wrap moment).
2. **Cross-attribute** — a tamper-proof hour-counter exceeding current PoH by >100h (margin) indicates the counter wrapped (persists after the moment):
   - Seagate FARM `farm_poh` / `farm_spoh` / `farm_head_flight_hours`
   - ATA Head Flying Hours (attr 240), hours parsed from `RawString`/`RawValue`

## Behavior

- Sets `AttributeStatusWarningScrutiny` on attr 9 with an explanatory `status_reason`.
- Does NOT mark the device failed and does NOT trigger failure notifications (rollover is a data artifact, not a failure).
- Frontend requires no change: the existing yellow `warn` badge + `status_reason` tooltip surface it automatically.

## Changes

- `webapp/backend/pkg/models/measurements/smart.go` — `DetectPowerOnHoursRollover` + `parseHoursFromRaw` helpers
- `webapp/backend/pkg/database/scrutiny_repository_device_smart_attributes.go` — call wired after delta-eval, nil-safe
- `webapp/backend/pkg/models/measurements/smart_rollover_test.go` — 8 table cases

## Testing

- `go build ./webapp/backend/cmd/scrutiny/` — OK
- `go vet ./webapp/backend/...` — clean
- `go test ./webapp/backend/pkg/models/measurements/` — pass (history decrease, FARM exceed, head-flying exceed, normal increase, within-margin, nil previous, non-ATA, existing-reason preserved)

## Out of scope

- Auto-correcting/offsetting the PoH value (needs persistent per-device state).
