### PR TITLE
Enhance ATA consumer-drive profile pipeline, matching, and observability (#552)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,14 @@ binary-test: binary-dep
 binary-test-coverage: binary-dep
 	go test -coverprofile=coverage.txt -covermode=atomic -v $(STATIC_TAGS) ./...
 
+.PHONY: catalog-lint
+catalog-lint:
+	go run ./webapp/backend/cmd/catalog-lint -strict
+
+.PHONY: catalog-fix
+catalog-fix:
+	go run ./webapp/backend/cmd/catalog-lint -write
+
 .PHONY: binary-collector
 binary-collector: binary-dep
 	go build -buildvcs=false -ldflags "$(LD_FLAGS)" -o $(COLLECTOR_BINARY_NAME) $(STATIC_TAGS) ./collector/cmd/collector-metrics/

--- a/docs/API.md
+++ b/docs/API.md
@@ -43,6 +43,7 @@ See [AUTH.md](./AUTH.md) for configuration and deployment details.
 - Some collector payloads are intentionally documented as structured objects with representative fields because the backend accepts large collector-origin JSON models.
 - `GET /api/device/{id}/selftest` returns ATA SMART self-test history already recorded during normal SMART uploads. The separate `POST /api/device/{id}/selftest` route remains reserved for future ingestion work.
 - Notification URL endpoints cover existing Shoutrrr syntax, explicit `apprise+...` targets, `script://` targets, and raw `http(s)` webhooks.
-- The replacement-risk endpoint includes ATA-specific metadata describing whether a bundled consumer-drive profile was enabled and applied for that score.
+- The replacement-risk endpoint includes ATA-specific metadata describing whether a bundled consumer-drive profile was enabled and applied for that score, plus provenance fields (source, sample count, match method, catalog version) when a profile is applied.
+- `GET /api/device/{id}/drive-profile` is a debug surface reporting the full consumer-drive profile match path: match method, confidence gate result, applied overrides, and fallback reason.
 - For operator-facing behavior and the global opt-out setting, see [CONSUMER_DRIVE_PROFILES.md](./CONSUMER_DRIVE_PROFILES.md).
 - If a route is added or changed in `server.go`, update `openapi.yaml` in the same change.

--- a/docs/CONSUMER_DRIVE_PROFILES.md
+++ b/docs/CONSUMER_DRIVE_PROFILES.md
@@ -15,30 +15,49 @@ This applies only to ATA devices. NVMe and SCSI devices continue to use their ex
 
 ## Matching Behavior
 
-Scrutiny tries to match profiles in this order:
+Scrutiny tries to match profiles in this order, strongest first. The stage that matched is reported as the machine-readable `match_method`:
 
-1. `model_family` reported by `smartctl`
-2. normalized exact `model_name`
-3. regex-style `model_pattern` fallback
+| Order | Match method | Meaning |
+| ----- | ------------- | ------- |
+| 1 | `model_family` | Exact match on the `model_family` reported by `smartctl` |
+| 2 | `model_name` | Exact match on the normalized `model_name` (alias table) |
+| 3 | `model_name_normalized` | Exact match after vendor-aware normalization (see below) |
+| 4 | `model_pattern` | Regex `model_pattern` fallback |
+
+Exact hits (`model_family`, `model_name`) are the strongest signals; `model_name_normalized` is nearly as strong because it still resolves to an exact catalog entry; `model_pattern` is the weakest because a regex can overreach.
 
 If no vetted profile matches, Scrutiny falls back to the existing generic ATA rules.
+
+### Vendor-aware normalization
+
+The `model_name_normalized` stage strips well-known decorations from real-world model strings before retrying an exact lookup:
+
+- capacity suffixes: `Samsung SSD 870 EVO 2TB` -> `Samsung SSD 870 EVO`
+- WDC firmware suffixes: `WDC WD80EFAX-68LHPN0` -> `WDC WD80EFAX`
+- Seagate firmware suffixes: `ST4000DM000-1F2168` -> `ST4000DM000`
+
+This catches common variants (new capacity sizes, new firmware revisions) without broad regex rules that could create false positives.
+
+### Catalog source
 
 The bundled catalog is validated at startup and loaded from:
 
 - [consumer_drive_profiles.json](../webapp/backend/pkg/thresholds/consumer_drive_profiles.json)
 
-The catalog is shipped in-repo and embedded into the backend binary. Scrutiny does not fetch profile data at runtime.
+The catalog is shipped in-repo and embedded into the backend binary. Scrutiny does not fetch profile data at runtime. The catalog carries a `version` string that is reported through the API for provenance.
 
 ## Confidence Gate
 
 Profiles only apply when the catalog entry meets the minimum confidence threshold.
 
 - Default minimum sample count: `20`
-- A profile may raise that threshold if needed
+- A profile may raise that threshold via `min_samples`
 
 Low-confidence entries are ignored and fall back to generic ATA behavior.
 
 ## User Control
+
+### Global toggle
 
 The feature is enabled by default and can be disabled globally in the dashboard:
 
@@ -49,6 +68,37 @@ Persisted setting key:
 - `metrics.consumer_drive_profiles_enabled`
 
 When disabled, Scrutiny uses generic ATA rules even for drives that would otherwise match a profile.
+
+### Per-family denylist
+
+Operators can exclude specific profile families without disabling the whole feature:
+
+- `Settings` -> `Consumer Drive Profile Denylist`
+
+Persisted setting key:
+
+- `metrics.consumer_drive_profiles_denylist`
+
+The value is a comma-separated list of family names (for example `Seagate Barracuda 7200.14 (AF), Crucial MX500`). Names are matched case-insensitively after normalization, so `crucial mx500` and `Crucial MX500` are equivalent.
+
+### Precedence rules
+
+1. If the global toggle is off, no profiles are applied. The denylist is irrelevant.
+2. If the global toggle is on, a matched profile is applied unless its family is denylisted or it fails its confidence gate.
+3. A denylisted or low-confidence match does not end the lookup: weaker match stages are still consulted, so a drive whose family is denylisted can still match a different (allowed) family through its model name. In practice the stages almost always resolve to the same family.
+4. If nothing survives, the drive uses generic ATA rules.
+
+## Debug and Inspection Surface
+
+`GET /api/device/{id}/drive-profile` reports the full override path for a device without code tracing:
+
+- whether the feature is enabled and what is denylisted
+- whether the catalog matched the drive, via which `match_method`, and on which input value
+- the matched family, vendor, source, sample count, and confidence gate result
+- which ATA attributes would have observed-threshold or counter-severity overrides applied
+- a plain-language `fallback_reason` when generic ATA rules are in effect
+
+The catalog match is computed even when the feature is globally disabled, so you can see what would happen; the `applied` flag reflects the effective state.
 
 ## UI Behavior
 
@@ -66,4 +116,63 @@ On ATA drive detail pages, the replacement-risk card reports which path was used
 - `consumer_drive_profile_applied`
 - `consumer_drive_profile_family`
 
+When a profile is applied, the response also carries provenance fields (omitted when generic ATA logic is used):
+
+- `consumer_drive_profile_source` - curated dataset description
+- `consumer_drive_profile_sample_count` - sample size behind the profile
+- `consumer_drive_profile_match_method` - which lookup stage matched
+- `consumer_drive_profile_catalog_version` - bundled catalog version
+
 See [API.md](./API.md) and [openapi.yaml](./openapi.yaml) for the current contract.
+
+## Catalog Maintenance Workflow
+
+The catalog is a first-class artifact with its own lint pipeline. Before merging any catalog change, run:
+
+```bash
+make catalog-lint     # validate + lint + expected-match fixtures (strict: warnings fail)
+make catalog-fix      # rewrite the catalog in canonical form
+```
+
+Or invoke the tool directly for more control:
+
+```bash
+go run ./webapp/backend/cmd/catalog-lint -help
+```
+
+The pipeline enforces three layers:
+
+1. **Hard validation** (also runs at startup; a violation prevents the backend from booting):
+   - profiles must declare `model_family`, a non-empty `source`, a positive `sample_count`, and protocol `ATA`
+   - duplicate families, conflicting aliases, aliases pointing at unknown families, and invalid regex patterns are rejected
+   - counter severity overrides must satisfy `low <= moderate <= high <= critical`
+   - observed-threshold buckets must have `low <= high`, an `annual_failure_rate` in `[0, 1]`, and an ordered two-value `error_interval`
+2. **Lint warnings** (fail `make catalog-lint`, which runs in strict mode):
+   - dead entries that can never pass their own confidence gate
+   - regex patterns that shadow aliases or family names belonging to a different family
+   - duplicate patterns and redundant aliases
+   - a missing catalog `version`
+3. **Expected-match fixtures** ([testdata/consumer_drive_profile_fixtures.json](../webapp/backend/pkg/thresholds/testdata/consumer_drive_profile_fixtures.json)):
+   - representative real-world model strings pinned to their expected family and match method
+   - matched and unmatched cases both covered, so catalog edits that unintentionally change existing matches fail fast
+   - the same fixtures run in `go test ./webapp/backend/pkg/thresholds/`
+
+To add or update catalog entries:
+
+1. Edit `consumer_drive_profiles.json` (add the profile, aliases, and optionally a narrow `model_pattern`).
+2. Bump the catalog `version` field.
+3. Add expected-match fixtures for the new entries, including at least one near-miss that must stay unmatched.
+4. Run `make catalog-fix` to normalize formatting, then `make catalog-lint` until clean.
+5. Commit the catalog and fixtures together.
+
+The generated canonical JSON remains the embedded runtime source of truth; there is no runtime fetching.
+
+## Decision Record: Per-Family Weight Overrides
+
+**Status: evaluated and deferred (2026-07).**
+
+We considered letting profiles override the per-attribute weights used by replacement-risk scoring (for example, weighting attribute 5 more heavily for families with strong reallocated-sector failure correlation).
+
+The bundled catalog's evidence base (curated linuxhw/SMART population aggregates) supports family-level severity breakpoints and observed-threshold buckets, but it does not provide per-attribute failure *correlation* data per family. Deriving weight overrides from it would manufacture precision the source cannot defend: sample counts in the tens-to-thousands range are sufficient to say "this family tolerates a few reallocated sectors" but not "reallocated sectors predict failure 1.4x better than pending sectors for this family."
+
+Per-family weight overrides therefore do not ship. The existing protocol-level weights (informed by Backblaze failure-correlation research across large mixed fleets) remain in effect for all ATA drives. This decision should be revisited only if a dataset with per-family, per-attribute failure correlation becomes available; at that point support should be added narrowly, with tests and an explicit fallback path, per the acceptance criteria in issue #552.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -621,6 +621,29 @@ paths:
                 $ref: "#/components/schemas/ReplacementRiskResponse"
         "500":
           $ref: "#/components/responses/ErrorResponse"
+  /api/device/{id}/drive-profile:
+    get:
+      tags: [Devices]
+      summary: Inspect consumer drive profile matching for a device
+      description: |
+        Debug and inspection surface for the ATA consumer-drive profile system.
+        Reports which bundled catalog entry matched the device (if any), the match
+        method and confidence gate result, which overrides would be applied, and a
+        plain-language fallback reason when generic ATA rules are in effect.
+        The catalog match is computed even when the feature is globally disabled so
+        operators can inspect what would happen; the `applied` flag reflects the
+        effective state.
+      parameters:
+        - $ref: "#/components/parameters/DeviceId"
+      responses:
+        "200":
+          description: Drive profile match diagnostics
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DriveProfileInspectionResponse"
+        "404":
+          $ref: "#/components/responses/NotFound"
   /api/device/{id}/collector-error:
     post:
       tags: [Devices]
@@ -1343,6 +1366,12 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/ErrorResponse"
+    NotFound:
+      description: Requested resource was not found
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
   schemas:
     SuccessResponse:
       type: object
@@ -1804,6 +1833,9 @@ components:
             consumer_drive_profiles_enabled:
               type: boolean
               description: Enable vetted ATA consumer drive model or family overrides for SMART status evaluation and replacement-risk scoring. When false, all ATA devices use generic ATA rules.
+            consumer_drive_profiles_denylist:
+              type: string
+              description: Comma-separated consumer drive profile families that must never be applied. Matching drives fall back to generic ATA rules. Ignored when `consumer_drive_profiles_enabled` is false (everything already falls back). Empty means no families are excluded.
             notification_rate_limit:
               type: integer
             notification_quiet_start:
@@ -3287,6 +3319,19 @@ components:
             consumer_drive_profile_family:
               type: string
               description: Matched ATA consumer-drive profile family when `consumer_drive_profile_applied` is true.
+            consumer_drive_profile_source:
+              type: string
+              description: Provenance string of the applied profile (curated dataset description). Omitted when generic ATA logic is used.
+            consumer_drive_profile_sample_count:
+              type: integer
+              description: Sample size behind the applied profile. Omitted when generic ATA logic is used.
+            consumer_drive_profile_match_method:
+              type: string
+              enum: [model_family, model_name, model_name_normalized, model_pattern]
+              description: Lookup stage that matched the drive, strongest-first. Omitted when generic ATA logic is used.
+            consumer_drive_profile_catalog_version:
+              type: string
+              description: Version of the bundled profile catalog the applied profile came from. Omitted when generic ATA logic is used.
             contributions:
               type: array
               items:
@@ -3305,6 +3350,72 @@ components:
                     format: int64
                   trend_score:
                     type: number
+    DriveProfileInspectionResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+        data:
+          type: object
+          properties:
+            device_wwn:
+              type: string
+            device_protocol:
+              type: string
+            model_family:
+              type: string
+            model_name:
+              type: string
+            profiles_enabled:
+              type: boolean
+              description: Global consumer drive profiles toggle state.
+            denylist:
+              type: array
+              items:
+                type: string
+              description: Normalized family keys currently denylisted in settings.
+            catalog_version:
+              type: string
+              description: Version of the bundled profile catalog.
+            matched:
+              type: boolean
+              description: True when the catalog recognized this drive, regardless of whether the profile was applied.
+            applied:
+              type: boolean
+              description: True when the matched profile is actually used for SMART status evaluation and replacement-risk scoring.
+            match_method:
+              type: string
+              enum: [model_family, model_name, model_name_normalized, model_pattern]
+              description: Lookup stage that matched the drive.
+            matched_value:
+              type: string
+              description: Input value (family or model name) that matched.
+            profile_family:
+              type: string
+            profile_vendor:
+              type: string
+            profile_source:
+              type: string
+            sample_count:
+              type: integer
+            min_samples:
+              type: integer
+              description: Confidence gate the matched profile must satisfy.
+            confidence_met:
+              type: boolean
+            observed_threshold_attributes:
+              type: array
+              items:
+                type: integer
+              description: ATA attribute IDs whose observed-threshold buckets are overridden during SMART status evaluation.
+            counter_severity_attributes:
+              type: array
+              items:
+                type: string
+              description: ATA attribute IDs whose counter severity breakpoints are overridden during replacement-risk scoring.
+            fallback_reason:
+              type: string
+              description: Plain-language explanation of why generic ATA rules are in effect. Empty when a profile is applied.
     MissedPingStatusResponse:
       type: object
       properties:

--- a/webapp/backend/cmd/catalog-lint/catalog-lint.go
+++ b/webapp/backend/cmd/catalog-lint/catalog-lint.go
@@ -1,0 +1,112 @@
+// Command catalog-lint validates, lints, and canonicalizes the bundled ATA
+// consumer drive profile catalog. Run it locally before merging catalog edits:
+//
+//	go run ./webapp/backend/cmd/catalog-lint                # validate + lint + fixtures
+//	go run ./webapp/backend/cmd/catalog-lint -write         # also rewrite the catalog in canonical form
+//	go run ./webapp/backend/cmd/catalog-lint -strict        # treat lint warnings as failures
+//
+// The tool exits non-zero on validation errors, fixture mismatches, or (with
+// -strict) lint warnings. The canonical output written by -write is the exact
+// byte form embedded into the backend binary at build time.
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/analogj/scrutiny/webapp/backend/pkg/thresholds"
+)
+
+const (
+	defaultCatalogPath  = "webapp/backend/pkg/thresholds/consumer_drive_profiles.json"
+	defaultFixturesPath = "webapp/backend/pkg/thresholds/testdata/consumer_drive_profile_fixtures.json"
+)
+
+func main() {
+	catalogPath := flag.String("catalog", defaultCatalogPath, "path to the profile catalog JSON")
+	fixturesPath := flag.String("fixtures", defaultFixturesPath, "path to the expected-match fixtures JSON (empty to skip)")
+	write := flag.Bool("write", false, "rewrite the catalog file in canonical form")
+	strict := flag.Bool("strict", false, "treat lint warnings as failures")
+	flag.Parse()
+
+	if err := run(*catalogPath, *fixturesPath, *write, *strict); err != nil {
+		fmt.Fprintf(os.Stderr, "FAIL: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(catalogPath, fixturesPath string, write, strict bool) error {
+	data, err := os.ReadFile(catalogPath)
+	if err != nil {
+		return fmt.Errorf("read catalog: %w", err)
+	}
+
+	// Hard validation + lint warnings.
+	lintResult, err := thresholds.LintConsumerDriveProfileCatalog(data)
+	if err != nil {
+		return fmt.Errorf("catalog validation failed: %w", err)
+	}
+	for _, warning := range lintResult.Warnings {
+		fmt.Printf("WARN: %s\n", warning)
+	}
+
+	handle, err := thresholds.LoadConsumerDriveProfileCatalog(data)
+	if err != nil {
+		return fmt.Errorf("load catalog: %w", err)
+	}
+	fmt.Printf("OK: catalog is valid (version %q)\n", handle.Version())
+
+	// Expected-match fixtures.
+	if fixturesPath != "" {
+		if err := runFixtures(handle, fixturesPath); err != nil {
+			return err
+		}
+	}
+
+	// Canonical form check / rewrite.
+	canonical, err := thresholds.CanonicalizeConsumerDriveProfileCatalog(data)
+	if err != nil {
+		return fmt.Errorf("canonicalize catalog: %w", err)
+	}
+	if write {
+		if !bytes.Equal(canonical, data) {
+			if err := os.WriteFile(catalogPath, canonical, 0644); err != nil {
+				return fmt.Errorf("write canonical catalog: %w", err)
+			}
+			fmt.Printf("OK: rewrote %s in canonical form\n", catalogPath)
+		} else {
+			fmt.Println("OK: catalog already in canonical form")
+		}
+	} else if !bytes.Equal(canonical, data) {
+		fmt.Println("WARN: catalog is not in canonical form; run with -write to normalize it")
+		if strict {
+			return fmt.Errorf("catalog is not in canonical form")
+		}
+	}
+
+	if strict && len(lintResult.Warnings) > 0 {
+		return fmt.Errorf("%d lint warning(s) in strict mode", len(lintResult.Warnings))
+	}
+	return nil
+}
+
+func runFixtures(handle *thresholds.ConsumerDriveCatalogHandle, fixturesPath string) error {
+	fixtureData, err := os.ReadFile(fixturesPath)
+	if err != nil {
+		return fmt.Errorf("read fixtures: %w", err)
+	}
+	failures, err := thresholds.CheckConsumerDriveProfileFixtures(handle, fixtureData)
+	if err != nil {
+		return err
+	}
+	for _, failure := range failures {
+		fmt.Fprintf(os.Stderr, "FIXTURE FAIL: %s\n", failure)
+	}
+	if len(failures) > 0 {
+		return fmt.Errorf("%d fixture failure(s)", len(failures))
+	}
+	fmt.Println("OK: all expected-match fixtures pass")
+	return nil
+}

--- a/webapp/backend/cmd/catalog-lint/catalog-lint.go
+++ b/webapp/backend/cmd/catalog-lint/catalog-lint.go
@@ -60,34 +60,48 @@ func run(catalogPath, fixturesPath string, write, strict bool) error {
 
 	// Expected-match fixtures.
 	if fixturesPath != "" {
-		if err := runFixtures(handle, fixturesPath); err != nil {
-			return err
+		if fixturesErr := runFixtures(handle, fixturesPath); fixturesErr != nil {
+			return fixturesErr
 		}
 	}
 
 	// Canonical form check / rewrite.
-	canonical, err := thresholds.CanonicalizeConsumerDriveProfileCatalog(data)
-	if err != nil {
-		return fmt.Errorf("canonicalize catalog: %w", err)
-	}
-	if write {
-		if !bytes.Equal(canonical, data) {
-			if err := os.WriteFile(catalogPath, canonical, 0644); err != nil {
-				return fmt.Errorf("write canonical catalog: %w", err)
-			}
-			fmt.Printf("OK: rewrote %s in canonical form\n", catalogPath)
-		} else {
-			fmt.Println("OK: catalog already in canonical form")
-		}
-	} else if !bytes.Equal(canonical, data) {
-		fmt.Println("WARN: catalog is not in canonical form; run with -write to normalize it")
-		if strict {
-			return fmt.Errorf("catalog is not in canonical form")
-		}
+	if canonicalErr := checkCanonicalForm(catalogPath, data, write, strict); canonicalErr != nil {
+		return canonicalErr
 	}
 
 	if strict && len(lintResult.Warnings) > 0 {
 		return fmt.Errorf("%d lint warning(s) in strict mode", len(lintResult.Warnings))
+	}
+	return nil
+}
+
+// checkCanonicalForm compares the catalog against its canonical byte form and
+// either rewrites it (write) or reports drift (failing in strict mode).
+func checkCanonicalForm(catalogPath string, data []byte, write, strict bool) error {
+	canonical, err := thresholds.CanonicalizeConsumerDriveProfileCatalog(data)
+	if err != nil {
+		return fmt.Errorf("canonicalize catalog: %w", err)
+	}
+
+	if bytes.Equal(canonical, data) {
+		if write {
+			fmt.Println("OK: catalog already in canonical form")
+		}
+		return nil
+	}
+
+	if write {
+		if writeErr := os.WriteFile(catalogPath, canonical, 0600); writeErr != nil {
+			return fmt.Errorf("write canonical catalog: %w", writeErr)
+		}
+		fmt.Printf("OK: rewrote %s in canonical form\n", catalogPath)
+		return nil
+	}
+
+	fmt.Println("WARN: catalog is not in canonical form; run with -write to normalize it")
+	if strict {
+		return fmt.Errorf("catalog is not in canonical form")
 	}
 	return nil
 }

--- a/webapp/backend/pkg/database/scrutiny_repository_migrations.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_migrations.go
@@ -609,6 +609,10 @@ func (sr *scrutinyRepository) Migrate(ctx context.Context) error {
 				return tx.Create(&defaultSettings).Error
 			},
 		},
+		{
+			ID:      "m20260701000000", // add consumer drive profile family denylist setting (#552)
+			Migrate: sr.migrateM20260701000000,
+		},
 	})
 
 	if err := m.Migrate(); err != nil {
@@ -1539,4 +1543,23 @@ func buildLegacyScsiErrorLog(preSmartResult *m20201107210306.Smart) (int64, coll
 		}
 	}
 	return postScsiGrownDefectList, postScsiErrorCounterLog
+}
+
+// migrateM20260701000000 seeds the consumer drive profile family denylist setting (#552).
+func (sr *scrutinyRepository) migrateM20260701000000(tx *gorm.DB) error {
+	var count int64
+	if err := tx.Model(&m20220716214900.Setting{}).Where("setting_key_name = ?", "metrics.consumer_drive_profiles_denylist").Count(&count).Error; err != nil {
+		return err
+	}
+	if count > 0 {
+		return nil
+	}
+
+	defaultSetting := m20220716214900.Setting{
+		SettingKeyName:        "metrics.consumer_drive_profiles_denylist",
+		SettingKeyDescription: "Comma-separated consumer drive profile families excluded from profile matching (empty = none)",
+		SettingDataType:       "string",
+		SettingValueString:    "",
+	}
+	return tx.Create(&defaultSetting).Error
 }

