### PR TITLE
docs: clarify loop pilot workflows

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,14 @@ We use a Gitflow-style workflow:
 4. Update `README.md` when your change affects the top-level product surface, feature set, supported deployment paths, or published image matrix
 5. Submit a PR to `develop` (or `master` for hotfixes)
 
+### Loop Pilot Workflows
+
+This repo also has read-only and draft-only loop pilot workflows on `master`.
+
+- `loop-pilot-triage.yaml` can run on schedule or via `workflow_dispatch`.
+- `loop-pilot-pr-babysitter.yaml` and `loop-pilot-dependency-sweeper.yaml` are manual analyzers only.
+- These workflows publish markdown artifacts and Actions summaries, but they do not commit, push, merge, label, or comment on PRs.
+
 ## Code Style
 
 - No emojis in code, commits, comments, or documentation

--- a/README.md
+++ b/README.md
@@ -95,6 +95,11 @@ This repo includes a loop pilot for PR flow, issue triage, and dependency hygien
 - Manual draft-only analyzers:
   - [`.github/workflows/loop-pilot-pr-babysitter.yaml`](./.github/workflows/loop-pilot-pr-babysitter.yaml)
   - [`.github/workflows/loop-pilot-dependency-sweeper.yaml`](./.github/workflows/loop-pilot-dependency-sweeper.yaml)
+- Actions run names:
+  - `Loop Pilot Triage`
+  - `Loop Pilot PR Babysitter`
+  - `Loop Pilot Dependency Sweeper`
+- Default-branch dispatch: available from GitHub Actions on `master`
 
 The pilot is intentionally draft-only for action loops: it can summarize blockers and produce artifacts, but it does not commit, push, merge, label, or comment on PRs.
 

--- a/docs/DEPLOYMENTS.md
+++ b/docs/DEPLOYMENTS.md
@@ -33,6 +33,18 @@ Production releases are created manually through `.github/workflows/release.yaml
 - The generator uses merged PR metadata as the source of truth, renders note content from each PR's `## Summary` block plus linked issues, and validates that no extracted summary items were dropped before it emits notes.
 - OpenAI polishing is optional and wording-only. If the polish step changes the entry structure or drops sub-bullets, the workflow falls back to the raw deterministic notes.
 
+## Loop Pilot Workflows
+
+This repo also ships non-deploy workflow automation for PR flow, issue triage, and dependency hygiene.
+
+| Workflow | Trigger | Purpose |
+| --- | --- | --- |
+| `.github/workflows/loop-pilot-triage.yaml` | Daily cron + manual | Read-only triage report covering open PRs, issues, and dependency hygiene candidates |
+| `.github/workflows/loop-pilot-pr-babysitter.yaml` | Manual | Draft-only blocker analysis for one PR |
+| `.github/workflows/loop-pilot-dependency-sweeper.yaml` | Manual | Draft-only dependency PR risk analysis for one target |
+
+These workflows do not publish images, deploy environments, SSH to Zeus, or mutate PR state. They only generate markdown summaries and uploaded artifacts.
+
 ## Required GitHub Secrets
 
 - `GITHUB_TOKEN`


### PR DESCRIPTION
## Summary
- document the live loop pilot workflows in README, contributing guidance, and deployment docs
- clarify which workflows are scheduled versus manual draft-only analyzers
- note that these workflows are now manually dispatchable from `master`

## Validation
- docs-only change
- verified the merged loop pilot workflows run successfully on GitHub Actions
