### PR TITLE
ci(sync): protect beta and recreate missing sync targets

### DIFF
--- a/.github/workflows/cleanup-branches.yaml
+++ b/.github/workflows/cleanup-branches.yaml
@@ -40,7 +40,7 @@ jobs:
           echo ""
 
           # Protected branches (never delete)
-          PROTECTED_BRANCHES="master develop main"
+          PROTECTED_BRANCHES="master develop beta main"
 
           DELETED_COUNT=0
           KEPT_COUNT=0

--- a/.github/workflows/sync-develop.yaml
+++ b/.github/workflows/sync-develop.yaml
@@ -26,7 +26,15 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git checkout "$TARGET"
+          if git ls-remote --exit-code --heads origin "$TARGET" >/dev/null 2>&1; then
+            git checkout "$TARGET"
+          else
+            echo "::warning::Branch $TARGET does not exist on origin; recreating it from master."
+            git checkout -B "$TARGET" origin/master
+            git push origin "$TARGET"
+            echo "Recreated $TARGET from master; already in sync."
+            exit 0
+          fi
           if git merge origin/master --no-edit; then
             git push origin "$TARGET"
             echo "Auto-merged master into $TARGET."
@@ -71,7 +79,15 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git checkout "$TARGET"
+          if git ls-remote --exit-code --heads origin "$TARGET" >/dev/null 2>&1; then
+            git checkout "$TARGET"
+          else
+            echo "::warning::Branch $TARGET does not exist on origin; recreating it from master."
+            git checkout -B "$TARGET" origin/master
+            git push origin "$TARGET"
+            echo "Recreated $TARGET from master; already in sync."
+            exit 0
+          fi
           if git merge origin/master --no-edit; then
             git push origin "$TARGET"
             echo "Auto-merged master into $TARGET."


### PR DESCRIPTION
## Summary

Hardens branch automation after `beta` was auto-deleted on the v1.65.0 release merge (#629), which broke the **Sync beta and develop** workflow (`git checkout beta` -> `pathspec 'beta' did not match`, exit 1).

- **cleanup-branches**: add `beta` to `PROTECTED_BRANCHES` (`master develop beta main`) so stale-branch cleanup never deletes the long-lived release branch.
- **sync-develop**: when a sync target is missing on origin, recreate it from `master` (already in sync) and exit cleanly, instead of failing the checkout. Applies to both the beta and develop steps.
- Repo setting `delete_branch_on_merge` set to `false` via API to stop the auto-delete recurring on release merges.

## Linked Issues

None.

## Test plan

- [x] `beta` recreated at master HEAD; beta and develop confirmed in sync with master
- [x] YAML validated (`yaml.safe_load` both files)
- [x] `delete_branch_on_merge` confirmed `false` via API
- [ ] Next master merge auto-syncs beta + develop without failure (verify on next release)