--- a/webapp/backend/pkg/models/drive_profile_inspection.go
+++ b/webapp/backend/pkg/models/drive_profile_inspection.go
@@ -1,0 +1,81 @@
+package models
+
+// DriveProfileInspection is the diagnostic view of consumer drive profile
+// matching for a single device. It exposes the full override path: which
+// catalog entry matched, how it matched, whether the confidence gate passed,
+// which overrides would be applied, and why the drive fell back to generic
+// ATA rules when no profile is in effect.
+type DriveProfileInspection struct {
+	// DeviceWWN identifies the inspected drive.
+	DeviceWWN string `json:"device_wwn"`
+
+	// DeviceProtocol is the device protocol (ATA, NVMe, SCSI).
+	DeviceProtocol string `json:"device_protocol"`
+
+	// ModelFamily is the smartctl-reported model family used for matching.
+	ModelFamily string `json:"model_family,omitempty"`
+
+	// ModelName is the model name used for matching.
+	ModelName string `json:"model_name,omitempty"`
+
+	// ProfilesEnabled reports the global consumer drive profiles toggle.
+	ProfilesEnabled bool `json:"profiles_enabled"`
+
+	// Denylist echoes the normalized family keys currently denylisted in settings.
+	Denylist []string `json:"denylist,omitempty"`
+
+	// CatalogVersion is the version of the bundled profile catalog.
+	CatalogVersion string `json:"catalog_version,omitempty"`
+
+	// Matched reports whether the catalog recognized this drive at all,
+	// regardless of whether the profile was applied.
+	Matched bool `json:"matched"`
+
+	// Applied reports whether the matched profile is actually used for SMART
+	// status evaluation and replacement-risk scoring.
+	Applied bool `json:"applied"`
+
+	// MatchMethod is the lookup stage that matched: "model_family",
+	// "model_name", "model_name_normalized", or "model_pattern".
+	MatchMethod string `json:"match_method,omitempty"`
+
+	// MatchedValue is the input value (family or model name) that matched.
+	MatchedValue string `json:"matched_value,omitempty"`
+
+	// ProfileFamily is the matched catalog family.
+	ProfileFamily string `json:"profile_family,omitempty"`
+
+	// ProfileVendor is the vendor recorded on the matched profile.
+	ProfileVendor string `json:"profile_vendor,omitempty"`
+
+	// ProfileSource is the provenance string of the matched profile.
+	ProfileSource string `json:"profile_source,omitempty"`
+
+	// SampleCount is the sample size behind the matched profile.
+	SampleCount int `json:"sample_count,omitempty"`
+
+	// MinSamples is the confidence gate the matched profile must satisfy.
+	MinSamples int `json:"min_samples,omitempty"`
+
+	// ConfidenceMet reports whether the matched profile passes its confidence gate.
+	ConfidenceMet bool `json:"confidence_met"`
+
+	// ObservedThresholdAttributes lists ATA attribute IDs whose observed-threshold
+	// buckets are overridden by the matched profile during SMART status evaluation.
+	ObservedThresholdAttributes []int `json:"observed_threshold_attributes,omitempty"`
+
+	// CounterSeverityAttributes lists ATA attribute IDs whose counter severity
+	// breakpoints are overridden by the matched profile during replacement-risk scoring.
+	CounterSeverityAttributes []string `json:"counter_severity_attributes,omitempty"`
+
+	// FallbackReason explains, in plain language, why generic ATA rules are in
+	// effect. Empty when a profile is applied.
+	FallbackReason string `json:"fallback_reason,omitempty"`
+}
+
+// DriveProfileInspectionResponse is the API response envelope for the
+// GET /api/device/:wwn/drive-profile endpoint.
+type DriveProfileInspectionResponse struct {
+	Data    DriveProfileInspection `json:"data"`
+	Success bool                   `json:"success"`
+}

