### PR TITLE
Fix MDADM device discovery and null handling

### DIFF
--- a/collector/pkg/mdadm/detect/detect.go
+++ b/collector/pkg/mdadm/detect/detect.go
@@ -121,7 +121,7 @@ func (d *Detect) getArrayDetail(name string) (models.MDADMArray, models.MDADMMet
 	}
 
 	d.resolveArrayUUID(&array, devicePath, name)
-	d.enrichArrayMetrics(&metrics, name, devicePath)
+	d.enrichArrayMetrics(&array, &metrics, name, devicePath)
 
 	return array, metrics, nil
 }
@@ -146,11 +146,14 @@ func (d *Detect) resolveArrayUUID(array *models.MDADMArray, devicePath, name str
 	d.Logger.Warnf("Using synthetic MDADM identifier for %s because mdadm did not expose a UUID", devicePath)
 }
 
-// enrichArrayMetrics augments parsed metrics with /proc/mdstat data (raw block, sync progress)
-// and filesystem usage when the array is mounted in the container.
-func (d *Detect) enrichArrayMetrics(metrics *models.MDADMMetrics, name, devicePath string) {
+// enrichArrayMetrics augments parsed array data with /proc/mdstat member devices and metrics,
+// plus filesystem usage when the array is mounted in the container.
+func (d *Detect) enrichArrayMetrics(array *models.MDADMArray, metrics *models.MDADMMetrics, name, devicePath string) {
 	rawMdstat, _ := d.getRawMdstat(name)
 	metrics.RawMdstat = rawMdstat
+	if len(array.Devices) == 0 {
+		array.Devices = parseMdstatDevices(rawMdstat)
+	}
 
 	// Parse sync/check/rebuild/recovery progress from /proc/mdstat if not already set
 	// by mdadm --detail. The "check = X%" line only appears in /proc/mdstat.
@@ -170,6 +173,29 @@ func (d *Detect) enrichArrayMetrics(metrics *models.MDADMMetrics, name, devicePa
 
 // mdstatProgressPattern matches the "check|resync|recovery|rebuild = X%" progress line in /proc/mdstat.
 var mdstatProgressPattern = regexp.MustCompile(`(?:check|resync|recovery|rebuild)\s*=\s*(\d+(?:\.\d+)?)%`)
+
+var mdstatDevicePattern = regexp.MustCompile(`(\S+)\[\d+\]`)
+
+// parseMdstatDevices extracts member device names from an array's first /proc/mdstat line.
+// mdstat omits the /dev prefix, so normalize the result to match mdadm --detail output.
+func parseMdstatDevices(rawMdstat string) []string {
+	devices := []string{}
+	firstLine, _, _ := strings.Cut(rawMdstat, "\n")
+	_, members, found := strings.Cut(firstLine, ":")
+	if !found {
+		return devices
+	}
+
+	for _, match := range mdstatDevicePattern.FindAllStringSubmatch(members, -1) {
+		device := match[1]
+		if !strings.HasPrefix(device, "/") {
+			device = "/dev/" + device
+		}
+		devices = append(devices, device)
+	}
+
+	return devices
+}
 
 func (d *Detect) getArrayUUIDFromExport(devicePath string) (string, error) {
 	var cmd *exec.Cmd
@@ -234,7 +260,7 @@ func (d *Detect) parseMdadmOutput(name string, output string) (models.MDADMArray
 
 	// Device list starts after the header
 	inDeviceList := false
-	devicePattern := regexp.MustCompile(`\s+\d+\s+\d+\s+\d+\s+\d+\s+.+\s+(/dev/\S+)`)
+	devicePattern := regexp.MustCompile(`(/dev/\S+)\s*$`)
 
 	for scanner.Scan() {
 		line := scanner.Text()

--- a/collector/pkg/mdadm/detect/detect_test.go
+++ b/collector/pkg/mdadm/detect/detect_test.go
@@ -18,7 +18,7 @@ md0 : active raid1 sdb[1] sda[0]
       1048512 blocks super 1.2 [2/2] [UU]
 
 unused devices: <none>`
-	
+
 	tmpfile, err := ioutil.TempFile("", "mdstat")
 	require.NoError(t, err)
 	defer os.Remove(tmpfile.Name())
@@ -31,7 +31,7 @@ unused devices: <none>`
 	// We need to override the file path in the implementation or use a trick
 	// Since I can't easily override os.Open("/proc/mdstat"), I'll modify the implementation
 	// to take a path or I'll just test the parsing logic directly if I split it.
-	
+
 	// For now, I'll test the parseMdadmOutput logic which is more complex.
 }
 
@@ -131,6 +131,39 @@ Consistency Policy : resync
 	// 2097024 KiB * 1024 = 2147352576 bytes (array size)
 	assert.Equal(t, int64(2147352576), metrics.ArraySize)
 	// Note: UsedBytes is populated by getMountUsage (statfs) in getArrayDetail, not by parseMdadmOutput.
+}
+
+func TestDetect_ParseMdadmOutput_DeviceWithNoRaidSlot(t *testing.T) {
+	d := &Detect{
+		Logger: logrus.NewEntry(logrus.New()),
+	}
+
+	output := `/dev/md0:
+        Raid Level : raid1
+              UUID : 12345678:12345678:12345678:12345678
+
+    Number   Major   Minor   RaidDevice State
+       0       8        2        0      active sync   /dev/sda2
+       2       8       34        -      spare   /dev/sdc2`
+
+	array, _, err := d.parseMdadmOutput("md0", output)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"/dev/sda2", "/dev/sdc2"}, array.Devices)
+}
+
+func TestParseMdstatDevices(t *testing.T) {
+	rawMdstat := `md1 : active raid6 sde2[0] sdc2[1](F) sdg2[2] sdf2[3]
+      15627534336 blocks super 1.2 level 6, 512k chunk, algorithm 2 [4/3] [U_UU]`
+
+	assert.Equal(t, []string{"/dev/sde2", "/dev/sdc2", "/dev/sdg2", "/dev/sdf2"}, parseMdstatDevices(rawMdstat))
+}
+
+func TestParseMdstatDevicesReturnsEmptySliceForMissingHeader(t *testing.T) {
+	devices := parseMdstatDevices("")
+
+	assert.NotNil(t, devices)
+	assert.Empty(t, devices)
 }
 
 func TestParseMdadmExportUUID(t *testing.T) {

--- a/webapp/backend/pkg/web/handler/mdadm_get_summary.go
+++ b/webapp/backend/pkg/web/handler/mdadm_get_summary.go
@@ -39,11 +39,15 @@ func GetMdadmSummary(c *gin.Context) {
 
 	summaries := make([]ArraySummary, 0, len(arrays))
 	for _, array := range arrays {
+		devices := array.Devices
+		if devices == nil {
+			devices = []string{}
+		}
 		summary := ArraySummary{
 			UUID:     array.UUID,
 			Name:     array.Name,
 			Level:    array.Level,
-			Devices:  array.Devices,
+			Devices:  devices,
 			Label:    array.Label,
 			Archived: array.Archived,
 			Muted:    array.Muted,

--- a/webapp/backend/pkg/web/handler/mdadm_get_summary_test.go
+++ b/webapp/backend/pkg/web/handler/mdadm_get_summary_test.go
@@ -1,0 +1,50 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	mock_database "github.com/analogj/scrutiny/webapp/backend/pkg/database/mock"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/models"
+	"github.com/gin-gonic/gin"
+	"github.com/golang/mock/gomock"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetMdadmSummaryNormalizesNullDevices(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	repo := mock_database.NewMockDeviceRepo(ctrl)
+	repo.EXPECT().GetMdadmArrays(gomock.Any()).Return([]models.MDADMArray{{
+		UUID:  "uuid-1",
+		Name:  "md0",
+		Level: "raid1",
+	}}, nil)
+	repo.EXPECT().GetLatestMdadmMetrics(gomock.Any(), "uuid-1").Return(nil, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/mdadm/summary", nil)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = req
+	c.Set("DEVICE_REPOSITORY", repo)
+	c.Set("LOGGER", logrus.NewEntry(logrus.New()))
+
+	GetMdadmSummary(c)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var response struct {
+		Data []struct {
+			Devices []string `json:"devices"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+	require.Len(t, response.Data, 1)
+	assert.NotNil(t, response.Data[0].Devices)
+	assert.Empty(t, response.Data[0].Devices)
+}

--- a/webapp/backend/pkg/web/handler/mdadm_register_arrays.go
+++ b/webapp/backend/pkg/web/handler/mdadm_register_arrays.go
@@ -33,12 +33,16 @@ func RegisterMdadmArrays(c *gin.Context) {
 			registrationErrors = append(registrationErrors, fmt.Sprintf("array %s rejected: missing UUID", collectorArray.Name))
 			continue
 		}
+		devices := collectorArray.Devices
+		if devices == nil {
+			devices = []string{}
+		}
 
 		array := models.MDADMArray{
 			UUID:    trimmedUUID,
 			Name:    collectorArray.Name,
 			Level:   collectorArray.Level,
-			Devices: collectorArray.Devices,
+			Devices: devices,
 			HostID:  collectorArray.HostID,
 		}
 

--- a/webapp/backend/pkg/web/handler/mdadm_register_arrays_test.go
+++ b/webapp/backend/pkg/web/handler/mdadm_register_arrays_test.go
@@ -112,3 +112,34 @@ func TestRegisterMdadmArraysRejectsMissingUUID(t *testing.T) {
 	require.Len(t, response.Errors, 1)
 	assert.Contains(t, response.Errors[0], "missing UUID")
 }
+
+func TestRegisterMdadmArraysNormalizesNullDevices(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	repo := mock_database.NewMockDeviceRepo(ctrl)
+	repo.EXPECT().RegisterMdadmArray(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, array models.MDADMArray) error {
+		assert.NotNil(t, array.Devices)
+		assert.Empty(t, array.Devices)
+		return nil
+	})
+
+	body := `{"data":[{"uuid":"uuid-1","name":"md0","level":"raid1","devices":null}]}`
+	req := httptest.NewRequest(http.MethodPost, "/api/mdadm/arrays/register", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = req
+	c.Set("DEVICE_REPOSITORY", repo)
+	c.Set("LOGGER", logrus.NewEntry(logrus.New()))
+
+	RegisterMdadmArrays(c)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var response models.MDADMArrayWrapper
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+	require.Len(t, response.Data, 1)
+	assert.NotNil(t, response.Data[0].Devices)
+	assert.Empty(t, response.Data[0].Devices)
+}

--- a/webapp/frontend/src/app/modules/mdadm/mdadm.service.spec.ts
+++ b/webapp/frontend/src/app/modules/mdadm/mdadm.service.spec.ts
@@ -1,0 +1,30 @@
+import { HttpClient } from '@angular/common/http';
+import { TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+import { MDADMService } from './mdadm.service';
+
+describe('MDADMService', () => {
+    let service: MDADMService;
+    let httpClientSpy: jasmine.SpyObj<HttpClient>;
+
+    beforeEach(() => {
+        httpClientSpy = jasmine.createSpyObj('HttpClient', ['get']);
+        TestBed.configureTestingModule({
+            providers: [MDADMService, { provide: HttpClient, useValue: httpClientSpy }],
+        });
+        service = TestBed.inject(MDADMService);
+    });
+
+    it('normalizes null member devices in summary data', (done: DoneFn) => {
+        const response = {
+            success: true,
+            data: [{ uuid: 'uuid-1', name: 'md0', level: 'raid1', devices: null }],
+        } as any;
+        httpClientSpy.get.and.returnValue(of(response));
+
+        service.getSummaryData().subscribe((arrays) => {
+            expect(arrays[0].devices).toEqual([]);
+            done();
+        });
+    });
+});

--- a/webapp/frontend/src/app/modules/mdadm/mdadm.service.ts
+++ b/webapp/frontend/src/app/modules/mdadm/mdadm.service.ts
@@ -33,7 +33,10 @@ export class MDADMService {
     getSummaryData(): Observable<MDADMArrayModel[]> {
         return this._httpClient.get(getBasePath() + '/api/mdadm/summary').pipe(
             map((response: MDADMArrayResponseWrapper) => {
-                return response.data;
+                return response.data.map((array) => ({
+                    ...array,
+                    devices: array.devices ?? [],
+                }));
             }),
             tap((response: MDADMArrayModel[]) => {
                 this._data.next(response);


### PR DESCRIPTION
## Summary
- accept MDADM device table variants and fall back to `/proc/mdstat` member discovery
- normalize missing device lists to empty arrays in registration and summary responses
- normalize legacy null device lists in the Angular client
- add collector, backend, and frontend regression tests

## Linked Issues
Closes #652

## Test plan
- `go test ./...`
- `ng test --watch=false --browsers=ChromeHeadless --include=src/app/modules/mdadm/mdadm.service.spec.ts`
- `ng lint`
- `ng build`