### PR TITLE
Ignore local agent surfaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,6 +119,15 @@ test_flux.go
 # Local architecture knowledge base (agent/maintainer guidance, not shipped)
 CONTEXT.md
 docs/adr/
+
+# Agent instruction and session surfaces are intentionally local-only.
+AGENTS.md
+CLAUDE.md
+.agents/
+.claude/
+.codex/
+.agent-session
+.codex-session-*
 docs/agents/invariants.md
 docs/agents/danger-zones.md
 docs/agents/review-checklist.md


### PR DESCRIPTION
## Summary
- ignore local agent instruction, configuration, and session surfaces
- preserve repository source and existing tracked files

This is external maintenance only and remains outside the Staros canonical workflow inventory.