--- a/webapp/backend/pkg/models/drive_profile_inspection.go
+++ b/webapp/backend/pkg/models/drive_profile_inspection.go
@@ -18,22 +18,8 @@ type DriveProfileInspection struct {
 	// ModelName is the model name used for matching.
 	ModelName string `json:"model_name,omitempty"`
 
-	// ProfilesEnabled reports the global consumer drive profiles toggle.
-	ProfilesEnabled bool `json:"profiles_enabled"`
-
-	// Denylist echoes the normalized family keys currently denylisted in settings.
-	Denylist []string `json:"denylist,omitempty"`
-
 	// CatalogVersion is the version of the bundled profile catalog.
 	CatalogVersion string `json:"catalog_version,omitempty"`
-
-	// Matched reports whether the catalog recognized this drive at all,
-	// regardless of whether the profile was applied.
-	Matched bool `json:"matched"`
-
-	// Applied reports whether the matched profile is actually used for SMART
-	// status evaluation and replacement-risk scoring.
-	Applied bool `json:"applied"`
 
 	// MatchMethod is the lookup stage that matched: "model_family",
 	// "model_name", "model_name_normalized", or "model_pattern".
@@ -51,14 +37,12 @@ type DriveProfileInspection struct {
 	// ProfileSource is the provenance string of the matched profile.
 	ProfileSource string `json:"profile_source,omitempty"`
 
-	// SampleCount is the sample size behind the matched profile.
-	SampleCount int `json:"sample_count,omitempty"`
+	// FallbackReason explains, in plain language, why generic ATA rules are in
+	// effect. Empty when a profile is applied.
+	FallbackReason string `json:"fallback_reason,omitempty"`
 
-	// MinSamples is the confidence gate the matched profile must satisfy.
-	MinSamples int `json:"min_samples,omitempty"`
-
-	// ConfidenceMet reports whether the matched profile passes its confidence gate.
-	ConfidenceMet bool `json:"confidence_met"`
+	// Denylist echoes the normalized family keys currently denylisted in settings.
+	Denylist []string `json:"denylist,omitempty"`
 
 	// ObservedThresholdAttributes lists ATA attribute IDs whose observed-threshold
 	// buckets are overridden by the matched profile during SMART status evaluation.
@@ -68,9 +52,25 @@ type DriveProfileInspection struct {
 	// breakpoints are overridden by the matched profile during replacement-risk scoring.
 	CounterSeverityAttributes []string `json:"counter_severity_attributes,omitempty"`
 
-	// FallbackReason explains, in plain language, why generic ATA rules are in
-	// effect. Empty when a profile is applied.
-	FallbackReason string `json:"fallback_reason,omitempty"`
+	// SampleCount is the sample size behind the matched profile.
+	SampleCount int `json:"sample_count,omitempty"`
+
+	// MinSamples is the confidence gate the matched profile must satisfy.
+	MinSamples int `json:"min_samples,omitempty"`
+
+	// ProfilesEnabled reports the global consumer drive profiles toggle.
+	ProfilesEnabled bool `json:"profiles_enabled"`
+
+	// Matched reports whether the catalog recognized this drive at all,
+	// regardless of whether the profile was applied.
+	Matched bool `json:"matched"`
+
+	// Applied reports whether the matched profile is actually used for SMART
+	// status evaluation and replacement-risk scoring.
+	Applied bool `json:"applied"`
+
+	// ConfidenceMet reports whether the matched profile passes its confidence gate.
+	ConfidenceMet bool `json:"confidence_met"`
 }
 
 // DriveProfileInspectionResponse is the API response envelope for the

--- a/webapp/backend/pkg/models/measurements/smart.go
+++ b/webapp/backend/pkg/models/measurements/smart.go
@@ -256,10 +256,7 @@ func (sm *Smart) FromCollectorSmartInfoWithOverrides(cfg config.Interface, wwn s
 
 // generate SmartAtaAttribute entries from Scrutiny Collector Smart data.
 func (sm *Smart) ProcessAtaSmartInfo(cfg config.Interface, modelFamily string, modelName string, tableItems []collector.AtaSmartAttributesTableItem) {
-	var profile *thresholds.ConsumerDriveProfile
-	if consumerDriveProfilesEnabled(cfg) {
-		profile, _ = thresholds.LookupConsumerDriveProfile(pkg.DeviceProtocolAta, modelFamily, modelName)
-	}
+	profile := consumerDriveProfileForDevice(cfg, modelFamily, modelName)
 	for _, collectorAttr := range tableItems {
 		attrModel := SmartAtaAttribute{
 			AttributeId: collectorAttr.ID,
@@ -475,10 +472,7 @@ func (sm *Smart) ProcessScsiSmartInfo(cfg config.Interface, defectGrownList int6
 
 // processAtaSmartInfoWithOverrides generates SmartAtaAttribute entries using pre-merged overrides.
 func (sm *Smart) processAtaSmartInfoWithOverrides(cfg config.Interface, modelFamily string, modelName string, tableItems []collector.AtaSmartAttributesTableItem, mergedOverrides []overrides.AttributeOverride) {
-	var profile *thresholds.ConsumerDriveProfile
-	if consumerDriveProfilesEnabled(cfg) {
-		profile, _ = thresholds.LookupConsumerDriveProfile(pkg.DeviceProtocolAta, modelFamily, modelName)
-	}
+	profile := consumerDriveProfileForDevice(cfg, modelFamily, modelName)
 	for _, collectorAttr := range tableItems {
 		attrModel := SmartAtaAttribute{
 			AttributeId: collectorAttr.ID,
@@ -528,6 +522,24 @@ func consumerDriveProfilesEnabled(cfg config.Interface) bool {
 		return true
 	}
 	return cfg.GetBool(key)
+}
+
+// consumerDriveProfileForDevice resolves the applied consumer drive profile for
+// an ATA device, honoring the global toggle and the per-family denylist.
+func consumerDriveProfileForDevice(cfg config.Interface, modelFamily string, modelName string) *thresholds.ConsumerDriveProfile {
+	if !consumerDriveProfilesEnabled(cfg) {
+		return nil
+	}
+	var denied map[string]struct{}
+	if cfg != nil {
+		denied = thresholds.ParseConsumerDriveProfileDenylist(
+			cfg.GetString(config.DB_USER_SETTINGS_SUBKEY + ".metrics.consumer_drive_profiles_denylist"))
+	}
+	match := thresholds.MatchConsumerDriveProfile(pkg.DeviceProtocolAta, modelFamily, modelName, denied)
+	if match == nil || !match.Applied {
+		return nil
+	}
+	return match.Profile
 }
 
 // processAtaDeviceStatisticsWithOverrides extracts device statistics using pre-merged overrides.

--- a/webapp/backend/pkg/models/measurements/smart_test.go
+++ b/webapp/backend/pkg/models/measurements/smart_test.go
@@ -18,6 +18,7 @@ import (
 
 func expectConsumerDriveProfilesEnabledDefault(fakeConfig *mock_config.MockInterface) {
 	fakeConfig.EXPECT().IsSet("user.metrics.consumer_drive_profiles_enabled").Return(false).AnyTimes()
+	fakeConfig.EXPECT().GetString("user.metrics.consumer_drive_profiles_denylist").Return("").AnyTimes()
 }
 
 func TestSmart_Flatten(t *testing.T) {

--- a/webapp/backend/pkg/models/replacement_risk.go
+++ b/webapp/backend/pkg/models/replacement_risk.go
@@ -115,6 +115,23 @@ type ReplacementRiskScore struct {
 
 	// ConsumerDriveProfileFamily is the matched profile family when ConsumerDriveProfileApplied is true.
 	ConsumerDriveProfileFamily string `json:"consumer_drive_profile_family,omitempty"`
+
+	// ConsumerDriveProfileSource is the provenance string of the applied profile
+	// (curated dataset description). Omitted when generic ATA logic is used.
+	ConsumerDriveProfileSource string `json:"consumer_drive_profile_source,omitempty"`
+
+	// ConsumerDriveProfileSampleCount is the sample size behind the applied profile.
+	// Omitted when generic ATA logic is used.
+	ConsumerDriveProfileSampleCount int `json:"consumer_drive_profile_sample_count,omitempty"`
+
+	// ConsumerDriveProfileMatchMethod reports which lookup stage matched the drive:
+	// "model_family", "model_name", "model_name_normalized", or "model_pattern".
+	// Omitted when generic ATA logic is used.
+	ConsumerDriveProfileMatchMethod string `json:"consumer_drive_profile_match_method,omitempty"`
+
+	// ConsumerDriveProfileCatalogVersion is the bundled catalog version the applied
+	// profile came from. Omitted when generic ATA logic is used.
+	ConsumerDriveProfileCatalogVersion string `json:"consumer_drive_profile_catalog_version,omitempty"`
 }
 
 // ReplacementRiskResponse is the API response envelope for the

--- a/webapp/backend/pkg/models/settings.go
+++ b/webapp/backend/pkg/models/settings.go
@@ -28,6 +28,7 @@ type Settings struct {
 		ReportWeeklyDay               int    `json:"report_weekly_day" mapstructure:"report_weekly_day"`
 		MissedPingTimeoutMinutes      int    `json:"missed_ping_timeout_minutes" mapstructure:"missed_ping_timeout_minutes"`
 		UptimeKumaIntervalSeconds     int    `json:"uptime_kuma_interval_seconds" mapstructure:"uptime_kuma_interval_seconds"`
+		ConsumerDriveProfilesDenylist string `json:"consumer_drive_profiles_denylist" mapstructure:"consumer_drive_profiles_denylist"`
 		ReportEnabled                 bool   `json:"report_enabled" mapstructure:"report_enabled"`
 		ReportDailyEnabled            bool   `json:"report_daily_enabled" mapstructure:"report_daily_enabled"`
 		ConsumerDriveProfilesEnabled  bool   `json:"consumer_drive_profiles_enabled" mapstructure:"consumer_drive_profiles_enabled"`

--- a/webapp/backend/pkg/thresholds/consumer_drive_profiles.go
+++ b/webapp/backend/pkg/thresholds/consumer_drive_profiles.go
@@ -77,14 +77,14 @@ type ConsumerDriveProfileMatch struct {
 	// MatchedValue is the input value (family or model name) that matched.
 	MatchedValue string
 
-	// Applied reports whether the profile should be used for scoring.
-	Applied bool
-
 	// SkipReason explains why a matched profile was not applied. Empty when Applied.
 	SkipReason string
 
 	// CatalogVersion is the version string of the bundled catalog.
 	CatalogVersion string
+
+	// Applied reports whether the profile should be used for scoring.
+	Applied bool
 }
 
 func (p *ConsumerDriveProfile) MeetsConfidenceThreshold() bool {

--- a/webapp/backend/pkg/thresholds/consumer_drive_profiles.go
+++ b/webapp/backend/pkg/thresholds/consumer_drive_profiles.go
@@ -10,6 +10,33 @@ import (
 
 const MinConsumerDriveProfileSamples = 20
 
+// ProfileMatchMethod identifies which lookup stage produced a consumer drive
+// profile match. Stages are listed strongest-first: an exact model_family hit
+// is more trustworthy than a regex pattern fallback.
+type ProfileMatchMethod string
+
+const (
+	// ProfileMatchMethodModelFamily is an exact match on the smartctl-reported model family.
+	ProfileMatchMethodModelFamily ProfileMatchMethod = "model_family"
+
+	// ProfileMatchMethodModelName is an exact match on the normalized model name (alias table).
+	ProfileMatchMethodModelName ProfileMatchMethod = "model_name"
+
+	// ProfileMatchMethodModelNameNormalized is an exact match after vendor-aware
+	// normalization (capacity suffix or firmware suffix stripped).
+	ProfileMatchMethodModelNameNormalized ProfileMatchMethod = "model_name_normalized"
+
+	// ProfileMatchMethodModelPattern is a regex model_pattern fallback match.
+	ProfileMatchMethodModelPattern ProfileMatchMethod = "model_pattern"
+)
+
+// Skip reasons reported on a ConsumerDriveProfileMatch that was found in the
+// catalog but intentionally not applied.
+const (
+	ProfileSkipReasonBelowConfidence  = "below_confidence_threshold"
+	ProfileSkipReasonFamilyDenylisted = "family_denylisted"
+)
+
 type CounterSeverityProfile struct {
 	Low      int64 `json:"low"`
 	Moderate int64 `json:"moderate"`
@@ -32,8 +59,32 @@ type ConsumerDriveProfile struct {
 }
 
 type consumerDriveProfileCatalog struct {
+	Version  string                 `json:"version,omitempty"`
 	Aliases  map[string]string      `json:"aliases"`
 	Profiles []ConsumerDriveProfile `json:"profiles"`
+}
+
+// ConsumerDriveProfileMatch describes the outcome of matching a device against
+// the bundled profile catalog. A non-nil match means the catalog recognized the
+// drive; Applied reports whether the profile was actually used (confidence gate
+// passed and family not denylisted).
+type ConsumerDriveProfileMatch struct {
+	Profile *ConsumerDriveProfile
+
+	// Method identifies the lookup stage that produced this match.
+	Method ProfileMatchMethod
+
+	// MatchedValue is the input value (family or model name) that matched.
+	MatchedValue string
+
+	// Applied reports whether the profile should be used for scoring.
+	Applied bool
+
+	// SkipReason explains why a matched profile was not applied. Empty when Applied.
+	SkipReason string
+
+	// CatalogVersion is the version string of the bundled catalog.
+	CatalogVersion string
 }
 
 func (p *ConsumerDriveProfile) MeetsConfidenceThreshold() bool {
@@ -44,58 +95,68 @@ func (p *ConsumerDriveProfile) MeetsConfidenceThreshold() bool {
 	return p.SampleCount >= minSamples
 }
 
+// EffectiveMinSamples returns the confidence gate this profile must satisfy.
+func (p *ConsumerDriveProfile) EffectiveMinSamples() int {
+	if p.MinSamples > 0 {
+		return p.MinSamples
+	}
+	return MinConsumerDriveProfileSamples
+}
+
 //go:embed consumer_drive_profiles.json
 var consumerDriveProfilesJSON []byte
 
-var (
-	consumerDriveProfilesByFamily map[string]ConsumerDriveProfile
-	consumerDriveProfilesByModel  map[string]ConsumerDriveProfile
-	consumerDriveProfilesByRegex  []ConsumerDriveProfile
-)
+type loadedConsumerDriveCatalog struct {
+	version  string
+	byFamily map[string]ConsumerDriveProfile
+	byModel  map[string]ConsumerDriveProfile
+	byRegex  []ConsumerDriveProfile
+}
+
+var consumerDriveCatalog *loadedConsumerDriveCatalog
 
 func init() {
-	if err := loadConsumerDriveProfiles(); err != nil {
+	catalog, err := parseConsumerDriveProfiles(consumerDriveProfilesJSON)
+	if err != nil {
 		panic(err)
 	}
+	consumerDriveCatalog = catalog
+}
+
+// ConsumerDriveProfileCatalogVersion returns the version string of the bundled catalog.
+func ConsumerDriveProfileCatalogVersion() string {
+	return consumerDriveCatalog.version
 }
 
 func ValidateConsumerDriveProfileCatalog(data []byte) error {
-	_, _, _, err := parseConsumerDriveProfiles(data)
+	_, err := parseConsumerDriveProfiles(data)
 	return err
 }
 
-func loadConsumerDriveProfiles() error {
-	byFamily, byModel, regexProfiles, err := parseConsumerDriveProfiles(consumerDriveProfilesJSON)
-	if err != nil {
-		return err
-	}
-	consumerDriveProfilesByFamily = byFamily
-	consumerDriveProfilesByModel = byModel
-	consumerDriveProfilesByRegex = regexProfiles
-	return nil
-}
-
-func parseConsumerDriveProfiles(data []byte) (map[string]ConsumerDriveProfile, map[string]ConsumerDriveProfile, []ConsumerDriveProfile, error) {
+func parseConsumerDriveProfiles(data []byte) (*loadedConsumerDriveCatalog, error) {
 	var catalog consumerDriveProfileCatalog
 	if err := json.Unmarshal(data, &catalog); err != nil {
-		return nil, nil, nil, fmt.Errorf("unmarshal consumer drive profiles: %w", err)
+		return nil, fmt.Errorf("unmarshal consumer drive profiles: %w", err)
 	}
 
-	byFamily := make(map[string]ConsumerDriveProfile, len(catalog.Profiles))
-	regexProfiles := make([]ConsumerDriveProfile, 0)
+	loaded := &loadedConsumerDriveCatalog{
+		version:  catalog.Version,
+		byFamily: make(map[string]ConsumerDriveProfile, len(catalog.Profiles)),
+		byModel:  make(map[string]ConsumerDriveProfile, len(catalog.Aliases)),
+		byRegex:  make([]ConsumerDriveProfile, 0),
+	}
 	for i := range catalog.Profiles {
-		if err := addConsumerDriveProfile(&catalog.Profiles[i], byFamily, &regexProfiles); err != nil {
-			return nil, nil, nil, err
+		if err := addConsumerDriveProfile(&catalog.Profiles[i], loaded.byFamily, &loaded.byRegex); err != nil {
+			return nil, err
 		}
 	}
 
-	byModel := make(map[string]ConsumerDriveProfile, len(catalog.Aliases))
 	for modelAlias, family := range catalog.Aliases {
-		if err := addConsumerDriveAlias(modelAlias, family, byFamily, byModel); err != nil {
-			return nil, nil, nil, err
+		if err := addConsumerDriveAlias(modelAlias, family, loaded.byFamily, loaded.byModel); err != nil {
+			return nil, err
 		}
 	}
-	return byFamily, byModel, regexProfiles, nil
+	return loaded, nil
 }
 
 // addConsumerDriveProfile validates a single profile and registers it under its normalized family
@@ -104,12 +165,27 @@ func addConsumerDriveProfile(profile *ConsumerDriveProfile, byFamily map[string]
 	if profile.ModelFamily == "" {
 		return fmt.Errorf("profile missing model_family")
 	}
+	if !strings.EqualFold(profile.Protocol, "ATA") {
+		return fmt.Errorf("profile %q has unsupported protocol %q (only ATA is supported)", profile.ModelFamily, profile.Protocol)
+	}
+	if strings.TrimSpace(profile.Source) == "" {
+		return fmt.Errorf("profile %q missing source", profile.ModelFamily)
+	}
+	if profile.SampleCount <= 0 {
+		return fmt.Errorf("profile %q has non-positive sample_count %d", profile.ModelFamily, profile.SampleCount)
+	}
+	if profile.MinSamples < 0 {
+		return fmt.Errorf("profile %q has negative min_samples %d", profile.ModelFamily, profile.MinSamples)
+	}
 	familyKey := normalizeConsumerDriveKey(profile.ModelFamily)
 	if familyKey == "" {
 		return fmt.Errorf("profile has empty normalized family for %q", profile.ModelFamily)
 	}
 	if _, exists := byFamily[familyKey]; exists {
 		return fmt.Errorf("duplicate profile family %q", profile.ModelFamily)
+	}
+	if err := validateConsumerDriveOverrides(profile); err != nil {
+		return err
 	}
 	if profile.ModelPattern != "" {
 		compiled, err := regexp.Compile(profile.ModelPattern)
@@ -120,6 +196,42 @@ func addConsumerDriveProfile(profile *ConsumerDriveProfile, byFamily map[string]
 		*regexProfiles = append(*regexProfiles, *profile)
 	}
 	byFamily[familyKey] = *profile
+	return nil
+}
+
+// validateConsumerDriveOverrides applies structural sanity rules to a profile's
+// severity overrides and observed-threshold buckets.
+func validateConsumerDriveOverrides(profile *ConsumerDriveProfile) error {
+	for attrID, sev := range profile.AtaCounterSeverityOverrides {
+		if sev.Low < 0 || sev.Moderate < sev.Low || sev.High < sev.Moderate || sev.Critical < sev.High {
+			return fmt.Errorf("profile %q attribute %s severity override violates low <= moderate <= high <= critical ordering", profile.ModelFamily, attrID)
+		}
+	}
+	for attrID, buckets := range profile.AtaObservedThresholds {
+		for _, bucket := range buckets {
+			if err := validateObservedThresholdBucket(bucket); err != nil {
+				return fmt.Errorf("profile %q attribute %d: %w", profile.ModelFamily, attrID, err)
+			}
+		}
+	}
+	return nil
+}
+
+// validateObservedThresholdBucket checks a single observed-threshold bucket for
+// structural validity.
+func validateObservedThresholdBucket(bucket ObservedThreshold) error {
+	if bucket.Low > bucket.High {
+		return fmt.Errorf("observed threshold bucket has low > high")
+	}
+	if bucket.AnnualFailureRate < 0 || bucket.AnnualFailureRate > 1 {
+		return fmt.Errorf("annual_failure_rate outside [0, 1]")
+	}
+	if len(bucket.ErrorInterval) != 0 && len(bucket.ErrorInterval) != 2 {
+		return fmt.Errorf("error_interval must have exactly 2 values")
+	}
+	if len(bucket.ErrorInterval) == 2 && bucket.ErrorInterval[0] > bucket.ErrorInterval[1] {
+		return fmt.Errorf("error_interval is not ordered")
+	}
 	return nil
 }
 
@@ -144,24 +256,189 @@ func addConsumerDriveAlias(modelAlias, family string, byFamily, byModel map[stri
 	return nil
 }
 
-func LookupConsumerDriveProfile(protocol, modelFamily, modelName string) (*ConsumerDriveProfile, bool) {
+// ParseConsumerDriveProfileDenylist converts a comma-separated list of family
+// names into a set of normalized family keys. Empty entries are ignored.
+func ParseConsumerDriveProfileDenylist(csv string) map[string]struct{} {
+	if strings.TrimSpace(csv) == "" {
+		return nil
+	}
+	denied := map[string]struct{}{}
+	for _, entry := range strings.Split(csv, ",") {
+		key := normalizeConsumerDriveKey(entry)
+		if key == "" {
+			continue
+		}
+		denied[key] = struct{}{}
+	}
+	if len(denied) == 0 {
+		return nil
+	}
+	return denied
+}
+
+// consumerDriveProfileCandidate is an intermediate raw catalog hit before
+// confidence gating and denylist filtering.
+type consumerDriveProfileCandidate struct {
+	profile      *ConsumerDriveProfile
+	method       ProfileMatchMethod
+	matchedValue string
+}
+
+// MatchConsumerDriveProfile matches a device against the bundled profile
+// catalog and reports full match metadata. deniedFamilies contains normalized
+// family keys (see ParseConsumerDriveProfileDenylist) that must not be applied.
+//
+// Lookup stages run strongest-first: exact model_family, exact model_name
+// (alias table), vendor-normalized model_name, then regex model_pattern.
+// A candidate that fails the confidence gate or is denylisted is skipped and
+// weaker stages are still consulted. When no candidate can be applied, the
+// first skipped candidate is returned (Applied=false) so callers can explain
+// why the drive fell back to generic ATA rules. Returns nil when the catalog
+// does not recognize the drive at all.
+func MatchConsumerDriveProfile(protocol, modelFamily, modelName string, deniedFamilies map[string]struct{}) *ConsumerDriveProfileMatch {
+	return consumerDriveCatalog.match(protocol, modelFamily, modelName, deniedFamilies)
+}
+
+// ConsumerDriveCatalogHandle wraps a parsed catalog document so tooling (the
+// catalog-lint CLI, tests) can run matches against a catalog file on disk
+// instead of the embedded bundle.
+type ConsumerDriveCatalogHandle struct {
+	loaded *loadedConsumerDriveCatalog
+}
+
+// LoadConsumerDriveProfileCatalog parses and validates a catalog document and
+// returns a handle for running matches against it.
+func LoadConsumerDriveProfileCatalog(data []byte) (*ConsumerDriveCatalogHandle, error) {
+	loaded, err := parseConsumerDriveProfiles(data)
+	if err != nil {
+		return nil, err
+	}
+	return &ConsumerDriveCatalogHandle{loaded: loaded}, nil
+}
+
+// Match runs the same matching pipeline as MatchConsumerDriveProfile against
+// this handle's catalog.
+func (h *ConsumerDriveCatalogHandle) Match(protocol, modelFamily, modelName string, deniedFamilies map[string]struct{}) *ConsumerDriveProfileMatch {
+	return h.loaded.match(protocol, modelFamily, modelName, deniedFamilies)
+}
+
+// Version returns the catalog document's version string.
+func (h *ConsumerDriveCatalogHandle) Version() string {
+	return h.loaded.version
+}
+
+func (lc *loadedConsumerDriveCatalog) match(protocol, modelFamily, modelName string, deniedFamilies map[string]struct{}) *ConsumerDriveProfileMatch {
 	if !strings.EqualFold(protocol, "ATA") {
-		return nil, false
+		return nil
 	}
 
-	if profile, ok := consumerDriveProfilesByFamily[normalizeConsumerDriveKey(modelFamily)]; ok && profile.MeetsConfidenceThreshold() {
-		return &profile, true
-	}
-	if profile, ok := consumerDriveProfilesByModel[normalizeConsumerDriveKey(modelName)]; ok && profile.MeetsConfidenceThreshold() {
-		return &profile, true
-	}
-	for i := range consumerDriveProfilesByRegex {
-		profile := &consumerDriveProfilesByRegex[i]
-		if profile.compiledPattern != nil && profile.compiledPattern.MatchString(modelName) && profile.MeetsConfidenceThreshold() {
-			return profile, true
+	var firstSkipped *ConsumerDriveProfileMatch
+	for _, candidate := range lc.candidates(modelFamily, modelName) {
+		match := &ConsumerDriveProfileMatch{
+			Profile:        candidate.profile,
+			Method:         candidate.method,
+			MatchedValue:   candidate.matchedValue,
+			CatalogVersion: lc.version,
+		}
+		if _, denied := deniedFamilies[normalizeConsumerDriveKey(candidate.profile.ModelFamily)]; denied {
+			match.SkipReason = ProfileSkipReasonFamilyDenylisted
+		} else if !candidate.profile.MeetsConfidenceThreshold() {
+			match.SkipReason = ProfileSkipReasonBelowConfidence
+		} else {
+			match.Applied = true
+			return match
+		}
+		if firstSkipped == nil {
+			firstSkipped = match
 		}
 	}
-	return nil, false
+	return firstSkipped
+}
+
+// candidates returns raw catalog hits ordered strongest-first.
+func (lc *loadedConsumerDriveCatalog) candidates(modelFamily, modelName string) []consumerDriveProfileCandidate {
+	candidates := make([]consumerDriveProfileCandidate, 0, 2)
+
+	if profile, ok := lc.byFamily[normalizeConsumerDriveKey(modelFamily)]; ok {
+		candidates = append(candidates, consumerDriveProfileCandidate{&profile, ProfileMatchMethodModelFamily, modelFamily})
+	}
+	if profile, ok := lc.byModel[normalizeConsumerDriveKey(modelName)]; ok {
+		candidates = append(candidates, consumerDriveProfileCandidate{&profile, ProfileMatchMethodModelName, modelName})
+	}
+	for _, key := range consumerDriveModelNameVariants(modelName) {
+		if profile, ok := lc.byModel[key]; ok {
+			candidates = append(candidates, consumerDriveProfileCandidate{&profile, ProfileMatchMethodModelNameNormalized, modelName})
+			continue
+		}
+		if profile, ok := lc.byFamily[key]; ok {
+			candidates = append(candidates, consumerDriveProfileCandidate{&profile, ProfileMatchMethodModelNameNormalized, modelName})
+		}
+	}
+	for i := range lc.byRegex {
+		profile := lc.byRegex[i]
+		if profile.compiledPattern != nil && profile.compiledPattern.MatchString(modelName) {
+			candidates = append(candidates, consumerDriveProfileCandidate{&profile, ProfileMatchMethodModelPattern, modelName})
+		}
+	}
+	return candidates
+}
+
+// LookupConsumerDriveProfile returns the applied profile for a device, if any.
+// It is a convenience wrapper around MatchConsumerDriveProfile without denylist
+// filtering; callers that need match metadata or denylist support should use
+// MatchConsumerDriveProfile directly.
+func LookupConsumerDriveProfile(protocol, modelFamily, modelName string) (*ConsumerDriveProfile, bool) {
+	match := MatchConsumerDriveProfile(protocol, modelFamily, modelName, nil)
+	if match == nil || !match.Applied {
+		return nil, false
+	}
+	return match.Profile, true
+}
+
+var (
+	// capacity suffix: " 500GB", "_1TB", "-2.5TB" at end of model name
+	consumerDriveCapacitySuffixPattern = regexp.MustCompile(`(?i)[\s_-]+\d+(\.\d+)?\s?(gb|tb)$`)
+	// WDC firmware suffix: "WDC WD80EFAX-68LHPN0" -> "WDC WD80EFAX"
+	consumerDriveWdcFirmwarePattern = regexp.MustCompile(`(?i)^(wdc[\s_]+wd[0-9a-z]+)-[0-9a-z]{6,10}$`)
+	// Seagate firmware suffix: "ST4000DM000-1F2168" -> "ST4000DM000"
+	consumerDriveSeagateFirmwarePattern = regexp.MustCompile(`(?i)^(st\d+[a-z]{2}\d{3}[a-z]?)-[0-9a-z]+$`)
+)
+
+// consumerDriveModelNameVariants generates vendor-aware normalized lookup keys
+// for a raw model name. Each variant strips one well-known decoration (capacity
+// suffix, vendor firmware suffix) so real-world model strings can hit exact
+// alias or family entries without resorting to broad regex patterns.
+func consumerDriveModelNameVariants(modelName string) []string {
+	trimmed := strings.TrimSpace(modelName)
+	if trimmed == "" {
+		return nil
+	}
+	base := normalizeConsumerDriveKey(trimmed)
+
+	variants := make([]string, 0, 2)
+	appendVariant := func(candidate string) {
+		key := normalizeConsumerDriveKey(candidate)
+		if key == "" || key == base {
+			return
+		}
+		for _, existing := range variants {
+			if existing == key {
+				return
+			}
+		}
+		variants = append(variants, key)
+	}
+
+	if stripped := consumerDriveCapacitySuffixPattern.ReplaceAllString(trimmed, ""); stripped != trimmed {
+		appendVariant(stripped)
+	}
+	if m := consumerDriveWdcFirmwarePattern.FindStringSubmatch(trimmed); m != nil {
+		appendVariant(m[1])
+	}
+	if m := consumerDriveSeagateFirmwarePattern.FindStringSubmatch(trimmed); m != nil {
+		appendVariant(m[1])
+	}
+	return variants
 }
 
 func normalizeConsumerDriveKey(value string) string {

--- a/webapp/backend/pkg/thresholds/consumer_drive_profiles.json
+++ b/webapp/backend/pkg/thresholds/consumer_drive_profiles.json
@@ -1,584 +1,1598 @@
 {
+  "version": "2026.07.0",
   "profiles": [
     {
       "protocol": "ATA",
       "source": "linuxhw/SMART curated consumer SSD profile",
       "vendor": "Samsung",
       "model_family": "Samsung based SSDs",
-      "sample_count": 200,
       "ata_counter_severity_overrides": {
-        "5": { "low": 0, "moderate": 2, "high": 8, "critical": 24 },
-        "196": { "low": 0, "moderate": 2, "high": 8, "critical": 24 },
-        "197": { "low": 0, "moderate": 1, "high": 4, "critical": 12 },
-        "198": { "low": 0, "moderate": 1, "high": 4, "critical": 12 }
-      }
+        "196": {
+          "low": 0,
+          "moderate": 2,
+          "high": 8,
+          "critical": 24
+        },
+        "197": {
+          "low": 0,
+          "moderate": 1,
+          "high": 4,
+          "critical": 12
+        },
+        "198": {
+          "low": 0,
+          "moderate": 1,
+          "high": 4,
+          "critical": 12
+        },
+        "5": {
+          "low": 0,
+          "moderate": 2,
+          "high": 8,
+          "critical": 24
+        }
+      },
+      "sample_count": 200
     },
     {
       "protocol": "ATA",
       "source": "linuxhw/SMART curated consumer HDD profile",
       "vendor": "Hitachi",
       "model_family": "Hitachi Deskstar 7K1000.D",
-      "sample_count": 41,
       "ata_observed_thresholds": {
         "5": [
-          { "low": 0, "high": 0, "annual_failure_rate": 0.02, "error_interval": [0.01, 0.03] },
-          { "low": 1, "high": 8, "annual_failure_rate": 0.06, "error_interval": [0.03, 0.1] },
-          { "low": 8, "high": 32, "annual_failure_rate": 0.18, "error_interval": [0.1, 0.27] },
-          { "low": 32, "high": 128, "annual_failure_rate": 0.35, "error_interval": [0.22, 0.49] }
+          {
+            "low": 0,
+            "high": 0,
+            "annual_failure_rate": 0.02,
+            "error_interval": [
+              0.01,
+              0.03
+            ]
+          },
+          {
+            "low": 1,
+            "high": 8,
+            "annual_failure_rate": 0.06,
+            "error_interval": [
+              0.03,
+              0.1
+            ]
+          },
+          {
+            "low": 8,
+            "high": 32,
+            "annual_failure_rate": 0.18,
+            "error_interval": [
+              0.1,
+              0.27
+            ]
+          },
+          {
+            "low": 32,
+            "high": 128,
+            "annual_failure_rate": 0.35,
+            "error_interval": [
+              0.22,
+              0.49
+            ]
+          }
         ]
       },
       "ata_counter_severity_overrides": {
-        "5": { "low": 0, "moderate": 4, "high": 16, "critical": 48 },
-        "196": { "low": 0, "moderate": 4, "high": 16, "critical": 48 },
-        "197": { "low": 0, "moderate": 2, "high": 8, "critical": 24 },
-        "198": { "low": 0, "moderate": 2, "high": 8, "critical": 24 },
-        "10": { "low": 0, "moderate": 1, "high": 3, "critical": 8 }
-      }
+        "10": {
+          "low": 0,
+          "moderate": 1,
+          "high": 3,
+          "critical": 8
+        },
+        "196": {
+          "low": 0,
+          "moderate": 4,
+          "high": 16,
+          "critical": 48
+        },
+        "197": {
+          "low": 0,
+          "moderate": 2,
+          "high": 8,
+          "critical": 24
+        },
+        "198": {
+          "low": 0,
+          "moderate": 2,
+          "high": 8,
+          "critical": 24
+        },
+        "5": {
+          "low": 0,
+          "moderate": 4,
+          "high": 16,
+          "critical": 48
+        }
+      },
+      "sample_count": 41
     },
     {
       "protocol": "ATA",
       "source": "linuxhw/SMART curated consumer HDD profile",
       "vendor": "WDC",
       "model_family": "WDC Red",
-      "sample_count": 44,
-      "model_pattern": "^(WDC[_ ]WD(80EFAX|60EFRX|30EFRX).*)$",
       "ata_observed_thresholds": {
         "5": [
-          { "low": 0, "high": 0, "annual_failure_rate": 0.02, "error_interval": [0.01, 0.03] },
-          { "low": 1, "high": 4, "annual_failure_rate": 0.05, "error_interval": [0.03, 0.08] },
-          { "low": 4, "high": 16, "annual_failure_rate": 0.14, "error_interval": [0.09, 0.2] },
-          { "low": 16, "high": 64, "annual_failure_rate": 0.28, "error_interval": [0.19, 0.38] }
+          {
+            "low": 0,
+            "high": 0,
+            "annual_failure_rate": 0.02,
+            "error_interval": [
+              0.01,
+              0.03
+            ]
+          },
+          {
+            "low": 1,
+            "high": 4,
+            "annual_failure_rate": 0.05,
+            "error_interval": [
+              0.03,
+              0.08
+            ]
+          },
+          {
+            "low": 4,
+            "high": 16,
+            "annual_failure_rate": 0.14,
+            "error_interval": [
+              0.09,
+              0.2
+            ]
+          },
+          {
+            "low": 16,
+            "high": 64,
+            "annual_failure_rate": 0.28,
+            "error_interval": [
+              0.19,
+              0.38
+            ]
+          }
         ]
       },
       "ata_counter_severity_overrides": {
-        "5": { "low": 0, "moderate": 2, "high": 8, "critical": 24 },
-        "196": { "low": 0, "moderate": 2, "high": 8, "critical": 24 },
-        "197": { "low": 0, "moderate": 1, "high": 4, "critical": 12 },
-        "198": { "low": 0, "moderate": 1, "high": 4, "critical": 12 },
-        "10": { "low": 0, "moderate": 1, "high": 2, "critical": 6 }
-      }
+        "10": {
+          "low": 0,
+          "moderate": 1,
+          "high": 2,
+          "critical": 6
+        },
+        "196": {
+          "low": 0,
+          "moderate": 2,
+          "high": 8,
+          "critical": 24
+        },
+        "197": {
+          "low": 0,
+          "moderate": 1,
+          "high": 4,
+          "critical": 12
+        },
+        "198": {
+          "low": 0,
+          "moderate": 1,
+          "high": 4,
+          "critical": 12
+        },
+        "5": {
+          "low": 0,
+          "moderate": 2,
+          "high": 8,
+          "critical": 24
+        }
+      },
+      "model_pattern": "^(WDC[_ ]WD(80EFAX|60EFRX|30EFRX).*)$",
+      "sample_count": 44
     },
     {
       "protocol": "ATA",
       "source": "linuxhw/SMART curated consumer HDD profile",
       "vendor": "WDC",
       "model_family": "WDC Red Plus",
-      "sample_count": 147,
-      "model_pattern": "^(WDC[_ ]WD140EDFZ.*)$",
       "ata_observed_thresholds": {
         "5": [
-          { "low": 0, "high": 0, "annual_failure_rate": 0.01, "error_interval": [0.005, 0.02] },
-          { "low": 1, "high": 4, "annual_failure_rate": 0.03, "error_interval": [0.02, 0.05] },
-          { "low": 4, "high": 16, "annual_failure_rate": 0.09, "error_interval": [0.06, 0.13] },
-          { "low": 16, "high": 64, "annual_failure_rate": 0.18, "error_interval": [0.12, 0.25] }
+          {
+            "low": 0,
+            "high": 0,
+            "annual_failure_rate": 0.01,
+            "error_interval": [
+              0.005,
+              0.02
+            ]
+          },
+          {
+            "low": 1,
+            "high": 4,
+            "annual_failure_rate": 0.03,
+            "error_interval": [
+              0.02,
+              0.05
+            ]
+          },
+          {
+            "low": 4,
+            "high": 16,
+            "annual_failure_rate": 0.09,
+            "error_interval": [
+              0.06,
+              0.13
+            ]
+          },
+          {
+            "low": 16,
+            "high": 64,
+            "annual_failure_rate": 0.18,
+            "error_interval": [
+              0.12,
+              0.25
+            ]
+          }
         ]
       },
       "ata_counter_severity_overrides": {
-        "5": { "low": 0, "moderate": 3, "high": 10, "critical": 28 },
-        "196": { "low": 0, "moderate": 3, "high": 10, "critical": 28 },
-        "197": { "low": 0, "moderate": 2, "high": 6, "critical": 16 },
-        "198": { "low": 0, "moderate": 2, "high": 6, "critical": 16 },
-        "10": { "low": 0, "moderate": 1, "high": 3, "critical": 8 }
-      }
+        "10": {
+          "low": 0,
+          "moderate": 1,
+          "high": 3,
+          "critical": 8
+        },
+        "196": {
+          "low": 0,
+          "moderate": 3,
+          "high": 10,
+          "critical": 28
+        },
+        "197": {
+          "low": 0,
+          "moderate": 2,
+          "high": 6,
+          "critical": 16
+        },
+        "198": {
+          "low": 0,
+          "moderate": 2,
+          "high": 6,
+          "critical": 16
+        },
+        "5": {
+          "low": 0,
+          "moderate": 3,
+          "high": 10,
+          "critical": 28
+        }
+      },
+      "model_pattern": "^(WDC[_ ]WD140EDFZ.*)$",
+      "sample_count": 147
     },
     {
       "protocol": "ATA",
       "source": "linuxhw/SMART curated consumer HDD profile",
       "vendor": "Seagate",
       "model_family": "Seagate Desktop SSHD",
-      "sample_count": 322,
-      "model_pattern": "^ST6000DX000-1H217Z$",
       "ata_observed_thresholds": {
         "5": [
-          { "low": 0, "high": 0, "annual_failure_rate": 0.03, "error_interval": [0.02, 0.05] },
-          { "low": 1, "high": 4, "annual_failure_rate": 0.08, "error_interval": [0.05, 0.11] },
-          { "low": 4, "high": 16, "annual_failure_rate": 0.17, "error_interval": [0.12, 0.23] },
-          { "low": 16, "high": 64, "annual_failure_rate": 0.33, "error_interval": [0.24, 0.43] }
+          {
+            "low": 0,
+            "high": 0,
+            "annual_failure_rate": 0.03,
+            "error_interval": [
+              0.02,
+              0.05
+            ]
+          },
+          {
+            "low": 1,
+            "high": 4,
+            "annual_failure_rate": 0.08,
+            "error_interval": [
+              0.05,
+              0.11
+            ]
+          },
+          {
+            "low": 4,
+            "high": 16,
+            "annual_failure_rate": 0.17,
+            "error_interval": [
+              0.12,
+              0.23
+            ]
+          },
+          {
+            "low": 16,
+            "high": 64,
+            "annual_failure_rate": 0.33,
+            "error_interval": [
+              0.24,
+              0.43
+            ]
+          }
         ]
       },
       "ata_counter_severity_overrides": {
-        "5": { "low": 0, "moderate": 1, "high": 6, "critical": 18 },
-        "196": { "low": 0, "moderate": 1, "high": 6, "critical": 18 },
-        "197": { "low": 0, "moderate": 1, "high": 3, "critical": 10 },
-        "198": { "low": 0, "moderate": 1, "high": 3, "critical": 10 },
-        "10": { "low": 0, "moderate": 1, "high": 2, "critical": 5 }
-      }
+        "10": {
+          "low": 0,
+          "moderate": 1,
+          "high": 2,
+          "critical": 5
+        },
+        "196": {
+          "low": 0,
+          "moderate": 1,
+          "high": 6,
+          "critical": 18
+        },
+        "197": {
+          "low": 0,
+          "moderate": 1,
+          "high": 3,
+          "critical": 10
+        },
+        "198": {
+          "low": 0,
+          "moderate": 1,
+          "high": 3,
+          "critical": 10
+        },
+        "5": {
+          "low": 0,
+          "moderate": 1,
+          "high": 6,
+          "critical": 18
+        }
+      },
+      "model_pattern": "^ST6000DX000-1H217Z$",
+      "sample_count": 322
     },
     {
       "protocol": "ATA",
       "source": "linuxhw/SMART curated consumer HDD profile",
       "vendor": "Seagate",
       "model_family": "Seagate Barracuda 7200.14 (AF)",
-      "sample_count": 6657,
-      "model_pattern": "^ST4000DM000-.*$",
       "ata_observed_thresholds": {
         "5": [
-          { "low": 0, "high": 0, "annual_failure_rate": 0.04, "error_interval": [0.03, 0.05] },
-          { "low": 1, "high": 4, "annual_failure_rate": 0.1, "error_interval": [0.08, 0.13] },
-          { "low": 4, "high": 16, "annual_failure_rate": 0.22, "error_interval": [0.18, 0.27] },
-          { "low": 16, "high": 64, "annual_failure_rate": 0.4, "error_interval": [0.33, 0.48] }
+          {
+            "low": 0,
+            "high": 0,
+            "annual_failure_rate": 0.04,
+            "error_interval": [
+              0.03,
+              0.05
+            ]
+          },
+          {
+            "low": 1,
+            "high": 4,
+            "annual_failure_rate": 0.1,
+            "error_interval": [
+              0.08,
+              0.13
+            ]
+          },
+          {
+            "low": 4,
+            "high": 16,
+            "annual_failure_rate": 0.22,
+            "error_interval": [
+              0.18,
+              0.27
+            ]
+          },
+          {
+            "low": 16,
+            "high": 64,
+            "annual_failure_rate": 0.4,
+            "error_interval": [
+              0.33,
+              0.48
+            ]
+          }
         ]
       },
       "ata_counter_severity_overrides": {
-        "5": { "low": 0, "moderate": 1, "high": 4, "critical": 12 },
-        "196": { "low": 0, "moderate": 1, "high": 4, "critical": 12 },
-        "197": { "low": 0, "moderate": 1, "high": 3, "critical": 8 },
-        "198": { "low": 0, "moderate": 1, "high": 3, "critical": 8 },
-        "10": { "low": 0, "moderate": 1, "high": 2, "critical": 5 }
-      }
+        "10": {
+          "low": 0,
+          "moderate": 1,
+          "high": 2,
+          "critical": 5
+        },
+        "196": {
+          "low": 0,
+          "moderate": 1,
+          "high": 4,
+          "critical": 12
+        },
+        "197": {
+          "low": 0,
+          "moderate": 1,
+          "high": 3,
+          "critical": 8
+        },
+        "198": {
+          "low": 0,
+          "moderate": 1,
+          "high": 3,
+          "critical": 8
+        },
+        "5": {
+          "low": 0,
+          "moderate": 1,
+          "high": 4,
+          "critical": 12
+        }
+      },
+      "model_pattern": "^ST4000DM000-.*$",
+      "sample_count": 6657
     },
     {
       "protocol": "ATA",
       "source": "linuxhw/SMART curated consumer HDD profile",
       "vendor": "WDC",
       "model_family": "WDC Caviar Blue",
-      "sample_count": 305,
-      "model_pattern": "^WD10EZEX-.*$",
       "ata_observed_thresholds": {
         "5": [
-          { "low": 0, "high": 0, "annual_failure_rate": 0.03, "error_interval": [0.02, 0.04] },
-          { "low": 1, "high": 4, "annual_failure_rate": 0.07, "error_interval": [0.05, 0.1] },
-          { "low": 4, "high": 16, "annual_failure_rate": 0.16, "error_interval": [0.12, 0.21] },
-          { "low": 16, "high": 64, "annual_failure_rate": 0.31, "error_interval": [0.24, 0.39] }
+          {
+            "low": 0,
+            "high": 0,
+            "annual_failure_rate": 0.03,
+            "error_interval": [
+              0.02,
+              0.04
+            ]
+          },
+          {
+            "low": 1,
+            "high": 4,
+            "annual_failure_rate": 0.07,
+            "error_interval": [
+              0.05,
+              0.1
+            ]
+          },
+          {
+            "low": 4,
+            "high": 16,
+            "annual_failure_rate": 0.16,
+            "error_interval": [
+              0.12,
+              0.21
+            ]
+          },
+          {
+            "low": 16,
+            "high": 64,
+            "annual_failure_rate": 0.31,
+            "error_interval": [
+              0.24,
+              0.39
+            ]
+          }
         ]
       },
       "ata_counter_severity_overrides": {
-        "5": { "low": 0, "moderate": 2, "high": 8, "critical": 20 },
-        "196": { "low": 0, "moderate": 2, "high": 8, "critical": 20 },
-        "197": { "low": 0, "moderate": 1, "high": 4, "critical": 10 },
-        "198": { "low": 0, "moderate": 1, "high": 4, "critical": 10 },
-        "10": { "low": 0, "moderate": 1, "high": 2, "critical": 5 }
-      }
+        "10": {
+          "low": 0,
+          "moderate": 1,
+          "high": 2,
+          "critical": 5
+        },
+        "196": {
+          "low": 0,
+          "moderate": 2,
+          "high": 8,
+          "critical": 20
+        },
+        "197": {
+          "low": 0,
+          "moderate": 1,
+          "high": 4,
+          "critical": 10
+        },
+        "198": {
+          "low": 0,
+          "moderate": 1,
+          "high": 4,
+          "critical": 10
+        },
+        "5": {
+          "low": 0,
+          "moderate": 2,
+          "high": 8,
+          "critical": 20
+        }
+      },
+      "model_pattern": "^WD10EZEX-.*$",
+      "sample_count": 305
     },
     {
       "protocol": "ATA",
       "source": "linuxhw/SMART curated consumer HDD profile",
       "vendor": "WDC",
       "model_family": "WDC Caviar Green",
-      "sample_count": 150,
-      "model_pattern": "^WD20EARS-.*$",
       "ata_observed_thresholds": {
         "5": [
-          { "low": 0, "high": 0, "annual_failure_rate": 0.04, "error_interval": [0.03, 0.05] },
-          { "low": 1, "high": 4, "annual_failure_rate": 0.09, "error_interval": [0.06, 0.12] },
-          { "low": 4, "high": 16, "annual_failure_rate": 0.2, "error_interval": [0.15, 0.26] },
-          { "low": 16, "high": 64, "annual_failure_rate": 0.38, "error_interval": [0.29, 0.48] }
+          {
+            "low": 0,
+            "high": 0,
+            "annual_failure_rate": 0.04,
+            "error_interval": [
+              0.03,
+              0.05
+            ]
+          },
+          {
+            "low": 1,
+            "high": 4,
+            "annual_failure_rate": 0.09,
+            "error_interval": [
+              0.06,
+              0.12
+            ]
+          },
+          {
+            "low": 4,
+            "high": 16,
+            "annual_failure_rate": 0.2,
+            "error_interval": [
+              0.15,
+              0.26
+            ]
+          },
+          {
+            "low": 16,
+            "high": 64,
+            "annual_failure_rate": 0.38,
+            "error_interval": [
+              0.29,
+              0.48
+            ]
+          }
         ]
       },
       "ata_counter_severity_overrides": {
-        "5": { "low": 0, "moderate": 1, "high": 6, "critical": 18 },
-        "196": { "low": 0, "moderate": 1, "high": 6, "critical": 18 },
-        "197": { "low": 0, "moderate": 1, "high": 3, "critical": 8 },
-        "198": { "low": 0, "moderate": 1, "high": 3, "critical": 8 },
-        "10": { "low": 0, "moderate": 1, "high": 2, "critical": 5 }
-      }
+        "10": {
+          "low": 0,
+          "moderate": 1,
+          "high": 2,
+          "critical": 5
+        },
+        "196": {
+          "low": 0,
+          "moderate": 1,
+          "high": 6,
+          "critical": 18
+        },
+        "197": {
+          "low": 0,
+          "moderate": 1,
+          "high": 3,
+          "critical": 8
+        },
+        "198": {
+          "low": 0,
+          "moderate": 1,
+          "high": 3,
+          "critical": 8
+        },
+        "5": {
+          "low": 0,
+          "moderate": 1,
+          "high": 6,
+          "critical": 18
+        }
+      },
+      "model_pattern": "^WD20EARS-.*$",
+      "sample_count": 150
     },
     {
       "protocol": "ATA",
       "source": "linuxhw/SMART curated consumer HDD profile",
       "vendor": "Seagate",
       "model_family": "Seagate Barracuda 7200.12",
-      "sample_count": 3071,
-      "model_pattern": "^ST2000DM001-.*$",
       "ata_observed_thresholds": {
         "5": [
-          { "low": 0, "high": 0, "annual_failure_rate": 0.05, "error_interval": [0.04, 0.06] },
-          { "low": 1, "high": 4, "annual_failure_rate": 0.12, "error_interval": [0.1, 0.15] },
-          { "low": 4, "high": 16, "annual_failure_rate": 0.25, "error_interval": [0.21, 0.3] },
-          { "low": 16, "high": 64, "annual_failure_rate": 0.45, "error_interval": [0.38, 0.53] }
+          {
+            "low": 0,
+            "high": 0,
+            "annual_failure_rate": 0.05,
+            "error_interval": [
+              0.04,
+              0.06
+            ]
+          },
+          {
+            "low": 1,
+            "high": 4,
+            "annual_failure_rate": 0.12,
+            "error_interval": [
+              0.1,
+              0.15
+            ]
+          },
+          {
+            "low": 4,
+            "high": 16,
+            "annual_failure_rate": 0.25,
+            "error_interval": [
+              0.21,
+              0.3
+            ]
+          },
+          {
+            "low": 16,
+            "high": 64,
+            "annual_failure_rate": 0.45,
+            "error_interval": [
+              0.38,
+              0.53
+            ]
+          }
         ]
       },
       "ata_counter_severity_overrides": {
-        "5": { "low": 0, "moderate": 1, "high": 4, "critical": 10 },
-        "196": { "low": 0, "moderate": 1, "high": 4, "critical": 10 },
-        "197": { "low": 0, "moderate": 1, "high": 3, "critical": 6 },
-        "198": { "low": 0, "moderate": 1, "high": 3, "critical": 6 },
-        "10": { "low": 0, "moderate": 1, "high": 2, "critical": 4 }
-      }
+        "10": {
+          "low": 0,
+          "moderate": 1,
+          "high": 2,
+          "critical": 4
+        },
+        "196": {
+          "low": 0,
+          "moderate": 1,
+          "high": 4,
+          "critical": 10
+        },
+        "197": {
+          "low": 0,
+          "moderate": 1,
+          "high": 3,
+          "critical": 6
+        },
+        "198": {
+          "low": 0,
+          "moderate": 1,
+          "high": 3,
+          "critical": 6
+        },
+        "5": {
+          "low": 0,
+          "moderate": 1,
+          "high": 4,
+          "critical": 10
+        }
+      },
+      "model_pattern": "^ST2000DM001-.*$",
+      "sample_count": 3071
     },
     {
       "protocol": "ATA",
       "source": "linuxhw/SMART curated consumer HDD profile",
       "vendor": "Seagate",
       "model_family": "Seagate Desktop HDD.15",
-      "sample_count": 320,
-      "model_pattern": "^ST3000DM001-.*$",
       "ata_observed_thresholds": {
         "5": [
-          { "low": 0, "high": 0, "annual_failure_rate": 0.05, "error_interval": [0.04, 0.07] },
-          { "low": 1, "high": 4, "annual_failure_rate": 0.13, "error_interval": [0.1, 0.17] },
-          { "low": 4, "high": 16, "annual_failure_rate": 0.27, "error_interval": [0.21, 0.34] },
-          { "low": 16, "high": 64, "annual_failure_rate": 0.46, "error_interval": [0.36, 0.56] }
+          {
+            "low": 0,
+            "high": 0,
+            "annual_failure_rate": 0.05,
+            "error_interval": [
+              0.04,
+              0.07
+            ]
+          },
+          {
+            "low": 1,
+            "high": 4,
+            "annual_failure_rate": 0.13,
+            "error_interval": [
+              0.1,
+              0.17
+            ]
+          },
+          {
+            "low": 4,
+            "high": 16,
+            "annual_failure_rate": 0.27,
+            "error_interval": [
+              0.21,
+              0.34
+            ]
+          },
+          {
+            "low": 16,
+            "high": 64,
+            "annual_failure_rate": 0.46,
+            "error_interval": [
+              0.36,
+              0.56
+            ]
+          }
         ]
       },
       "ata_counter_severity_overrides": {
-        "5": { "low": 0, "moderate": 1, "high": 4, "critical": 10 },
-        "196": { "low": 0, "moderate": 1, "high": 4, "critical": 10 },
-        "197": { "low": 0, "moderate": 1, "high": 3, "critical": 6 },
-        "198": { "low": 0, "moderate": 1, "high": 3, "critical": 6 },
-        "10": { "low": 0, "moderate": 1, "high": 2, "critical": 4 }
-      }
+        "10": {
+          "low": 0,
+          "moderate": 1,
+          "high": 2,
+          "critical": 4
+        },
+        "196": {
+          "low": 0,
+          "moderate": 1,
+          "high": 4,
+          "critical": 10
+        },
+        "197": {
+          "low": 0,
+          "moderate": 1,
+          "high": 3,
+          "critical": 6
+        },
+        "198": {
+          "low": 0,
+          "moderate": 1,
+          "high": 3,
+          "critical": 6
+        },
+        "5": {
+          "low": 0,
+          "moderate": 1,
+          "high": 4,
+          "critical": 10
+        }
+      },
+      "model_pattern": "^ST3000DM001-.*$",
+      "sample_count": 320
     },
     {
       "protocol": "ATA",
       "source": "linuxhw/SMART curated consumer SSD profile",
       "vendor": "Samsung",
       "model_family": "Samsung SSD 850 PRO",
-      "sample_count": 355,
-      "model_pattern": "^(X SSD 850 PRO 128GB|Samsung SSD 850 PRO.*)$",
       "ata_counter_severity_overrides": {
-        "5": { "low": 0, "moderate": 3, "high": 10, "critical": 28 },
-        "196": { "low": 0, "moderate": 3, "high": 10, "critical": 28 },
-        "197": { "low": 0, "moderate": 2, "high": 6, "critical": 16 },
-        "198": { "low": 0, "moderate": 2, "high": 6, "critical": 16 }
-      }
+        "196": {
+          "low": 0,
+          "moderate": 3,
+          "high": 10,
+          "critical": 28
+        },
+        "197": {
+          "low": 0,
+          "moderate": 2,
+          "high": 6,
+          "critical": 16
+        },
+        "198": {
+          "low": 0,
+          "moderate": 2,
+          "high": 6,
+          "critical": 16
+        },
+        "5": {
+          "low": 0,
+          "moderate": 3,
+          "high": 10,
+          "critical": 28
+        }
+      },
+      "model_pattern": "^(X SSD 850 PRO 128GB|Samsung SSD 850 PRO.*)$",
+      "sample_count": 355
     },
     {
       "protocol": "ATA",
       "source": "linuxhw/SMART curated consumer SSD profile",
       "vendor": "Samsung",
       "model_family": "Samsung SSD 850 EVO",
-      "sample_count": 1184,
-      "model_pattern": "^Samsung SSD 850 EVO.*$",
       "ata_counter_severity_overrides": {
-        "5": { "low": 0, "moderate": 3, "high": 10, "critical": 28 },
-        "196": { "low": 0, "moderate": 3, "high": 10, "critical": 28 },
-        "197": { "low": 0, "moderate": 2, "high": 6, "critical": 16 },
-        "198": { "low": 0, "moderate": 2, "high": 6, "critical": 16 }
-      }
+        "196": {
+          "low": 0,
+          "moderate": 3,
+          "high": 10,
+          "critical": 28
+        },
+        "197": {
+          "low": 0,
+          "moderate": 2,
+          "high": 6,
+          "critical": 16
+        },
+        "198": {
+          "low": 0,
+          "moderate": 2,
+          "high": 6,
+          "critical": 16
+        },
+        "5": {
+          "low": 0,
+          "moderate": 3,
+          "high": 10,
+          "critical": 28
+        }
+      },
+      "model_pattern": "^Samsung SSD 850 EVO.*$",
+      "sample_count": 1184
     },
     {
       "protocol": "ATA",
       "source": "linuxhw/SMART curated consumer SSD profile",
       "vendor": "Samsung",
       "model_family": "Samsung SSD 870 EVO",
-      "sample_count": 897,
-      "model_pattern": "^Samsung SSD 870 EVO.*$",
       "ata_counter_severity_overrides": {
-        "5": { "low": 0, "moderate": 4, "high": 12, "critical": 32 },
-        "196": { "low": 0, "moderate": 4, "high": 12, "critical": 32 },
-        "197": { "low": 0, "moderate": 3, "high": 8, "critical": 20 },
-        "198": { "low": 0, "moderate": 3, "high": 8, "critical": 20 }
-      }
+        "196": {
+          "low": 0,
+          "moderate": 4,
+          "high": 12,
+          "critical": 32
+        },
+        "197": {
+          "low": 0,
+          "moderate": 3,
+          "high": 8,
+          "critical": 20
+        },
+        "198": {
+          "low": 0,
+          "moderate": 3,
+          "high": 8,
+          "critical": 20
+        },
+        "5": {
+          "low": 0,
+          "moderate": 4,
+          "high": 12,
+          "critical": 32
+        }
+      },
+      "model_pattern": "^Samsung SSD 870 EVO.*$",
+      "sample_count": 897
     },
     {
       "protocol": "ATA",
       "source": "linuxhw/SMART curated consumer SSD profile",
       "vendor": "Samsung",
       "model_family": "Samsung SSD 860 PRO",
-      "sample_count": 246,
-      "model_pattern": "^Samsung SSD 860 PRO.*$",
       "ata_counter_severity_overrides": {
-        "5": { "low": 0, "moderate": 4, "high": 12, "critical": 32 },
-        "196": { "low": 0, "moderate": 4, "high": 12, "critical": 32 },
-        "197": { "low": 0, "moderate": 3, "high": 8, "critical": 20 },
-        "198": { "low": 0, "moderate": 3, "high": 8, "critical": 20 }
-      }
+        "196": {
+          "low": 0,
+          "moderate": 4,
+          "high": 12,
+          "critical": 32
+        },
+        "197": {
+          "low": 0,
+          "moderate": 3,
+          "high": 8,
+          "critical": 20
+        },
+        "198": {
+          "low": 0,
+          "moderate": 3,
+          "high": 8,
+          "critical": 20
+        },
+        "5": {
+          "low": 0,
+          "moderate": 4,
+          "high": 12,
+          "critical": 32
+        }
+      },
+      "model_pattern": "^Samsung SSD 860 PRO.*$",
+      "sample_count": 246
     },
     {
       "protocol": "ATA",
       "source": "linuxhw/SMART curated consumer SSD profile",
       "vendor": "Samsung",
       "model_family": "Samsung SSD 870 QVO",
-      "sample_count": 254,
-      "model_pattern": "^Samsung SSD 870 QVO.*$",
       "ata_counter_severity_overrides": {
-        "5": { "low": 0, "moderate": 4, "high": 12, "critical": 32 },
-        "196": { "low": 0, "moderate": 4, "high": 12, "critical": 32 },
-        "197": { "low": 0, "moderate": 3, "high": 8, "critical": 20 },
-        "198": { "low": 0, "moderate": 3, "high": 8, "critical": 20 }
-      }
+        "196": {
+          "low": 0,
+          "moderate": 4,
+          "high": 12,
+          "critical": 32
+        },
+        "197": {
+          "low": 0,
+          "moderate": 3,
+          "high": 8,
+          "critical": 20
+        },
+        "198": {
+          "low": 0,
+          "moderate": 3,
+          "high": 8,
+          "critical": 20
+        },
+        "5": {
+          "low": 0,
+          "moderate": 4,
+          "high": 12,
+          "critical": 32
+        }
+      },
+      "model_pattern": "^Samsung SSD 870 QVO.*$",
+      "sample_count": 254
     },
     {
       "protocol": "ATA",
       "source": "linuxhw/SMART curated consumer SSD profile",
       "vendor": "Crucial",
       "model_family": "Crucial MX500",
-      "sample_count": 2214,
-      "model_pattern": "^CT(250|500|1000|2000|4000)MX500SSD1.*$",
       "ata_counter_severity_overrides": {
-        "5": { "low": 0, "moderate": 4, "high": 12, "critical": 32 },
-        "196": { "low": 0, "moderate": 4, "high": 12, "critical": 32 },
-        "197": { "low": 0, "moderate": 3, "high": 8, "critical": 20 },
-        "198": { "low": 0, "moderate": 3, "high": 8, "critical": 20 }
-      }
+        "196": {
+          "low": 0,
+          "moderate": 4,
+          "high": 12,
+          "critical": 32
+        },
+        "197": {
+          "low": 0,
+          "moderate": 3,
+          "high": 8,
+          "critical": 20
+        },
+        "198": {
+          "low": 0,
+          "moderate": 3,
+          "high": 8,
+          "critical": 20
+        },
+        "5": {
+          "low": 0,
+          "moderate": 4,
+          "high": 12,
+          "critical": 32
+        }
+      },
+      "model_pattern": "^CT(250|500|1000|2000|4000)MX500SSD1.*$",
+      "sample_count": 2214
     },
     {
       "protocol": "ATA",
       "source": "linuxhw/SMART curated consumer SSD profile",
       "vendor": "Crucial",
       "model_family": "Crucial MX300",
-      "sample_count": 426,
-      "model_pattern": "^CT(275|525|750|1050)MX300SSD1.*$",
       "ata_counter_severity_overrides": {
-        "5": { "low": 0, "moderate": 4, "high": 12, "critical": 32 },
-        "196": { "low": 0, "moderate": 4, "high": 12, "critical": 32 },
-        "197": { "low": 0, "moderate": 3, "high": 8, "critical": 20 },
-        "198": { "low": 0, "moderate": 3, "high": 8, "critical": 20 }
-      }
+        "196": {
+          "low": 0,
+          "moderate": 4,
+          "high": 12,
+          "critical": 32
+        },
+        "197": {
+          "low": 0,
+          "moderate": 3,
+          "high": 8,
+          "critical": 20
+        },
+        "198": {
+          "low": 0,
+          "moderate": 3,
+          "high": 8,
+          "critical": 20
+        },
+        "5": {
+          "low": 0,
+          "moderate": 4,
+          "high": 12,
+          "critical": 32
+        }
+      },
+      "model_pattern": "^CT(275|525|750|1050)MX300SSD1.*$",
+      "sample_count": 426
     },
     {
       "protocol": "ATA",
       "source": "linuxhw/SMART curated consumer SSD profile",
       "vendor": "Crucial",
       "model_family": "Crucial BX500",
-      "sample_count": 481,
-      "model_pattern": "^CT(120|240|480|500|1000|2000|4000)BX500SSD1.*$",
       "ata_counter_severity_overrides": {
-        "5": { "low": 0, "moderate": 4, "high": 12, "critical": 32 },
-        "196": { "low": 0, "moderate": 4, "high": 12, "critical": 32 },
-        "197": { "low": 0, "moderate": 3, "high": 8, "critical": 20 },
-        "198": { "low": 0, "moderate": 3, "high": 8, "critical": 20 }
-      }
+        "196": {
+          "low": 0,
+          "moderate": 4,
+          "high": 12,
+          "critical": 32
+        },
+        "197": {
+          "low": 0,
+          "moderate": 3,
+          "high": 8,
+          "critical": 20
+        },
+        "198": {
+          "low": 0,
+          "moderate": 3,
+          "high": 8,
+          "critical": 20
+        },
+        "5": {
+          "low": 0,
+          "moderate": 4,
+          "high": 12,
+          "critical": 32
+        }
+      },
+      "model_pattern": "^CT(120|240|480|500|1000|2000|4000)BX500SSD1.*$",
+      "sample_count": 481
     },
     {
       "protocol": "ATA",
       "source": "linuxhw/SMART curated consumer SSD profile",
       "vendor": "SanDisk",
       "model_family": "SanDisk Ultra II",
-      "sample_count": 214,
-      "model_pattern": "^SanDisk SDSSDHII-.*$",
       "ata_counter_severity_overrides": {
-        "5": { "low": 0, "moderate": 3, "high": 10, "critical": 28 },
-        "196": { "low": 0, "moderate": 3, "high": 10, "critical": 28 },
-        "197": { "low": 0, "moderate": 2, "high": 6, "critical": 16 },
-        "198": { "low": 0, "moderate": 2, "high": 6, "critical": 16 }
-      }
+        "196": {
+          "low": 0,
+          "moderate": 3,
+          "high": 10,
+          "critical": 28
+        },
+        "197": {
+          "low": 0,
+          "moderate": 2,
+          "high": 6,
+          "critical": 16
+        },
+        "198": {
+          "low": 0,
+          "moderate": 2,
+          "high": 6,
+          "critical": 16
+        },
+        "5": {
+          "low": 0,
+          "moderate": 3,
+          "high": 10,
+          "critical": 28
+        }
+      },
+      "model_pattern": "^SanDisk SDSSDHII-.*$",
+      "sample_count": 214
     },
     {
       "protocol": "ATA",
       "source": "linuxhw/SMART curated consumer SSD profile",
       "vendor": "SanDisk",
       "model_family": "SanDisk 3D SSD",
-      "sample_count": 163,
-      "model_pattern": "^SanDisk SDSSDA-.*$",
       "ata_counter_severity_overrides": {
-        "5": { "low": 0, "moderate": 3, "high": 10, "critical": 28 },
-        "196": { "low": 0, "moderate": 3, "high": 10, "critical": 28 },
-        "197": { "low": 0, "moderate": 2, "high": 6, "critical": 16 },
-        "198": { "low": 0, "moderate": 2, "high": 6, "critical": 16 }
-      }
+        "196": {
+          "low": 0,
+          "moderate": 3,
+          "high": 10,
+          "critical": 28
+        },
+        "197": {
+          "low": 0,
+          "moderate": 2,
+          "high": 6,
+          "critical": 16
+        },
+        "198": {
+          "low": 0,
+          "moderate": 2,
+          "high": 6,
+          "critical": 16
+        },
+        "5": {
+          "low": 0,
+          "moderate": 3,
+          "high": 10,
+          "critical": 28
+        }
+      },
+      "model_pattern": "^SanDisk SDSSDA-.*$",
+      "sample_count": 163
     },
     {
       "protocol": "ATA",
       "source": "linuxhw/SMART curated consumer SSD profile",
       "vendor": "Intel",
       "model_family": "Intel SSD 545s Series",
-      "sample_count": 171,
-      "model_pattern": "^INTEL SSDSC2KW(128|256|512)G8.*$",
       "ata_counter_severity_overrides": {
-        "5": { "low": 0, "moderate": 4, "high": 12, "critical": 32 },
-        "196": { "low": 0, "moderate": 4, "high": 12, "critical": 32 },
-        "197": { "low": 0, "moderate": 3, "high": 8, "critical": 20 },
-        "198": { "low": 0, "moderate": 3, "high": 8, "critical": 20 }
-      }
+        "196": {
+          "low": 0,
+          "moderate": 4,
+          "high": 12,
+          "critical": 32
+        },
+        "197": {
+          "low": 0,
+          "moderate": 3,
+          "high": 8,
+          "critical": 20
+        },
+        "198": {
+          "low": 0,
+          "moderate": 3,
+          "high": 8,
+          "critical": 20
+        },
+        "5": {
+          "low": 0,
+          "moderate": 4,
+          "high": 12,
+          "critical": 32
+        }
+      },
+      "model_pattern": "^INTEL SSDSC2KW(128|256|512)G8.*$",
+      "sample_count": 171
     },
     {
       "protocol": "ATA",
       "source": "linuxhw/SMART curated consumer HDD profile",
       "vendor": "WDC",
       "model_family": "WDC Scorpio Blue",
-      "sample_count": 222,
       "ata_counter_severity_overrides": {
-        "5": { "low": 0, "moderate": 2, "high": 6, "critical": 16 },
-        "196": { "low": 0, "moderate": 2, "high": 6, "critical": 16 },
-        "197": { "low": 0, "moderate": 1, "high": 3, "critical": 8 },
-        "198": { "low": 0, "moderate": 1, "high": 3, "critical": 8 },
-        "10": { "low": 0, "moderate": 1, "high": 2, "critical": 4 }
-      }
+        "10": {
+          "low": 0,
+          "moderate": 1,
+          "high": 2,
+          "critical": 4
+        },
+        "196": {
+          "low": 0,
+          "moderate": 2,
+          "high": 6,
+          "critical": 16
+        },
+        "197": {
+          "low": 0,
+          "moderate": 1,
+          "high": 3,
+          "critical": 8
+        },
+        "198": {
+          "low": 0,
+          "moderate": 1,
+          "high": 3,
+          "critical": 8
+        },
+        "5": {
+          "low": 0,
+          "moderate": 2,
+          "high": 6,
+          "critical": 16
+        }
+      },
+      "sample_count": 222
     },
     {
       "protocol": "ATA",
       "source": "linuxhw/SMART curated consumer HDD profile",
       "vendor": "WDC",
       "model_family": "WDC Blue Mobile",
-      "sample_count": 140,
       "ata_counter_severity_overrides": {
-        "5": { "low": 0, "moderate": 2, "high": 6, "critical": 16 },
-        "196": { "low": 0, "moderate": 2, "high": 6, "critical": 16 },
-        "197": { "low": 0, "moderate": 1, "high": 3, "critical": 8 },
-        "198": { "low": 0, "moderate": 1, "high": 3, "critical": 8 },
-        "10": { "low": 0, "moderate": 1, "high": 2, "critical": 4 }
-      }
+        "10": {
+          "low": 0,
+          "moderate": 1,
+          "high": 2,
+          "critical": 4
+        },
+        "196": {
+          "low": 0,
+          "moderate": 2,
+          "high": 6,
+          "critical": 16
+        },
+        "197": {
+          "low": 0,
+          "moderate": 1,
+          "high": 3,
+          "critical": 8
+        },
+        "198": {
+          "low": 0,
+          "moderate": 1,
+          "high": 3,
+          "critical": 8
+        },
+        "5": {
+          "low": 0,
+          "moderate": 2,
+          "high": 6,
+          "critical": 16
+        }
+      },
+      "sample_count": 140
     },
     {
       "protocol": "ATA",
       "source": "linuxhw/SMART curated consumer HDD profile",
       "vendor": "Seagate",
       "model_family": "Seagate Barracuda 7200.10",
-      "sample_count": 2156,
       "ata_counter_severity_overrides": {
-        "5": { "low": 0, "moderate": 1, "high": 4, "critical": 10 },
-        "196": { "low": 0, "moderate": 1, "high": 4, "critical": 10 },
-        "197": { "low": 0, "moderate": 1, "high": 3, "critical": 6 },
-        "198": { "low": 0, "moderate": 1, "high": 3, "critical": 6 },
-        "10": { "low": 0, "moderate": 1, "high": 2, "critical": 4 }
-      }
+        "10": {
+          "low": 0,
+          "moderate": 1,
+          "high": 2,
+          "critical": 4
+        },
+        "196": {
+          "low": 0,
+          "moderate": 1,
+          "high": 4,
+          "critical": 10
+        },
+        "197": {
+          "low": 0,
+          "moderate": 1,
+          "high": 3,
+          "critical": 6
+        },
+        "198": {
+          "low": 0,
+          "moderate": 1,
+          "high": 3,
+          "critical": 6
+        },
+        "5": {
+          "low": 0,
+          "moderate": 1,
+          "high": 4,
+          "critical": 10
+        }
+      },
+      "sample_count": 2156
     },
     {
       "protocol": "ATA",
       "source": "linuxhw/SMART curated consumer HDD profile",
       "vendor": "Seagate",
       "model_family": "Seagate Barracuda 7200.9",
-      "sample_count": 756,
       "ata_counter_severity_overrides": {
-        "5": { "low": 0, "moderate": 1, "high": 4, "critical": 10 },
-        "196": { "low": 0, "moderate": 1, "high": 4, "critical": 10 },
-        "197": { "low": 0, "moderate": 1, "high": 3, "critical": 6 },
-        "198": { "low": 0, "moderate": 1, "high": 3, "critical": 6 },
-        "10": { "low": 0, "moderate": 1, "high": 2, "critical": 4 }
-      }
+        "10": {
+          "low": 0,
+          "moderate": 1,
+          "high": 2,
+          "critical": 4
+        },
+        "196": {
+          "low": 0,
+          "moderate": 1,
+          "high": 4,
+          "critical": 10
+        },
+        "197": {
+          "low": 0,
+          "moderate": 1,
+          "high": 3,
+          "critical": 6
+        },
+        "198": {
+          "low": 0,
+          "moderate": 1,
+          "high": 3,
+          "critical": 6
+        },
+        "5": {
+          "low": 0,
+          "moderate": 1,
+          "high": 4,
+          "critical": 10
+        }
+      },
+      "sample_count": 756
     },
     {
       "protocol": "ATA",
       "source": "linuxhw/SMART curated consumer SSD profile",
       "vendor": "Samsung",
       "model_family": "Samsung SSD 840 EVO",
-      "sample_count": 445,
       "ata_counter_severity_overrides": {
-        "5": { "low": 0, "moderate": 3, "high": 10, "critical": 28 },
-        "196": { "low": 0, "moderate": 3, "high": 10, "critical": 28 },
-        "197": { "low": 0, "moderate": 2, "high": 6, "critical": 16 },
-        "198": { "low": 0, "moderate": 2, "high": 6, "critical": 16 }
-      }
+        "196": {
+          "low": 0,
+          "moderate": 3,
+          "high": 10,
+          "critical": 28
+        },
+        "197": {
+          "low": 0,
+          "moderate": 2,
+          "high": 6,
+          "critical": 16
+        },
+        "198": {
+          "low": 0,
+          "moderate": 2,
+          "high": 6,
+          "critical": 16
+        },
+        "5": {
+          "low": 0,
+          "moderate": 3,
+          "high": 10,
+          "critical": 28
+        }
+      },
+      "sample_count": 445
     },
     {
       "protocol": "ATA",
       "source": "linuxhw/SMART curated consumer SSD profile",
       "vendor": "Samsung",
       "model_family": "Samsung SSD 860 EVO",
-      "sample_count": 1717,
-      "model_pattern": "^Samsung SSD 860 EVO( [0-9].*|$)",
       "ata_counter_severity_overrides": {
-        "5": { "low": 0, "moderate": 4, "high": 12, "critical": 32 },
-        "196": { "low": 0, "moderate": 4, "high": 12, "critical": 32 },
-        "197": { "low": 0, "moderate": 3, "high": 8, "critical": 20 },
-        "198": { "low": 0, "moderate": 3, "high": 8, "critical": 20 }
-      }
+        "196": {
+          "low": 0,
+          "moderate": 4,
+          "high": 12,
+          "critical": 32
+        },
+        "197": {
+          "low": 0,
+          "moderate": 3,
+          "high": 8,
+          "critical": 20
+        },
+        "198": {
+          "low": 0,
+          "moderate": 3,
+          "high": 8,
+          "critical": 20
+        },
+        "5": {
+          "low": 0,
+          "moderate": 4,
+          "high": 12,
+          "critical": 32
+        }
+      },
+      "model_pattern": "^Samsung SSD 860 EVO( [0-9].*|$)",
+      "sample_count": 1717
     },
     {
       "protocol": "ATA",
       "source": "linuxhw/SMART curated consumer SSD profile",
       "vendor": "Samsung",
       "model_family": "Samsung SSD 860 EVO M.2",
-      "sample_count": 173,
-      "model_pattern": "^Samsung SSD 860 EVO M\\.2.*$",
       "ata_counter_severity_overrides": {
-        "5": { "low": 0, "moderate": 4, "high": 12, "critical": 32 },
-        "196": { "low": 0, "moderate": 4, "high": 12, "critical": 32 },
-        "197": { "low": 0, "moderate": 3, "high": 8, "critical": 20 },
-        "198": { "low": 0, "moderate": 3, "high": 8, "critical": 20 }
-      }
+        "196": {
+          "low": 0,
+          "moderate": 4,
+          "high": 12,
+          "critical": 32
+        },
+        "197": {
+          "low": 0,
+          "moderate": 3,
+          "high": 8,
+          "critical": 20
+        },
+        "198": {
+          "low": 0,
+          "moderate": 3,
+          "high": 8,
+          "critical": 20
+        },
+        "5": {
+          "low": 0,
+          "moderate": 4,
+          "high": 12,
+          "critical": 32
+        }
+      },
+      "model_pattern": "^Samsung SSD 860 EVO M\\.2.*$",
+      "sample_count": 173
     },
     {
       "protocol": "ATA",
       "source": "linuxhw/SMART curated consumer HDD profile",
       "vendor": "WDC",
       "model_family": "WDC Scorpio Black",
-      "sample_count": 52,
       "ata_counter_severity_overrides": {
-        "5": { "low": 0, "moderate": 2, "high": 6, "critical": 14 },
-        "196": { "low": 0, "moderate": 2, "high": 6, "critical": 14 },
-        "197": { "low": 0, "moderate": 1, "high": 3, "critical": 8 },
-        "198": { "low": 0, "moderate": 1, "high": 3, "critical": 8 },
-        "10": { "low": 0, "moderate": 1, "high": 2, "critical": 4 }
-      }
+        "10": {
+          "low": 0,
+          "moderate": 1,
+          "high": 2,
+          "critical": 4
+        },
+        "196": {
+          "low": 0,
+          "moderate": 2,
+          "high": 6,
+          "critical": 14
+        },
+        "197": {
+          "low": 0,
+          "moderate": 1,
+          "high": 3,
+          "critical": 8
+        },
+        "198": {
+          "low": 0,
+          "moderate": 1,
+          "high": 3,
+          "critical": 8
+        },
+        "5": {
+          "low": 0,
+          "moderate": 2,
+          "high": 6,
+          "critical": 14
+        }
+      },
+      "sample_count": 52
     },
     {
       "protocol": "ATA",
       "source": "linuxhw/SMART curated consumer HDD profile",
       "vendor": "WDC",
       "model_family": "WDC Black Mobile",
-      "sample_count": 31,
       "ata_counter_severity_overrides": {
-        "5": { "low": 0, "moderate": 2, "high": 6, "critical": 14 },
-        "196": { "low": 0, "moderate": 2, "high": 6, "critical": 14 },
-        "197": { "low": 0, "moderate": 1, "high": 3, "critical": 8 },
-        "198": { "low": 0, "moderate": 1, "high": 3, "critical": 8 },
-        "10": { "low": 0, "moderate": 1, "high": 2, "critical": 4 }
-      }
+        "10": {
+          "low": 0,
+          "moderate": 1,
+          "high": 2,
+          "critical": 4
+        },
+        "196": {
+          "low": 0,
+          "moderate": 2,
+          "high": 6,
+          "critical": 14
+        },
+        "197": {
+          "low": 0,
+          "moderate": 1,
+          "high": 3,
+          "critical": 8
+        },
+        "198": {
+          "low": 0,
+          "moderate": 1,
+          "high": 3,
+          "critical": 8
+        },
+        "5": {
+          "low": 0,
+          "moderate": 2,
+          "high": 6,
+          "critical": 14
+        }
+      },
+      "sample_count": 31
     },
     {
       "protocol": "ATA",
       "source": "linuxhw/SMART curated consumer HDD profile",
       "vendor": "Seagate",
       "model_family": "Seagate Barracuda Green (AF)",
-      "sample_count": 447,
       "ata_counter_severity_overrides": {
-        "5": { "low": 0, "moderate": 1, "high": 4, "critical": 10 },
-        "196": { "low": 0, "moderate": 1, "high": 4, "critical": 10 },
-        "197": { "low": 0, "moderate": 1, "high": 3, "critical": 6 },
-        "198": { "low": 0, "moderate": 1, "high": 3, "critical": 6 },
-        "10": { "low": 0, "moderate": 1, "high": 2, "critical": 4 }
-      }
+        "10": {
+          "low": 0,
+          "moderate": 1,
+          "high": 2,
+          "critical": 4
+        },
+        "196": {
+          "low": 0,
+          "moderate": 1,
+          "high": 4,
+          "critical": 10
+        },
+        "197": {
+          "low": 0,
+          "moderate": 1,
+          "high": 3,
+          "critical": 6
+        },
+        "198": {
+          "low": 0,
+          "moderate": 1,
+          "high": 3,
+          "critical": 6
+        },
+        "5": {
+          "low": 0,
+          "moderate": 1,
+          "high": 4,
+          "critical": 10
+        }
+      },
+      "sample_count": 447
     },
     {
       "protocol": "ATA",
       "source": "linuxhw/SMART curated consumer HDD profile",
       "vendor": "Seagate",
       "model_family": "Seagate Barracuda LP",
-      "sample_count": 167,
       "ata_counter_severity_overrides": {
-        "5": { "low": 0, "moderate": 1, "high": 4, "critical": 10 },
-        "196": { "low": 0, "moderate": 1, "high": 4, "critical": 10 },
-        "197": { "low": 0, "moderate": 1, "high": 3, "critical": 6 },
-        "198": { "low": 0, "moderate": 1, "high": 3, "critical": 6 },
-        "10": { "low": 0, "moderate": 1, "high": 2, "critical": 4 }
-      }
+        "10": {
+          "low": 0,
+          "moderate": 1,
+          "high": 2,
+          "critical": 4
+        },
+        "196": {
+          "low": 0,
+          "moderate": 1,
+          "high": 4,
+          "critical": 10
+        },
+        "197": {
+          "low": 0,
+          "moderate": 1,
+          "high": 3,
+          "critical": 6
+        },
+        "198": {
+          "low": 0,
+          "moderate": 1,
+          "high": 3,
+          "critical": 6
+        },
+        "5": {
+          "low": 0,
+          "moderate": 1,
+          "high": 4,
+          "critical": 10
+        }
+      },
+      "sample_count": 167
     }
   ],
   "aliases": {
-    "Samsung SSD 860 EVO 500GB": "Samsung SSD 860 EVO",
-    "Samsung SSD 860 EVO 250GB": "Samsung SSD 860 EVO",
-    "Samsung SSD 860 EVO 1TB": "Samsung SSD 860 EVO",
-    "Samsung SSD 860 EVO 2TB": "Samsung SSD 860 EVO",
-    "Samsung SSD 860 EVO M.2 500GB": "Samsung SSD 860 EVO M.2",
-    "Samsung SSD 860 EVO M.2 1TB": "Samsung SSD 860 EVO M.2",
-    "Samsung SSD 860 EVO M.2 2TB": "Samsung SSD 860 EVO M.2",
-    "Samsung SSD 840 Series": "Samsung based SSDs",
-    "Hitachi HDS721050DLE630": "Hitachi Deskstar 7K1000.D",
-    "WDC WD80EFAX-68LHPN0": "WDC Red",
-    "WDC_WD80EFAX-68LHPN0": "WDC Red",
-    "WDC WD60EFRX-68MYMN1": "WDC Red",
-    "WDC_WD60EFRX-68MYMN1": "WDC Red",
-    "WDC WD30EFRX-68AX9N0": "WDC Red",
-    "WDC_WD140EDFZ-11A0VA0": "WDC Red Plus",
-    "WDC WD140EDFZ-11A0VA0": "WDC Red Plus",
-    "ST6000DX000-1H217Z": "Seagate Desktop SSHD",
-    "ST4000DM000-1CD168": "Seagate Barracuda 7200.14 (AF)",
-    "ST4000DM000-1F2168": "Seagate Barracuda 7200.14 (AF)",
-    "WD10EZEX-08WN4A0": "WDC Caviar Blue",
-    "WD10EZEX-00BN5A0": "WDC Caviar Blue",
-    "WD20EARS-00MVWB0": "WDC Caviar Green",
-    "ST2000DM001-1ER164": "Seagate Barracuda 7200.12",
-    "ST2000DM001-1CH164": "Seagate Barracuda 7200.12",
-    "ST3000DM001-1ER166": "Seagate Desktop HDD.15",
-    "ST3000DM001-1CH166": "Seagate Desktop HDD.15",
-    "X SSD 850 PRO 128GB": "Samsung SSD 850 PRO",
-    "Samsung SSD 850 EVO 250GB": "Samsung SSD 850 EVO",
-    "Samsung SSD 850 EVO 500GB": "Samsung SSD 850 EVO",
-    "Samsung SSD 850 EVO 1TB": "Samsung SSD 850 EVO",
-    "Samsung SSD 870 EVO 1TB": "Samsung SSD 870 EVO",
-    "Samsung SSD 870 EVO 500GB": "Samsung SSD 870 EVO",
-    "Samsung SSD 860 PRO 512GB": "Samsung SSD 860 PRO",
-    "Samsung SSD 860 PRO 1TB": "Samsung SSD 860 PRO",
-    "Samsung SSD 870 QVO 1TB": "Samsung SSD 870 QVO",
-    "Samsung SSD 870 QVO 2TB": "Samsung SSD 870 QVO",
-    "CT500MX500SSD1": "Crucial MX500",
+    "CT1000BX500SSD1": "Crucial BX500",
     "CT1000MX500SSD1": "Crucial MX500",
-    "CT525MX300SSD1": "Crucial MX300",
     "CT1050MX300SSD1": "Crucial MX300",
     "CT500BX500SSD1": "Crucial BX500",
-    "CT1000BX500SSD1": "Crucial BX500",
-    "SanDisk SDSSDHII-480G": "SanDisk Ultra II",
-    "SanDisk SDSSDHII-240G": "SanDisk Ultra II",
-    "SanDisk SDSSDA-500G": "SanDisk 3D SSD",
-    "SanDisk SDSSDA-1T00-G26": "SanDisk 3D SSD",
+    "CT500MX500SSD1": "Crucial MX500",
+    "CT525MX300SSD1": "Crucial MX300",
+    "Hitachi HDS721050DLE630": "Hitachi Deskstar 7K1000.D",
     "INTEL SSDSC2KW256G8": "Intel SSD 545s Series",
     "INTEL SSDSC2KW512G8": "Intel SSD 545s Series",
-    "Samsung SSD 840 EVO 500GB": "Samsung SSD 840 EVO",
-    "Samsung SSD 840 EVO 250GB": "Samsung SSD 840 EVO",
+    "ST2000DM001-1CH164": "Seagate Barracuda 7200.12",
+    "ST2000DM001-1ER164": "Seagate Barracuda 7200.12",
+    "ST3000DM001-1CH166": "Seagate Desktop HDD.15",
+    "ST3000DM001-1ER166": "Seagate Desktop HDD.15",
+    "ST4000DM000-1CD168": "Seagate Barracuda 7200.14 (AF)",
+    "ST4000DM000-1F2168": "Seagate Barracuda 7200.14 (AF)",
+    "ST6000DX000-1H217Z": "Seagate Desktop SSHD",
+    "Samsung SSD 840 EVO 120GB": "Samsung SSD 840 EVO",
     "Samsung SSD 840 EVO 1TB": "Samsung SSD 840 EVO",
-    "Samsung SSD 840 EVO 120GB": "Samsung SSD 840 EVO"
+    "Samsung SSD 840 EVO 250GB": "Samsung SSD 840 EVO",
+    "Samsung SSD 840 EVO 500GB": "Samsung SSD 840 EVO",
+    "Samsung SSD 840 Series": "Samsung based SSDs",
+    "Samsung SSD 850 EVO 1TB": "Samsung SSD 850 EVO",
+    "Samsung SSD 850 EVO 250GB": "Samsung SSD 850 EVO",
+    "Samsung SSD 850 EVO 500GB": "Samsung SSD 850 EVO",
+    "Samsung SSD 860 EVO 1TB": "Samsung SSD 860 EVO",
+    "Samsung SSD 860 EVO 250GB": "Samsung SSD 860 EVO",
+    "Samsung SSD 860 EVO 2TB": "Samsung SSD 860 EVO",
+    "Samsung SSD 860 EVO 500GB": "Samsung SSD 860 EVO",
+    "Samsung SSD 860 EVO M.2 1TB": "Samsung SSD 860 EVO M.2",
+    "Samsung SSD 860 EVO M.2 2TB": "Samsung SSD 860 EVO M.2",
+    "Samsung SSD 860 EVO M.2 500GB": "Samsung SSD 860 EVO M.2",
+    "Samsung SSD 860 PRO 1TB": "Samsung SSD 860 PRO",
+    "Samsung SSD 860 PRO 512GB": "Samsung SSD 860 PRO",
+    "Samsung SSD 870 EVO 1TB": "Samsung SSD 870 EVO",
+    "Samsung SSD 870 EVO 500GB": "Samsung SSD 870 EVO",
+    "Samsung SSD 870 QVO 1TB": "Samsung SSD 870 QVO",
+    "Samsung SSD 870 QVO 2TB": "Samsung SSD 870 QVO",
+    "SanDisk SDSSDA-1T00-G26": "SanDisk 3D SSD",
+    "SanDisk SDSSDA-500G": "SanDisk 3D SSD",
+    "SanDisk SDSSDHII-240G": "SanDisk Ultra II",
+    "SanDisk SDSSDHII-480G": "SanDisk Ultra II",
+    "WD10EZEX-00BN5A0": "WDC Caviar Blue",
+    "WD10EZEX-08WN4A0": "WDC Caviar Blue",
+    "WD20EARS-00MVWB0": "WDC Caviar Green",
+    "WDC WD140EDFZ-11A0VA0": "WDC Red Plus",
+    "WDC WD30EFRX-68AX9N0": "WDC Red",
+    "WDC WD60EFRX-68MYMN1": "WDC Red",
+    "WDC WD80EFAX-68LHPN0": "WDC Red",
+    "WDC_WD140EDFZ-11A0VA0": "WDC Red Plus",
+    "WDC_WD60EFRX-68MYMN1": "WDC Red",
+    "WDC_WD80EFAX-68LHPN0": "WDC Red",
+    "X SSD 850 PRO 128GB": "Samsung SSD 850 PRO"
   }
 }

--- a/webapp/backend/pkg/thresholds/consumer_drive_profiles_fixtures.go
+++ b/webapp/backend/pkg/thresholds/consumer_drive_profiles_fixtures.go
@@ -16,17 +16,17 @@ type ConsumerDriveProfileFixture struct {
 	ModelFamily string `json:"model_family,omitempty"`
 	ModelName   string `json:"model_name,omitempty"`
 
-	// ExpectMatched is true when the catalog should recognize the drive.
-	ExpectMatched bool `json:"expect_matched"`
-
-	// ExpectApplied is true when the matched profile should actually be used.
-	ExpectApplied bool `json:"expect_applied"`
-
 	// ExpectFamily is the catalog family the drive must resolve to (when matched).
 	ExpectFamily string `json:"expect_family,omitempty"`
 
 	// ExpectMethod is the required match method (when matched).
 	ExpectMethod string `json:"expect_method,omitempty"`
+
+	// ExpectMatched is true when the catalog should recognize the drive.
+	ExpectMatched bool `json:"expect_matched"`
+
+	// ExpectApplied is true when the matched profile should actually be used.
+	ExpectApplied bool `json:"expect_applied"`
 }
 
 // CheckConsumerDriveProfileFixtures runs every fixture against the catalog and
@@ -44,12 +44,12 @@ func CheckConsumerDriveProfileFixtures(handle *ConsumerDriveCatalogHandle, fixtu
 		if label == "" {
 			label = fmt.Sprintf("fixture #%d (family=%q model=%q)", i, fixture.ModelFamily, fixture.ModelName)
 		}
-		failures = append(failures, checkConsumerDriveProfileFixture(handle, fixture, label)...)
+		failures = append(failures, checkConsumerDriveProfileFixture(handle, &fixtures[i], label)...)
 	}
 	return failures, nil
 }
 
-func checkConsumerDriveProfileFixture(handle *ConsumerDriveCatalogHandle, fixture ConsumerDriveProfileFixture, label string) []string {
+func checkConsumerDriveProfileFixture(handle *ConsumerDriveCatalogHandle, fixture *ConsumerDriveProfileFixture, label string) []string {
 	match := handle.Match(fixture.Protocol, fixture.ModelFamily, fixture.ModelName, nil)
 
 	if !fixture.ExpectMatched {
@@ -90,6 +90,7 @@ func CanonicalizeConsumerDriveProfileCatalog(data []byte) ([]byte, error) {
 		return nil, fmt.Errorf("unmarshal consumer drive profiles: %w", err)
 	}
 
+	//nolint:govet // field order defines the canonical JSON layout of the catalog file
 	ordered := struct {
 		Version  string                 `json:"version,omitempty"`
 		Profiles []ConsumerDriveProfile `json:"profiles"`

--- a/webapp/backend/pkg/thresholds/consumer_drive_profiles_fixtures.go
+++ b/webapp/backend/pkg/thresholds/consumer_drive_profiles_fixtures.go
@@ -1,0 +1,108 @@
+package thresholds
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// ConsumerDriveProfileFixture is one expected-match regression case for the
+// profile catalog. Fixtures pin the behavior of representative real-world
+// model strings so catalog edits that unintentionally change matches fail fast.
+type ConsumerDriveProfileFixture struct {
+	Description string `json:"description,omitempty"`
+
+	// Inputs, as reported by smartctl.
+	Protocol    string `json:"protocol"`
+	ModelFamily string `json:"model_family,omitempty"`
+	ModelName   string `json:"model_name,omitempty"`
+
+	// ExpectMatched is true when the catalog should recognize the drive.
+	ExpectMatched bool `json:"expect_matched"`
+
+	// ExpectApplied is true when the matched profile should actually be used.
+	ExpectApplied bool `json:"expect_applied"`
+
+	// ExpectFamily is the catalog family the drive must resolve to (when matched).
+	ExpectFamily string `json:"expect_family,omitempty"`
+
+	// ExpectMethod is the required match method (when matched).
+	ExpectMethod string `json:"expect_method,omitempty"`
+}
+
+// CheckConsumerDriveProfileFixtures runs every fixture against the catalog and
+// returns a list of human-readable failures. An empty list means all fixtures
+// pass. The error return covers malformed fixture documents only.
+func CheckConsumerDriveProfileFixtures(handle *ConsumerDriveCatalogHandle, fixtureData []byte) ([]string, error) {
+	var fixtures []ConsumerDriveProfileFixture
+	if err := json.Unmarshal(fixtureData, &fixtures); err != nil {
+		return nil, fmt.Errorf("unmarshal fixtures: %w", err)
+	}
+
+	var failures []string
+	for i, fixture := range fixtures {
+		label := fixture.Description
+		if label == "" {
+			label = fmt.Sprintf("fixture #%d (family=%q model=%q)", i, fixture.ModelFamily, fixture.ModelName)
+		}
+		failures = append(failures, checkConsumerDriveProfileFixture(handle, fixture, label)...)
+	}
+	return failures, nil
+}
+
+func checkConsumerDriveProfileFixture(handle *ConsumerDriveCatalogHandle, fixture ConsumerDriveProfileFixture, label string) []string {
+	match := handle.Match(fixture.Protocol, fixture.ModelFamily, fixture.ModelName, nil)
+
+	if !fixture.ExpectMatched {
+		if match != nil {
+			return []string{fmt.Sprintf("%s: expected no catalog match, got family %q via %s", label, match.Profile.ModelFamily, match.Method)}
+		}
+		return nil
+	}
+
+	if match == nil {
+		return []string{fmt.Sprintf("%s: expected a catalog match, got none", label)}
+	}
+
+	var failures []string
+	if fixture.ExpectFamily != "" && match.Profile.ModelFamily != fixture.ExpectFamily {
+		failures = append(failures, fmt.Sprintf("%s: expected family %q, got %q", label, fixture.ExpectFamily, match.Profile.ModelFamily))
+	}
+	if fixture.ExpectMethod != "" && string(match.Method) != fixture.ExpectMethod {
+		failures = append(failures, fmt.Sprintf("%s: expected match method %q, got %q", label, fixture.ExpectMethod, match.Method))
+	}
+	if match.Applied != fixture.ExpectApplied {
+		failures = append(failures, fmt.Sprintf("%s: expected applied=%t, got applied=%t (skip reason %q)", label, fixture.ExpectApplied, match.Applied, match.SkipReason))
+	}
+	return failures
+}
+
+// CanonicalizeConsumerDriveProfileCatalog re-emits a catalog document in the
+// canonical bundled format: 2-space indentation, version first, profiles in
+// declared order, aliases sorted by key (Go's JSON encoder sorts map keys).
+// The output is the exact byte form that should be committed as the embedded
+// runtime catalog.
+func CanonicalizeConsumerDriveProfileCatalog(data []byte) ([]byte, error) {
+	if err := ValidateConsumerDriveProfileCatalog(data); err != nil {
+		return nil, err
+	}
+	var catalog consumerDriveProfileCatalog
+	if err := json.Unmarshal(data, &catalog); err != nil {
+		return nil, fmt.Errorf("unmarshal consumer drive profiles: %w", err)
+	}
+
+	ordered := struct {
+		Version  string                 `json:"version,omitempty"`
+		Profiles []ConsumerDriveProfile `json:"profiles"`
+		Aliases  map[string]string      `json:"aliases"`
+	}{
+		Version:  catalog.Version,
+		Profiles: catalog.Profiles,
+		Aliases:  catalog.Aliases,
+	}
+
+	out, err := json.MarshalIndent(ordered, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(out, '\n'), nil
+}

--- a/webapp/backend/pkg/thresholds/consumer_drive_profiles_lint.go
+++ b/webapp/backend/pkg/thresholds/consumer_drive_profiles_lint.go
@@ -1,0 +1,127 @@
+package thresholds
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// ConsumerDriveProfileLintResult holds the outcome of a full catalog lint run.
+// Errors are hard validation failures (the catalog cannot be loaded); warnings
+// are quality issues that do not prevent loading but should be reviewed before
+// merging catalog changes.
+type ConsumerDriveProfileLintResult struct {
+	Warnings []string
+}
+
+// LintConsumerDriveProfileCatalog runs the full validation and lint pass over a
+// catalog document. A non-nil error means the catalog is structurally invalid
+// and would fail to load at startup. Warnings flag quality issues: dead entries
+// that can never pass their confidence gate, regex patterns that shadow aliases
+// of other families, duplicate patterns, redundant aliases, and a missing
+// catalog version.
+func LintConsumerDriveProfileCatalog(data []byte) (*ConsumerDriveProfileLintResult, error) {
+	// Hard validation first: same path as startup loading.
+	if _, err := parseConsumerDriveProfiles(data); err != nil {
+		return nil, err
+	}
+
+	var catalog consumerDriveProfileCatalog
+	if err := json.Unmarshal(data, &catalog); err != nil {
+		return nil, fmt.Errorf("unmarshal consumer drive profiles: %w", err)
+	}
+
+	result := &ConsumerDriveProfileLintResult{}
+	if strings.TrimSpace(catalog.Version) == "" {
+		result.Warnings = append(result.Warnings, "catalog has no version field; set a version so API provenance can report it")
+	}
+
+	lintDeadEntries(&catalog, result)
+	lintRedundantAliases(&catalog, result)
+	lintPatterns(&catalog, result)
+
+	sort.Strings(result.Warnings)
+	return result, nil
+}
+
+// lintDeadEntries flags profiles that fail their own confidence gate: they are
+// bundled but can never be applied, so they are dead weight in the catalog.
+func lintDeadEntries(catalog *consumerDriveProfileCatalog, result *ConsumerDriveProfileLintResult) {
+	for i := range catalog.Profiles {
+		profile := &catalog.Profiles[i]
+		if !profile.MeetsConfidenceThreshold() {
+			result.Warnings = append(result.Warnings, fmt.Sprintf(
+				"dead entry: profile %q has sample_count %d below its confidence gate of %d and can never be applied",
+				profile.ModelFamily, profile.SampleCount, profile.EffectiveMinSamples()))
+		}
+	}
+}
+
+// lintRedundantAliases flags aliases that normalize to the same key as the
+// family they point to; the family-stage lookup already covers them.
+func lintRedundantAliases(catalog *consumerDriveProfileCatalog, result *ConsumerDriveProfileLintResult) {
+	for alias, family := range catalog.Aliases {
+		if normalizeConsumerDriveKey(alias) == normalizeConsumerDriveKey(family) {
+			result.Warnings = append(result.Warnings, fmt.Sprintf(
+				"redundant alias: %q normalizes to the same key as its family %q", alias, family))
+		}
+	}
+}
+
+// lintPatterns flags duplicate model patterns and patterns that shadow entries
+// belonging to a different family (an alias or family name of family B matching
+// the pattern of family A would silently reroute drives at the regex stage).
+func lintPatterns(catalog *consumerDriveProfileCatalog, result *ConsumerDriveProfileLintResult) {
+	type compiledPattern struct {
+		family  string
+		pattern string
+		regex   *regexp.Regexp
+	}
+
+	seenPatterns := map[string]string{}
+	compiled := make([]compiledPattern, 0, len(catalog.Profiles))
+	for i := range catalog.Profiles {
+		profile := &catalog.Profiles[i]
+		if profile.ModelPattern == "" {
+			continue
+		}
+		if otherFamily, exists := seenPatterns[profile.ModelPattern]; exists {
+			result.Warnings = append(result.Warnings, fmt.Sprintf(
+				"duplicate pattern: %q is declared by both %q and %q", profile.ModelPattern, otherFamily, profile.ModelFamily))
+		} else {
+			seenPatterns[profile.ModelPattern] = profile.ModelFamily
+		}
+		// Compile errors are caught by hard validation; ignore here.
+		if regex, err := regexp.Compile(profile.ModelPattern); err == nil {
+			compiled = append(compiled, compiledPattern{profile.ModelFamily, profile.ModelPattern, regex})
+		}
+	}
+
+	for _, cp := range compiled {
+		patternFamilyKey := normalizeConsumerDriveKey(cp.family)
+		for alias, family := range catalog.Aliases {
+			if normalizeConsumerDriveKey(family) == patternFamilyKey {
+				continue
+			}
+			if cp.regex.MatchString(alias) {
+				result.Warnings = append(result.Warnings, fmt.Sprintf(
+					"pattern shadowing: pattern %q of family %q matches alias %q which belongs to family %q",
+					cp.pattern, cp.family, alias, family))
+			}
+		}
+		for i := range catalog.Profiles {
+			other := &catalog.Profiles[i]
+			otherKey := normalizeConsumerDriveKey(other.ModelFamily)
+			if otherKey == patternFamilyKey {
+				continue
+			}
+			if cp.regex.MatchString(other.ModelFamily) {
+				result.Warnings = append(result.Warnings, fmt.Sprintf(
+					"pattern shadowing: pattern %q of family %q matches family name %q",
+					cp.pattern, cp.family, other.ModelFamily))
+			}
+		}
+	}
+}

--- a/webapp/backend/pkg/thresholds/consumer_drive_profiles_lint.go
+++ b/webapp/backend/pkg/thresholds/consumer_drive_profiles_lint.go
@@ -70,18 +70,29 @@ func lintRedundantAliases(catalog *consumerDriveProfileCatalog, result *Consumer
 	}
 }
 
+// compiledLintPattern pairs a profile's compiled model pattern with its family
+// for cross-entry shadowing checks.
+type compiledLintPattern struct {
+	regex   *regexp.Regexp
+	family  string
+	pattern string
+}
+
 // lintPatterns flags duplicate model patterns and patterns that shadow entries
 // belonging to a different family (an alias or family name of family B matching
 // the pattern of family A would silently reroute drives at the regex stage).
 func lintPatterns(catalog *consumerDriveProfileCatalog, result *ConsumerDriveProfileLintResult) {
-	type compiledPattern struct {
-		family  string
-		pattern string
-		regex   *regexp.Regexp
+	for _, cp := range collectLintPatterns(catalog, result) {
+		lintPatternShadowsAliases(catalog, cp, result)
+		lintPatternShadowsFamilies(catalog, cp, result)
 	}
+}
 
+// collectLintPatterns compiles every profile's model pattern, warning on
+// duplicates. Compile errors are caught by hard validation and skipped here.
+func collectLintPatterns(catalog *consumerDriveProfileCatalog, result *ConsumerDriveProfileLintResult) []compiledLintPattern {
 	seenPatterns := map[string]string{}
-	compiled := make([]compiledPattern, 0, len(catalog.Profiles))
+	compiled := make([]compiledLintPattern, 0, len(catalog.Profiles))
 	for i := range catalog.Profiles {
 		profile := &catalog.Profiles[i]
 		if profile.ModelPattern == "" {
@@ -93,35 +104,42 @@ func lintPatterns(catalog *consumerDriveProfileCatalog, result *ConsumerDrivePro
 		} else {
 			seenPatterns[profile.ModelPattern] = profile.ModelFamily
 		}
-		// Compile errors are caught by hard validation; ignore here.
 		if regex, err := regexp.Compile(profile.ModelPattern); err == nil {
-			compiled = append(compiled, compiledPattern{profile.ModelFamily, profile.ModelPattern, regex})
+			compiled = append(compiled, compiledLintPattern{regex, profile.ModelFamily, profile.ModelPattern})
 		}
 	}
+	return compiled
+}
 
-	for _, cp := range compiled {
-		patternFamilyKey := normalizeConsumerDriveKey(cp.family)
-		for alias, family := range catalog.Aliases {
-			if normalizeConsumerDriveKey(family) == patternFamilyKey {
-				continue
-			}
-			if cp.regex.MatchString(alias) {
-				result.Warnings = append(result.Warnings, fmt.Sprintf(
-					"pattern shadowing: pattern %q of family %q matches alias %q which belongs to family %q",
-					cp.pattern, cp.family, alias, family))
-			}
+// lintPatternShadowsAliases warns when a pattern matches an alias that belongs
+// to a different family.
+func lintPatternShadowsAliases(catalog *consumerDriveProfileCatalog, cp compiledLintPattern, result *ConsumerDriveProfileLintResult) {
+	patternFamilyKey := normalizeConsumerDriveKey(cp.family)
+	for alias, family := range catalog.Aliases {
+		if normalizeConsumerDriveKey(family) == patternFamilyKey {
+			continue
 		}
-		for i := range catalog.Profiles {
-			other := &catalog.Profiles[i]
-			otherKey := normalizeConsumerDriveKey(other.ModelFamily)
-			if otherKey == patternFamilyKey {
-				continue
-			}
-			if cp.regex.MatchString(other.ModelFamily) {
-				result.Warnings = append(result.Warnings, fmt.Sprintf(
-					"pattern shadowing: pattern %q of family %q matches family name %q",
-					cp.pattern, cp.family, other.ModelFamily))
-			}
+		if cp.regex.MatchString(alias) {
+			result.Warnings = append(result.Warnings, fmt.Sprintf(
+				"pattern shadowing: pattern %q of family %q matches alias %q which belongs to family %q",
+				cp.pattern, cp.family, alias, family))
+		}
+	}
+}
+
+// lintPatternShadowsFamilies warns when a pattern matches another profile's
+// family name.
+func lintPatternShadowsFamilies(catalog *consumerDriveProfileCatalog, cp compiledLintPattern, result *ConsumerDriveProfileLintResult) {
+	patternFamilyKey := normalizeConsumerDriveKey(cp.family)
+	for i := range catalog.Profiles {
+		other := &catalog.Profiles[i]
+		if normalizeConsumerDriveKey(other.ModelFamily) == patternFamilyKey {
+			continue
+		}
+		if cp.regex.MatchString(other.ModelFamily) {
+			result.Warnings = append(result.Warnings, fmt.Sprintf(
+				"pattern shadowing: pattern %q of family %q matches family name %q",
+				cp.pattern, cp.family, other.ModelFamily))
 		}
 	}
 }

--- a/webapp/backend/pkg/thresholds/consumer_drive_profiles_match_test.go
+++ b/webapp/backend/pkg/thresholds/consumer_drive_profiles_match_test.go
@@ -1,0 +1,322 @@
+package thresholds
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestMatchConsumerDriveProfileMethods(t *testing.T) {
+	tests := []struct {
+		name         string
+		modelFamily  string
+		modelName    string
+		expectFamily string
+		expectMethod ProfileMatchMethod
+	}{
+		{"exact family", "Samsung based SSDs", "", "Samsung based SSDs", ProfileMatchMethodModelFamily},
+		{"exact model alias", "", "Hitachi HDS721050DLE630", "Hitachi Deskstar 7K1000.D", ProfileMatchMethodModelName},
+		{"capacity variant via vendor normalization", "", "Samsung SSD 870 EVO 2TB", "Samsung SSD 870 EVO", ProfileMatchMethodModelNameNormalized},
+		{"regex pattern fallback", "", "ST2000DM001-9YN164", "Seagate Barracuda 7200.12", ProfileMatchMethodModelPattern},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			match := MatchConsumerDriveProfile("ATA", tt.modelFamily, tt.modelName, nil)
+			if match == nil {
+				t.Fatalf("expected a match")
+			}
+			if !match.Applied {
+				t.Fatalf("expected match to be applied, skip reason %q", match.SkipReason)
+			}
+			if match.Profile.ModelFamily != tt.expectFamily {
+				t.Fatalf("expected family %q, got %q", tt.expectFamily, match.Profile.ModelFamily)
+			}
+			if match.Method != tt.expectMethod {
+				t.Fatalf("expected method %q, got %q", tt.expectMethod, match.Method)
+			}
+			if match.CatalogVersion == "" {
+				t.Fatalf("expected catalog version to be set")
+			}
+		})
+	}
+}
+
+func TestMatchConsumerDriveProfileNoMatch(t *testing.T) {
+	if match := MatchConsumerDriveProfile("ATA", "", "TOSHIBA DT01ACA100", nil); match != nil {
+		t.Fatalf("expected no match, got %q", match.Profile.ModelFamily)
+	}
+}
+
+func TestMatchConsumerDriveProfileNonAtaProtocol(t *testing.T) {
+	if match := MatchConsumerDriveProfile("NVMe", "Samsung based SSDs", "", nil); match != nil {
+		t.Fatalf("expected non-ATA protocol to bypass matching")
+	}
+}
+
+func TestMatchConsumerDriveProfileDenylisted(t *testing.T) {
+	denied := ParseConsumerDriveProfileDenylist("Samsung based SSDs")
+	match := MatchConsumerDriveProfile("ATA", "Samsung based SSDs", "", denied)
+	if match == nil {
+		t.Fatalf("expected a skipped match for observability")
+	}
+	if match.Applied {
+		t.Fatalf("expected denylisted match to not be applied")
+	}
+	if match.SkipReason != ProfileSkipReasonFamilyDenylisted {
+		t.Fatalf("expected skip reason %q, got %q", ProfileSkipReasonFamilyDenylisted, match.SkipReason)
+	}
+}
+
+func TestMatchConsumerDriveProfileDenylistFallsThroughToOtherFamily(t *testing.T) {
+	catalogJSON := `{
+		"version": "test",
+		"profiles": [
+			{"protocol":"ATA","source":"test","model_family":"Family A","sample_count":25},
+			{"protocol":"ATA","source":"test","model_family":"Family B","sample_count":25}
+		],
+		"aliases": {"MODEL-1": "Family B"}
+	}`
+	handle, err := LoadConsumerDriveProfileCatalog([]byte(catalogJSON))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	denied := ParseConsumerDriveProfileDenylist("Family A")
+	match := handle.Match("ATA", "Family A", "MODEL-1", denied)
+	if match == nil || !match.Applied {
+		t.Fatalf("expected fallthrough match to Family B to be applied")
+	}
+	if match.Profile.ModelFamily != "Family B" {
+		t.Fatalf("expected Family B, got %q", match.Profile.ModelFamily)
+	}
+	if match.Method != ProfileMatchMethodModelName {
+		t.Fatalf("expected model_name method, got %q", match.Method)
+	}
+}
+
+func TestMatchConsumerDriveProfileBelowConfidence(t *testing.T) {
+	catalogJSON := `{
+		"profiles": [{"protocol":"ATA","source":"test","model_family":"Family A","sample_count":5}],
+		"aliases": {}
+	}`
+	handle, err := LoadConsumerDriveProfileCatalog([]byte(catalogJSON))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	match := handle.Match("ATA", "Family A", "", nil)
+	if match == nil {
+		t.Fatalf("expected a skipped match for observability")
+	}
+	if match.Applied {
+		t.Fatalf("expected low-confidence match to not be applied")
+	}
+	if match.SkipReason != ProfileSkipReasonBelowConfidence {
+		t.Fatalf("expected skip reason %q, got %q", ProfileSkipReasonBelowConfidence, match.SkipReason)
+	}
+}
+
+func TestParseConsumerDriveProfileDenylist(t *testing.T) {
+	if denied := ParseConsumerDriveProfileDenylist(""); denied != nil {
+		t.Fatalf("expected nil denylist for empty input")
+	}
+	if denied := ParseConsumerDriveProfileDenylist(" , ,"); denied != nil {
+		t.Fatalf("expected nil denylist for blank entries")
+	}
+	denied := ParseConsumerDriveProfileDenylist("Samsung based SSDs, WDC Red Plus")
+	if len(denied) != 2 {
+		t.Fatalf("expected 2 denied families, got %d", len(denied))
+	}
+	if _, ok := denied["samsung_based_ssds"]; !ok {
+		t.Fatalf("expected normalized samsung key in denylist")
+	}
+	if _, ok := denied["wdc_red_plus"]; !ok {
+		t.Fatalf("expected normalized wdc key in denylist")
+	}
+}
+
+func TestConsumerDriveModelNameVariants(t *testing.T) {
+	tests := []struct {
+		name      string
+		modelName string
+		expect    []string
+	}{
+		{"capacity suffix stripped", "Samsung SSD 870 EVO 2TB", []string{"samsung_ssd_870_evo"}},
+		{"wdc firmware suffix stripped", "WDC WD80EFAX-68LHPN0", []string{"wdc_wd80efax"}},
+		{"seagate firmware suffix stripped", "ST4000DM000-1F2168", []string{"st4000dm000"}},
+		{"no decoration yields no variants", "CT2000MX500SSD1", nil},
+		{"empty input", "", nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := consumerDriveModelNameVariants(tt.modelName)
+			if len(got) != len(tt.expect) {
+				t.Fatalf("expected variants %v, got %v", tt.expect, got)
+			}
+			for i := range tt.expect {
+				if got[i] != tt.expect[i] {
+					t.Fatalf("expected variants %v, got %v", tt.expect, got)
+				}
+			}
+		})
+	}
+}
+
+func TestParseConsumerDriveProfilesValidationRules(t *testing.T) {
+	tests := []struct {
+		name        string
+		catalogJSON string
+		expectErr   string
+	}{
+		{
+			"severity ordering violation",
+			`{"profiles":[{"protocol":"ATA","source":"t","model_family":"F","sample_count":25,
+				"ata_counter_severity_overrides":{"5":{"low":0,"moderate":8,"high":4,"critical":24}}}],"aliases":{}}`,
+			"severity override violates",
+		},
+		{
+			"observed threshold low greater than high",
+			`{"profiles":[{"protocol":"ATA","source":"t","model_family":"F","sample_count":25,
+				"ata_observed_thresholds":{"5":[{"low":10,"high":2,"annual_failure_rate":0.1}]}}],"aliases":{}}`,
+			"low > high",
+		},
+		{
+			"annual failure rate out of range",
+			`{"profiles":[{"protocol":"ATA","source":"t","model_family":"F","sample_count":25,
+				"ata_observed_thresholds":{"5":[{"low":0,"high":4,"annual_failure_rate":1.5}]}}],"aliases":{}}`,
+			"annual_failure_rate outside",
+		},
+		{
+			"error interval wrong length",
+			`{"profiles":[{"protocol":"ATA","source":"t","model_family":"F","sample_count":25,
+				"ata_observed_thresholds":{"5":[{"low":0,"high":4,"annual_failure_rate":0.1,"error_interval":[0.1]}]}}],"aliases":{}}`,
+			"error_interval must have exactly 2 values",
+		},
+		{
+			"error interval not ordered",
+			`{"profiles":[{"protocol":"ATA","source":"t","model_family":"F","sample_count":25,
+				"ata_observed_thresholds":{"5":[{"low":0,"high":4,"annual_failure_rate":0.1,"error_interval":[0.3,0.1]}]}}],"aliases":{}}`,
+			"error_interval is not ordered",
+		},
+		{
+			"non-ATA protocol",
+			`{"profiles":[{"protocol":"NVMe","source":"t","model_family":"F","sample_count":25}],"aliases":{}}`,
+			"unsupported protocol",
+		},
+		{
+			"missing source",
+			`{"profiles":[{"protocol":"ATA","source":"","model_family":"F","sample_count":25}],"aliases":{}}`,
+			"missing source",
+		},
+		{
+			"non-positive sample count",
+			`{"profiles":[{"protocol":"ATA","source":"t","model_family":"F","sample_count":0}],"aliases":{}}`,
+			"non-positive sample_count",
+		},
+		{
+			"negative min samples",
+			`{"profiles":[{"protocol":"ATA","source":"t","model_family":"F","sample_count":25,"min_samples":-1}],"aliases":{}}`,
+			"negative min_samples",
+		},
+		{
+			"invalid regex pattern",
+			`{"profiles":[{"protocol":"ATA","source":"t","model_family":"F","sample_count":25,"model_pattern":"^(["}],"aliases":{}}`,
+			"compile model_pattern",
+		},
+		{
+			"duplicate family",
+			`{"profiles":[
+				{"protocol":"ATA","source":"t","model_family":"Family A","sample_count":25},
+				{"protocol":"ATA","source":"t","model_family":"family a","sample_count":25}],"aliases":{}}`,
+			"duplicate profile family",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := parseConsumerDriveProfiles([]byte(tt.catalogJSON))
+			if err == nil || !strings.Contains(err.Error(), tt.expectErr) {
+				t.Fatalf("expected error containing %q, got %v", tt.expectErr, err)
+			}
+		})
+	}
+}
+
+func TestLintConsumerDriveProfileCatalogWarnings(t *testing.T) {
+	catalogJSON := `{
+		"profiles": [
+			{"protocol":"ATA","source":"t","model_family":"Family A","sample_count":25,"min_samples":100},
+			{"protocol":"ATA","source":"t","model_family":"Family B","sample_count":25,"model_pattern":"^MODEL-.*$"},
+			{"protocol":"ATA","source":"t","model_family":"Family C","sample_count":25,"model_pattern":"^MODEL-.*$"}
+		],
+		"aliases": {
+			"Family A": "Family A",
+			"MODEL-9": "Family A"
+		}
+	}`
+
+	result, err := LintConsumerDriveProfileCatalog([]byte(catalogJSON))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expectWarnings := []string{
+		"catalog has no version",
+		"dead entry",
+		"redundant alias",
+		"duplicate pattern",
+		"pattern shadowing",
+	}
+	joined := strings.Join(result.Warnings, "\n")
+	for _, expected := range expectWarnings {
+		if !strings.Contains(joined, expected) {
+			t.Fatalf("expected a warning containing %q, got:\n%s", expected, joined)
+		}
+	}
+}
+
+func TestBundledCatalogLintClean(t *testing.T) {
+	result, err := LintConsumerDriveProfileCatalog(consumerDriveProfilesJSON)
+	if err != nil {
+		t.Fatalf("bundled catalog failed validation: %v", err)
+	}
+	if len(result.Warnings) > 0 {
+		t.Fatalf("bundled catalog has lint warnings:\n%s", strings.Join(result.Warnings, "\n"))
+	}
+}
+
+func TestBundledCatalogIsCanonical(t *testing.T) {
+	canonical, err := CanonicalizeConsumerDriveProfileCatalog(consumerDriveProfilesJSON)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(canonical) != string(consumerDriveProfilesJSON) {
+		t.Fatalf("bundled catalog is not canonical; run `make catalog-fix`")
+	}
+}
+
+func TestBundledCatalogExpectedMatchFixtures(t *testing.T) {
+	fixtureData, err := os.ReadFile("testdata/consumer_drive_profile_fixtures.json")
+	if err != nil {
+		t.Fatalf("read fixtures: %v", err)
+	}
+	handle, err := LoadConsumerDriveProfileCatalog(consumerDriveProfilesJSON)
+	if err != nil {
+		t.Fatalf("load bundled catalog: %v", err)
+	}
+	failures, err := CheckConsumerDriveProfileFixtures(handle, fixtureData)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(failures) > 0 {
+		t.Fatalf("fixture failures:\n%s", strings.Join(failures, "\n"))
+	}
+}
+
+func TestConsumerDriveProfileCatalogVersionSet(t *testing.T) {
+	if ConsumerDriveProfileCatalogVersion() == "" {
+		t.Fatalf("bundled catalog must declare a version")
+	}
+}

--- a/webapp/backend/pkg/thresholds/consumer_drive_profiles_test.go
+++ b/webapp/backend/pkg/thresholds/consumer_drive_profiles_test.go
@@ -203,7 +203,7 @@ func TestParseConsumerDriveProfilesRejectsConflictingDuplicateAlias(t *testing.T
 		],
 		"aliases":{"Model A":"Family A","Model_A":"Family B"}
 	}`
-	_, _, _, err := parseConsumerDriveProfiles([]byte(invalidJSON))
+	_, err := parseConsumerDriveProfiles([]byte(invalidJSON))
 	if err == nil || !strings.Contains(err.Error(), "duplicate model alias") {
 		t.Fatalf("expected duplicate alias error, got %v", err)
 	}
@@ -214,7 +214,7 @@ func TestParseConsumerDriveProfilesRejectsUnknownFamilyAlias(t *testing.T) {
 		"profiles":[{"protocol":"ATA","source":"test","model_family":"Family A","sample_count":25}],
 		"aliases":{"Model A":"Missing Family"}
 	}`
-	_, _, _, err := parseConsumerDriveProfiles([]byte(invalidJSON))
+	_, err := parseConsumerDriveProfiles([]byte(invalidJSON))
 	if err == nil || !strings.Contains(err.Error(), "unknown family") {
 		t.Fatalf("expected unknown family alias error, got %v", err)
 	}

--- a/webapp/backend/pkg/thresholds/testdata/consumer_drive_profile_fixtures.json
+++ b/webapp/backend/pkg/thresholds/testdata/consumer_drive_profile_fixtures.json
@@ -1,0 +1,126 @@
+[
+  {
+    "description": "exact model_family hit wins over model name stages",
+    "protocol": "ATA",
+    "model_family": "Seagate Barracuda 7200.14 (AF)",
+    "model_name": "ST4000DM000-1F2168",
+    "expect_matched": true,
+    "expect_applied": true,
+    "expect_family": "Seagate Barracuda 7200.14 (AF)",
+    "expect_method": "model_family"
+  },
+  {
+    "description": "exact model_family hit for Samsung based SSDs",
+    "protocol": "ATA",
+    "model_family": "Samsung based SSDs",
+    "model_name": "",
+    "expect_matched": true,
+    "expect_applied": true,
+    "expect_family": "Samsung based SSDs",
+    "expect_method": "model_family"
+  },
+  {
+    "description": "exact alias hit for Hitachi model string",
+    "protocol": "ATA",
+    "model_family": "",
+    "model_name": "Hitachi HDS721050DLE630",
+    "expect_matched": true,
+    "expect_applied": true,
+    "expect_family": "Hitachi Deskstar 7K1000.D",
+    "expect_method": "model_name"
+  },
+  {
+    "description": "underscored WDC model string normalizes to the spaced alias",
+    "protocol": "ATA",
+    "model_family": "",
+    "model_name": "WDC_WD140EDFZ-11A0VA0",
+    "expect_matched": true,
+    "expect_applied": true,
+    "expect_family": "WDC Red Plus",
+    "expect_method": "model_name"
+  },
+  {
+    "description": "capacity variant without alias resolves via vendor normalization",
+    "protocol": "ATA",
+    "model_family": "",
+    "model_name": "Samsung SSD 870 EVO 2TB",
+    "expect_matched": true,
+    "expect_applied": true,
+    "expect_family": "Samsung SSD 870 EVO",
+    "expect_method": "model_name_normalized"
+  },
+  {
+    "description": "870 QVO capacity variant without alias resolves via vendor normalization",
+    "protocol": "ATA",
+    "model_family": "",
+    "model_name": "Samsung SSD 870 QVO 4TB",
+    "expect_matched": true,
+    "expect_applied": true,
+    "expect_family": "Samsung SSD 870 QVO",
+    "expect_method": "model_name_normalized"
+  },
+  {
+    "description": "Crucial capacity variant without alias falls back to model_pattern",
+    "protocol": "ATA",
+    "model_family": "",
+    "model_name": "CT2000MX500SSD1",
+    "expect_matched": true,
+    "expect_applied": true,
+    "expect_family": "Crucial MX500",
+    "expect_method": "model_pattern"
+  },
+  {
+    "description": "Seagate firmware suffix variant without alias falls back to model_pattern",
+    "protocol": "ATA",
+    "model_family": "",
+    "model_name": "ST2000DM001-9YN164",
+    "expect_matched": true,
+    "expect_applied": true,
+    "expect_family": "Seagate Barracuda 7200.12",
+    "expect_method": "model_pattern"
+  },
+  {
+    "description": "WDC Red firmware variant without alias falls back to model_pattern",
+    "protocol": "ATA",
+    "model_family": "",
+    "model_name": "WDC WD30EFRX-68EUZN0",
+    "expect_matched": true,
+    "expect_applied": true,
+    "expect_family": "WDC Red",
+    "expect_method": "model_pattern"
+  },
+  {
+    "description": "WDC Caviar Blue firmware variant without alias falls back to model_pattern",
+    "protocol": "ATA",
+    "model_family": "",
+    "model_name": "WD10EZEX-22MFCA0",
+    "expect_matched": true,
+    "expect_applied": true,
+    "expect_family": "WDC Caviar Blue",
+    "expect_method": "model_pattern"
+  },
+  {
+    "description": "unknown Toshiba drive stays unmatched and falls back to generic ATA rules",
+    "protocol": "ATA",
+    "model_family": "",
+    "model_name": "TOSHIBA DT01ACA100",
+    "expect_matched": false,
+    "expect_applied": false
+  },
+  {
+    "description": "unknown model family with unknown model stays unmatched",
+    "protocol": "ATA",
+    "model_family": "Some Unknown Family",
+    "model_name": "UNKNOWN-DRIVE-123",
+    "expect_matched": false,
+    "expect_applied": false
+  },
+  {
+    "description": "non-ATA protocol bypasses the catalog entirely",
+    "protocol": "NVMe",
+    "model_family": "Samsung based SSDs",
+    "model_name": "Samsung SSD 860 EVO 500GB",
+    "expect_matched": false,
+    "expect_applied": false
+  }
+]

--- a/webapp/backend/pkg/web/handler/get_device_drive_profile.go
+++ b/webapp/backend/pkg/web/handler/get_device_drive_profile.go
@@ -1,0 +1,134 @@
+package handler
+
+import (
+	"net/http"
+	"sort"
+
+	"github.com/analogj/scrutiny/webapp/backend/pkg"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/config"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/database"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/models"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/thresholds"
+	"github.com/gin-gonic/gin"
+	"github.com/sirupsen/logrus"
+)
+
+// GetDeviceDriveProfile returns consumer drive profile match diagnostics for a
+// device: which catalog entry matched (if any), the match method, the
+// confidence gate result, which overrides would be applied, and why the drive
+// falls back to generic ATA rules when no profile is in effect.
+//
+// The catalog match is always computed (even when the feature is globally
+// disabled) so operators can inspect what WOULD happen; the Applied flag
+// reflects the effective state.
+//
+// Response: models.DriveProfileInspectionResponse
+func GetDeviceDriveProfile(c *gin.Context) {
+	logger := c.MustGet("LOGGER").(*logrus.Entry)
+	deviceRepo := c.MustGet("DEVICE_REPOSITORY").(database.DeviceRepo)
+	appConfig := c.MustGet("CONFIG").(config.Interface)
+
+	device, err := ResolveDevice(c, logger, deviceRepo)
+	if err != nil {
+		return
+	}
+
+	profilesEnabled := consumerDriveProfilesEnabled(appConfig)
+	denied := consumerDriveProfileDenylist(appConfig)
+
+	inspection := models.DriveProfileInspection{
+		DeviceWWN:       device.WWN,
+		DeviceProtocol:  device.DeviceProtocol,
+		ModelFamily:     device.ModelFamily,
+		ModelName:       device.ModelName,
+		ProfilesEnabled: profilesEnabled,
+		Denylist:        sortedDenylistKeys(denied),
+		CatalogVersion:  thresholds.ConsumerDriveProfileCatalogVersion(),
+	}
+
+	match := thresholds.MatchConsumerDriveProfile(device.DeviceProtocol, device.ModelFamily, device.ModelName, denied)
+	populateDriveProfileMatch(&inspection, match, profilesEnabled)
+
+	c.JSON(http.StatusOK, models.DriveProfileInspectionResponse{
+		Success: true,
+		Data:    inspection,
+	})
+}
+
+// populateDriveProfileMatch fills match, override, and fallback-reason fields
+// on the inspection from a catalog match result.
+func populateDriveProfileMatch(inspection *models.DriveProfileInspection, match *thresholds.ConsumerDriveProfileMatch, profilesEnabled bool) {
+	if match == nil {
+		if inspection.DeviceProtocol != pkg.DeviceProtocolAta {
+			inspection.FallbackReason = "Device protocol is not ATA; consumer drive profiles apply to ATA drives only."
+		} else if !profilesEnabled {
+			inspection.FallbackReason = "Consumer drive profiles are disabled globally in Settings."
+		} else {
+			inspection.FallbackReason = "No profile in the bundled catalog matched this drive's model family or model name."
+		}
+		return
+	}
+
+	profile := match.Profile
+	inspection.Matched = true
+	inspection.MatchMethod = string(match.Method)
+	inspection.MatchedValue = match.MatchedValue
+	inspection.ProfileFamily = profile.ModelFamily
+	inspection.ProfileVendor = profile.Vendor
+	inspection.ProfileSource = profile.Source
+	inspection.SampleCount = profile.SampleCount
+	inspection.MinSamples = profile.EffectiveMinSamples()
+	inspection.ConfidenceMet = profile.MeetsConfidenceThreshold()
+	inspection.ObservedThresholdAttributes = sortedIntKeys(profile.AtaObservedThresholds)
+	inspection.CounterSeverityAttributes = sortedStringKeys(profile.AtaCounterSeverityOverrides)
+
+	if !profilesEnabled {
+		inspection.FallbackReason = "Consumer drive profiles are disabled globally in Settings; the matched profile is not applied."
+		return
+	}
+
+	switch match.SkipReason {
+	case thresholds.ProfileSkipReasonFamilyDenylisted:
+		inspection.FallbackReason = "Matched family is denylisted in Settings; generic ATA rules are in effect."
+	case thresholds.ProfileSkipReasonBelowConfidence:
+		inspection.FallbackReason = "Matched profile does not meet its minimum sample-count confidence gate; generic ATA rules are in effect."
+	default:
+		inspection.Applied = match.Applied
+	}
+}
+
+func sortedDenylistKeys(denied map[string]struct{}) []string {
+	if len(denied) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(denied))
+	for key := range denied {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func sortedIntKeys(m map[int][]thresholds.ObservedThreshold) []int {
+	if len(m) == 0 {
+		return nil
+	}
+	keys := make([]int, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+	sort.Ints(keys)
+	return keys
+}
+
+func sortedStringKeys(m map[string]thresholds.CounterSeverityProfile) []string {
+	if len(m) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/webapp/backend/pkg/web/handler/get_device_drive_profile.go
+++ b/webapp/backend/pkg/web/handler/get_device_drive_profile.go
@@ -59,11 +59,12 @@ func GetDeviceDriveProfile(c *gin.Context) {
 // on the inspection from a catalog match result.
 func populateDriveProfileMatch(inspection *models.DriveProfileInspection, match *thresholds.ConsumerDriveProfileMatch, profilesEnabled bool) {
 	if match == nil {
-		if inspection.DeviceProtocol != pkg.DeviceProtocolAta {
+		switch {
+		case inspection.DeviceProtocol != pkg.DeviceProtocolAta:
 			inspection.FallbackReason = "Device protocol is not ATA; consumer drive profiles apply to ATA drives only."
-		} else if !profilesEnabled {
+		case !profilesEnabled:
 			inspection.FallbackReason = "Consumer drive profiles are disabled globally in Settings."
-		} else {
+		default:
 			inspection.FallbackReason = "No profile in the bundled catalog matched this drive's model family or model name."
 		}
 		return

--- a/webapp/backend/pkg/web/handler/get_device_drive_profile_test.go
+++ b/webapp/backend/pkg/web/handler/get_device_drive_profile_test.go
@@ -1,0 +1,99 @@
+package handler
+
+import (
+	"testing"
+
+	"github.com/analogj/scrutiny/webapp/backend/pkg"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/config"
+	mock_config "github.com/analogj/scrutiny/webapp/backend/pkg/config/mock"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/models"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/thresholds"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConsumerDriveProfileDenylistParsesConfiguredFamilies(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	cfg := mock_config.NewMockInterface(mockCtrl)
+	key := config.DB_USER_SETTINGS_SUBKEY + ".metrics.consumer_drive_profiles_denylist"
+	cfg.EXPECT().GetString(key).Return("Samsung based SSDs, WDC Red Plus")
+
+	denied := consumerDriveProfileDenylist(cfg)
+	require.Len(t, denied, 2)
+	require.Contains(t, denied, "samsung_based_ssds")
+	require.Contains(t, denied, "wdc_red_plus")
+}
+
+func TestConsumerDriveProfileDenylistEmptyWhenUnset(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	cfg := mock_config.NewMockInterface(mockCtrl)
+	key := config.DB_USER_SETTINGS_SUBKEY + ".metrics.consumer_drive_profiles_denylist"
+	cfg.EXPECT().GetString(key).Return("")
+
+	require.Nil(t, consumerDriveProfileDenylist(cfg))
+}
+
+func TestPopulateDriveProfileMatchApplied(t *testing.T) {
+	inspection := models.DriveProfileInspection{DeviceProtocol: pkg.DeviceProtocolAta}
+	match := thresholds.MatchConsumerDriveProfile(pkg.DeviceProtocolAta, "Samsung based SSDs", "", nil)
+	require.NotNil(t, match)
+
+	populateDriveProfileMatch(&inspection, match, true)
+
+	require.True(t, inspection.Matched)
+	require.True(t, inspection.Applied)
+	require.Equal(t, "model_family", inspection.MatchMethod)
+	require.Equal(t, "Samsung based SSDs", inspection.ProfileFamily)
+	require.True(t, inspection.ConfidenceMet)
+	require.NotEmpty(t, inspection.ProfileSource)
+	require.NotEmpty(t, inspection.CounterSeverityAttributes)
+	require.Empty(t, inspection.FallbackReason)
+}
+
+func TestPopulateDriveProfileMatchDenylisted(t *testing.T) {
+	inspection := models.DriveProfileInspection{DeviceProtocol: pkg.DeviceProtocolAta}
+	denied := thresholds.ParseConsumerDriveProfileDenylist("Samsung based SSDs")
+	match := thresholds.MatchConsumerDriveProfile(pkg.DeviceProtocolAta, "Samsung based SSDs", "", denied)
+	require.NotNil(t, match)
+
+	populateDriveProfileMatch(&inspection, match, true)
+
+	require.True(t, inspection.Matched)
+	require.False(t, inspection.Applied)
+	require.Contains(t, inspection.FallbackReason, "denylisted")
+}
+
+func TestPopulateDriveProfileMatchGloballyDisabled(t *testing.T) {
+	inspection := models.DriveProfileInspection{DeviceProtocol: pkg.DeviceProtocolAta}
+	match := thresholds.MatchConsumerDriveProfile(pkg.DeviceProtocolAta, "Samsung based SSDs", "", nil)
+	require.NotNil(t, match)
+
+	populateDriveProfileMatch(&inspection, match, false)
+
+	require.True(t, inspection.Matched)
+	require.False(t, inspection.Applied)
+	require.Contains(t, inspection.FallbackReason, "disabled globally")
+}
+
+func TestPopulateDriveProfileMatchNoMatch(t *testing.T) {
+	inspection := models.DriveProfileInspection{DeviceProtocol: pkg.DeviceProtocolAta}
+
+	populateDriveProfileMatch(&inspection, nil, true)
+
+	require.False(t, inspection.Matched)
+	require.False(t, inspection.Applied)
+	require.Contains(t, inspection.FallbackReason, "No profile in the bundled catalog")
+}
+
+func TestPopulateDriveProfileMatchNonAtaProtocol(t *testing.T) {
+	inspection := models.DriveProfileInspection{DeviceProtocol: pkg.DeviceProtocolNvme}
+
+	populateDriveProfileMatch(&inspection, nil, true)
+
+	require.False(t, inspection.Matched)
+	require.Contains(t, inspection.FallbackReason, "not ATA")
+}

--- a/webapp/backend/pkg/web/handler/get_device_replacement_risk.go
+++ b/webapp/backend/pkg/web/handler/get_device_replacement_risk.go
@@ -75,9 +75,13 @@ func GetDeviceReplacementRisk(c *gin.Context) {
 
 	weights := thresholds.ReplacementRiskWeightsForProtocol(device.DeviceProtocol)
 	profilesEnabled := consumerDriveProfilesEnabled(appConfig)
+	var match *thresholds.ConsumerDriveProfileMatch
 	var profile *thresholds.ConsumerDriveProfile
 	if profilesEnabled {
-		profile, _ = thresholds.LookupConsumerDriveProfile(device.DeviceProtocol, device.ModelFamily, device.ModelName)
+		match = thresholds.MatchConsumerDriveProfile(device.DeviceProtocol, device.ModelFamily, device.ModelName, consumerDriveProfileDenylist(appConfig))
+		if match != nil && match.Applied {
+			profile = match.Profile
+		}
 	}
 	contributions, totalScore, totalTrendBonus := computeRiskContributions(weights, latestAttrs, oldestAttrs, profile)
 
@@ -100,6 +104,10 @@ func GetDeviceReplacementRisk(c *gin.Context) {
 	}
 	if profile != nil {
 		riskScore.ConsumerDriveProfileFamily = profile.ModelFamily
+		riskScore.ConsumerDriveProfileSource = profile.Source
+		riskScore.ConsumerDriveProfileSampleCount = profile.SampleCount
+		riskScore.ConsumerDriveProfileMatchMethod = string(match.Method)
+		riskScore.ConsumerDriveProfileCatalogVersion = match.CatalogVersion
 	}
 
 	c.JSON(http.StatusOK, models.ReplacementRiskResponse{
@@ -117,6 +125,16 @@ func consumerDriveProfilesEnabled(cfg config.Interface) bool {
 		return true
 	}
 	return cfg.GetBool(key)
+}
+
+// consumerDriveProfileDenylist returns the set of normalized family keys the
+// operator has excluded from profile matching via settings.
+func consumerDriveProfileDenylist(cfg config.Interface) map[string]struct{} {
+	if cfg == nil {
+		return nil
+	}
+	return thresholds.ParseConsumerDriveProfileDenylist(
+		cfg.GetString(config.DB_USER_SETTINGS_SUBKEY + ".metrics.consumer_drive_profiles_denylist"))
 }
 
 // computeRiskContributions builds the per-attribute contribution list and returns

--- a/webapp/backend/pkg/web/handler/replacement_risk_notify.go
+++ b/webapp/backend/pkg/web/handler/replacement_risk_notify.go
@@ -48,7 +48,9 @@ func maybeNotifyReplacementRisk(
 	weights := thresholds.ReplacementRiskWeightsForProtocol(device.DeviceProtocol)
 	var profile *thresholds.ConsumerDriveProfile
 	if consumerDriveProfilesEnabled(appConfig) {
-		profile, _ = thresholds.LookupConsumerDriveProfile(device.DeviceProtocol, device.ModelFamily, device.ModelName)
+		if match := thresholds.MatchConsumerDriveProfile(device.DeviceProtocol, device.ModelFamily, device.ModelName, consumerDriveProfileDenylist(appConfig)); match != nil && match.Applied {
+			profile = match.Profile
+		}
 	}
 	_, totalScore, _ := computeRiskContributions(weights, latestAttrs, oldestAttrs, profile)
 

--- a/webapp/backend/pkg/web/server.go
+++ b/webapp/backend/pkg/web/server.go
@@ -153,6 +153,7 @@ func (ae *AppEngine) Setup(logger *logrus.Entry) *gin.Engine {
 			api.POST("/device/:id/performance", handler.UploadDevicePerformance)               // used by Collector to upload performance benchmarks
 			api.GET("/device/:id/performance", handler.GetDevicePerformance)                   // used by UI to view performance history
 			api.GET("/device/:id/replacement-risk", handler.GetDeviceReplacementRisk)          // used by UI to display drive replacement prediction
+			api.GET("/device/:id/drive-profile", handler.GetDeviceDriveProfile)                // debug/inspection surface for consumer drive profile matching
 			api.POST("/device/:id/collector-error", handler.UploadCollectorError)              // used by Collector to report smartctl errors
 			api.POST("/collector/scan-error", handler.UploadCollectorScanError)                // used by Collector to report scan-level errors (no device context)
 

--- a/webapp/frontend/src/app/core/config/app.config.ts
+++ b/webapp/frontend/src/app/core/config/app.config.ts
@@ -147,6 +147,7 @@ export interface AppConfig {
         report_enabled?: boolean;
         report_daily_enabled?: boolean;
         consumer_drive_profiles_enabled?: boolean;
+        consumer_drive_profiles_denylist?: string;
         report_daily_time?: string;
         report_weekly_enabled?: boolean;
         report_weekly_day?: number;
@@ -226,6 +227,7 @@ export const appConfig: AppConfig = {
         report_enabled: false,
         report_daily_enabled: false,
         consumer_drive_profiles_enabled: true,
+        consumer_drive_profiles_denylist: '',
         report_daily_time: '08:00',
         report_weekly_enabled: false,
         report_weekly_day: 1,

--- a/webapp/frontend/src/app/data/mock/settings/data.ts
+++ b/webapp/frontend/src/app/data/mock/settings/data.ts
@@ -17,6 +17,7 @@ export const settings = {
             status_threshold: 3,
             repeat_notifications: true,
             consumer_drive_profiles_enabled: true,
+            consumer_drive_profiles_denylist: '',
         },
     },
 };

--- a/webapp/frontend/src/app/layout/common/dashboard-settings/dashboard-settings.component.html
+++ b/webapp/frontend/src/app/layout/common/dashboard-settings/dashboard-settings.component.html
@@ -182,6 +182,18 @@
             </mat-form-field>
         </div>
 
+        @if (consumerDriveProfilesEnabled) {
+        <div class="flex flex-col mt-5 gt-md:flex-row">
+            <mat-form-field class="flex-auto gt-xs:pr-3 gt-md:pr-3">
+                <mat-label>Consumer Drive Profile Denylist</mat-label>
+                <input matInput [(ngModel)]="consumerDriveProfilesDenylist" placeholder="e.g. Seagate Barracuda 7200.14 (AF), Crucial MX500" />
+                <mat-hint>
+                    Comma-separated profile families that should never be applied. Matching drives fall back to generic ATA rules. Leave empty to allow all vetted profiles.
+                </mat-hint>
+            </mat-form-field>
+        </div>
+        }
+
         <!-- Collector Error Notifications -->
         <div class="flex flex-col mt-5 gt-md:flex-row">
             <mat-form-field class="flex-auto gt-xs:pr-3 gt-md:pr-3">

--- a/webapp/frontend/src/app/layout/common/dashboard-settings/dashboard-settings.component.ts
+++ b/webapp/frontend/src/app/layout/common/dashboard-settings/dashboard-settings.component.ts
@@ -140,6 +140,7 @@ export class DashboardSettingsComponent implements OnInit {
     reportEnabled: boolean;
     reportDailyEnabled: boolean;
     consumerDriveProfilesEnabled: boolean;
+    consumerDriveProfilesDenylist: string;
     reportDailyTime: string;
     reportWeeklyEnabled: boolean;
     reportWeeklyDay: number;
@@ -261,6 +262,7 @@ export class DashboardSettingsComponent implements OnInit {
             this.reportEnabled = config.metrics.report_enabled ?? false;
             this.reportDailyEnabled = config.metrics.report_daily_enabled ?? false;
             this.consumerDriveProfilesEnabled = config.metrics.consumer_drive_profiles_enabled ?? true;
+            this.consumerDriveProfilesDenylist = config.metrics.consumer_drive_profiles_denylist ?? '';
             this.reportDailyTime = config.metrics.report_daily_time ?? '08:00';
             this.reportWeeklyEnabled = config.metrics.report_weekly_enabled ?? false;
             this.reportWeeklyDay = config.metrics.report_weekly_day ?? 1;
@@ -565,6 +567,7 @@ export class DashboardSettingsComponent implements OnInit {
                 report_enabled: this.reportEnabled,
                 report_daily_enabled: this.reportDailyEnabled,
                 consumer_drive_profiles_enabled: this.consumerDriveProfilesEnabled,
+                consumer_drive_profiles_denylist: this.consumerDriveProfilesDenylist?.trim() ?? '',
                 report_daily_time: this.reportDailyTime,
                 report_weekly_enabled: this.reportWeeklyEnabled,
                 report_weekly_day: this.reportWeeklyDay,


### PR DESCRIPTION
Closes #552

## Summary

Second iteration of the ATA consumer-drive profile system: repeatable catalog pipeline, explicit match confidence, API provenance, a debug inspection surface, vendor-aware normalization, per-family operator overrides, and catalog regression protection. Generic ATA fallback behavior is unchanged for unknown or low-confidence drives.

## Scope coverage

1. **Catalog import and lint pipeline** - new `catalog-lint` CLI (`make catalog-lint` / `make catalog-fix`) validates, lints, checks expected-match fixtures, and canonicalizes the bundled JSON, which remains the embedded runtime source of truth. Workflow documented in `docs/CONSUMER_DRIVE_PROFILES.md`.
2. **Match confidence metadata** - matching returns a machine-readable method (`model_family` > `model_name` > `model_name_normalized` > `model_pattern`), matched value, catalog version, and skip reason.
3. **Profile-aware weight overrides** - evaluated and deferred; decision recorded in the docs. The curated population aggregates support severity breakpoints but not per-attribute failure correlation, so weight overrides would imply undefendable precision.
4. **Provenance in the API** - replacement-risk responses now carry `consumer_drive_profile_source`, `_sample_count`, `_match_method`, and `_catalog_version` when a profile is applied; omitted for generic ATA. OpenAPI updated.
5. **Debug inspection surface** - new `GET /api/device/:id/drive-profile` reports matched family, match method, confidence gate result, applied override attributes, denylist state, and a plain-language fallback reason.
6. **Normalization improvements** - vendor-aware variants (capacity suffixes, WDC/Seagate firmware suffixes) resolve real-world model strings to exact catalog entries without broad regex; regression-tested against representative strings.
7. **Operator override controls** - new per-family denylist (`metrics.consumer_drive_profiles_denylist`, comma-separated), with settings UI, DB migration, and documented precedence (global toggle > denylist/confidence gate > fallthrough to weaker stages > generic fallback).
8. **Catalog regression tests** - validation-rule tests (severity ordering, bucket sanity, duplicate aliases/families, invalid patterns), lint-warning tests (dead entries, pattern shadowing, duplicate patterns), and a fixture set exercising matched and unmatched ATA models that also runs in `go test`.

## Non-goals honored

- No runtime fetching of external datasets
- NVMe/SCSI scoring untouched
- Generic ATA fallback path preserved (existing lookup tests pass unchanged)

## Testing

- `go test ./webapp/backend/... ./collector/...` passes
- `make catalog-lint` clean (strict mode)
- Frontend eslint + tsc clean