### PR TITLE
fix(collector): preserve jmb39x-q device type and accept usable SMART JSON

### DIFF
--- a/collector/pkg/collector/base.go
+++ b/collector/pkg/collector/base.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/analogj/scrutiny/webapp/backend/pkg/smartctl"
 	"github.com/sirupsen/logrus"
 )
 
@@ -122,32 +123,32 @@ func drainAndClose(body io.ReadCloser) {
 }
 
 // LogSmartctlExitCode logs each set bit in the smartctl exit code bitmask.
-// Fatal bits (0x01, 0x02) are logged at ERROR; health-related bits (0x08,
-// 0x10, 0x20) at WARN; purely informational bits (0x04, 0x40, 0x80) at INFO.
-// http://www.linuxguide.it/command_line/linux-manpage/do.php?file=smartctl#sect7
+// The fatal bits are logged at ERROR; health-related bits at WARN; purely
+// informational bits at INFO. See webapp/backend/pkg/smartctl for the bit
+// definitions and for which of them are considered fatal.
 func (c *BaseCollector) LogSmartctlExitCode(exitCode int, deviceName string) {
-	if exitCode&0x01 != 0 {
+	if exitCode&smartctl.ExitCommandLineError != 0 {
 		c.logger.Errorf("smartctl could not parse command line for %s", deviceName)
 	}
-	if exitCode&0x02 != 0 {
+	if exitCode&smartctl.ExitDeviceOpenFailed != 0 {
 		c.logger.Errorf("smartctl could not open device %s", deviceName)
 	}
-	if exitCode&0x04 != 0 {
+	if exitCode&smartctl.ExitChecksumError != 0 {
 		c.logger.Infof("smartctl detected a checksum error for %s (bit 0x04)", deviceName)
 	}
-	if exitCode&0x08 != 0 {
+	if exitCode&smartctl.ExitDiskFailing != 0 {
 		c.logger.Warnf("smartctl detected a failing disk for %s (bit 0x08)", deviceName)
 	}
-	if exitCode&0x10 != 0 {
+	if exitCode&smartctl.ExitPrefailBelowThreshold != 0 {
 		c.logger.Warnf("smartctl detected a disk in pre-fail for %s (bit 0x10)", deviceName)
 	}
-	if exitCode&0x20 != 0 {
+	if exitCode&smartctl.ExitUsageBelowThreshold != 0 {
 		c.logger.Warnf("smartctl detected a disk close to failure for %s (bit 0x20)", deviceName)
 	}
-	if exitCode&0x40 != 0 {
+	if exitCode&smartctl.ExitErrorLogHasRecords != 0 {
 		c.logger.Infof("smartctl error log contains records of errors for %s (bit 0x40)", deviceName)
 	}
-	if exitCode&0x80 != 0 {
+	if exitCode&smartctl.ExitSelfTestLogHasErrors != 0 {
 		c.logger.Infof("smartctl self-test log contains errors for %s (bit 0x80)", deviceName)
 	}
 }

--- a/collector/pkg/collector/metrics.go
+++ b/collector/pkg/collector/metrics.go
@@ -16,6 +16,7 @@ import (
 	"github.com/analogj/scrutiny/collector/pkg/detect"
 	collectorerrors "github.com/analogj/scrutiny/collector/pkg/errors"
 	"github.com/analogj/scrutiny/collector/pkg/models"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/smartctl"
 	"github.com/sirupsen/logrus"
 )
 
@@ -207,21 +208,14 @@ func (mc *MetricsCollector) Collect(deviceID string, deviceName string, deviceTy
 	if err != nil {
 		if exitError, ok := err.(*exec.ExitError); ok {
 			exitCode := exitError.ExitCode()
-			// Bits 0x01 and 0x02 indicate fatal errors where the JSON
-			// output should not be trusted:
-			//   0x01 = command line parse error
-			//   0x02 = device open failed (includes standby)
-			// Other bits are informational and the JSON data is still valid:
-			//   0x04 = checksum error in response (common behind RAID/HBA)
-			//   0x08 = SMART status failure
-			//   0x10 = prefail attributes past threshold
-			//   0x20 = some attributes past threshold
-			//   0x40 = error log contains records of errors
-			//   0x80 = self-test log contains errors
-			if exitCode&0x03 != 0 {
+			// Only a command line parse error or a device open failure mean the
+			// JSON output cannot be trusted. Every other bit describes a condition
+			// of the disk, and the payload is still complete. See
+			// webapp/backend/pkg/smartctl for the bit definitions.
+			if smartctl.IsFatal(exitCode) {
 				mc.logger.Errorf("smartctl returned a fatal error code (%d) while processing %s", exitCode, deviceName)
 				mc.LogSmartctlExitCode(exitCode, deviceName)
-				if exitCode&0x02 != 0 {
+				if exitCode&smartctl.ExitDeviceOpenFailed != 0 {
 					mc.hintAppArmorOnDeviceOpenFailure(deviceName)
 				}
 				mc.ReportDeviceError(deviceID, "xall", fmt.Sprintf("smartctl exited with fatal code %d while reading %s", exitCode, deviceName))

--- a/collector/pkg/collector/metrics_collect_test.go
+++ b/collector/pkg/collector/metrics_collect_test.go
@@ -1,0 +1,177 @@
+package collector
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	mock_shell "github.com/analogj/scrutiny/collector/pkg/common/shell/mock"
+	collectorconfig "github.com/analogj/scrutiny/collector/pkg/config"
+	"github.com/golang/mock/gomock"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+const someSmartPayload = `{"smartctl":{"exit_status":4},"model_name":"WDC WD40EFRX-68N32N0"}`
+
+// fixes #663: `jmb39x-q,0` must reach smartctl as a single --device argument on the
+// SMART collection call, exactly as it does on the detection call.
+func TestMetricsCollector_Collect_PassesCommaDeviceTypeAsOneArgument(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	fakeShell := mock_shell.NewMockInterface(ctrl)
+	fakeShell.EXPECT().
+		CommandContext(gomock.Any(), gomock.Any(), "smartctl",
+			[]string{"--xall", "--json", "--device", "jmb39x-q,0", "/dev/sda"},
+			"", gomock.Any()).
+		Return(someSmartPayload, nil)
+
+	var published int32
+	mc := newTestCollectCollector(t, fakeShell, func(*http.Request) {
+		atomic.AddInt32(&published, 1)
+	})
+
+	mc.Collect("some-device-id", "sda", "jmb39x-q,0")
+
+	require.Equal(t, int32(1), atomic.LoadInt32(&published), "SMART payload should be published")
+}
+
+// The FARM call is the third site that appends --device and must stay identical to
+// the other two.
+func TestMetricsCollector_Collect_PassesCommaDeviceTypeToFarmCall(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	fakeShell := mock_shell.NewMockInterface(ctrl)
+	fakeShell.EXPECT().
+		CommandContext(gomock.Any(), gomock.Any(), "smartctl",
+			[]string{"--xall", "--json", "--device", "jmb39x-q,0", "/dev/sda"},
+			"", gomock.Any()).
+		Return(someSmartPayload, nil)
+	fakeShell.EXPECT().
+		CommandContext(gomock.Any(), gomock.Any(), "smartctl",
+			[]string{"-l", "farm", "--json", "--device", "jmb39x-q,0", "/dev/sda"},
+			"", gomock.Any()).
+		Return(`{"seagate_farm_log":{}}`, nil)
+
+	mc := newTestCollectCollector(t, fakeShell, nil)
+	mc.config.Set("commands.metrics_farm_enabled", true)
+
+	mc.Collect("some-device-id", "sda", "jmb39x-q,0")
+}
+
+// Only exit-status bits 0-1 invalidate the payload. Bit 2 accompanies the QNAP
+// TR-004 "Read Device Statistics page 0x00 failed" warning and must still publish.
+func TestMetricsCollector_Collect_PublishesOnNonFatalExitStatus(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	fakeShell := mock_shell.NewMockInterface(ctrl)
+	fakeShell.EXPECT().
+		CommandContext(gomock.Any(), gomock.Any(), "smartctl", gomock.Any(), "", gomock.Any()).
+		Return(someSmartPayload, collectExitErrorWithCode(t, 4))
+
+	var publishedPaths []string
+	mc := newTestCollectCollector(t, fakeShell, func(req *http.Request) {
+		publishedPaths = append(publishedPaths, req.URL.Path)
+	})
+
+	mc.Collect("some-device-id", "sda", "jmb39x-q,0")
+
+	require.Equal(t, []string{"/api/device/some-device-id/smart"}, publishedPaths)
+}
+
+func TestMetricsCollector_Collect_ReportsErrorOnFatalExitStatus(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	fakeShell := mock_shell.NewMockInterface(ctrl)
+	fakeShell.EXPECT().
+		CommandContext(gomock.Any(), gomock.Any(), "smartctl", gomock.Any(), "", gomock.Any()).
+		Return(someSmartPayload, collectExitErrorWithCode(t, 2))
+
+	var publishedPaths []string
+	mc := newTestCollectCollector(t, fakeShell, func(req *http.Request) {
+		publishedPaths = append(publishedPaths, req.URL.Path)
+	})
+
+	mc.Collect("some-device-id", "sda", "jmb39x-q,0")
+
+	// the SMART payload must not be published, only the collector-error report
+	require.Equal(t, []string{"/api/device/some-device-id/collector-error"}, publishedPaths)
+}
+
+// newTestCollectCollector builds a MetricsCollector wired to the given shell, with
+// every HTTP request answered 200 and optionally handed to observe first.
+func newTestCollectCollector(t *testing.T, fakeShell *mock_shell.MockInterface, observe func(*http.Request)) MetricsCollector {
+	t.Helper()
+
+	cfg, err := collectorconfig.Create()
+	require.NoError(t, err)
+	cfg.Set(configKeyMetricsAPIRetryCount, 0)
+	cfg.Set(configKeyMetricsAPIRetryDelay, 0)
+
+	client := &http.Client{
+		Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			if observe != nil {
+				observe(req)
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Status:     "200 OK",
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(`{"success":true}`)),
+			}, nil
+		}),
+	}
+
+	logger := logrus.New()
+	logger.SetOutput(io.Discard)
+
+	parsedURL, err := url.Parse("http://example.com/")
+	require.NoError(t, err)
+
+	return MetricsCollector{
+		config:      cfg,
+		apiEndpoint: parsedURL,
+		shell:       fakeShell,
+		BaseCollector: BaseCollector{
+			logger:     logrus.NewEntry(logger),
+			httpClient: client,
+		},
+	}
+}
+
+// collectExitErrorWithCode returns a genuine *exec.ExitError carrying the requested
+// exit status. os.ProcessState cannot be constructed directly, so a child process is
+// required; re-executing the test binary keeps this portable.
+func collectExitErrorWithCode(t *testing.T, code int) *exec.ExitError {
+	t.Helper()
+	cmd := exec.Command(os.Args[0], "-test.run=^TestCollectExitCodeHelperProcess$")
+	cmd.Env = append(os.Environ(), fmt.Sprintf("GO_COLLECT_HELPER_EXIT_CODE=%d", code))
+
+	var exitErr *exec.ExitError
+	require.ErrorAs(t, cmd.Run(), &exitErr, "helper process should fail with an ExitError")
+	require.Equal(t, code, exitErr.ExitCode())
+	return exitErr
+}
+
+// TestCollectExitCodeHelperProcess is not a real test. It is the child process that
+// collectExitErrorWithCode re-executes to produce a real *exec.ExitError.
+func TestCollectExitCodeHelperProcess(t *testing.T) {
+	code := os.Getenv("GO_COLLECT_HELPER_EXIT_CODE")
+	if code == "" {
+		t.Skip("helper process; not meant to be run directly")
+	}
+	parsed, err := strconv.Atoi(code)
+	require.NoError(t, err)
+	os.Exit(parsed)
+}

--- a/collector/pkg/config/config.go
+++ b/collector/pkg/config/config.go
@@ -179,18 +179,60 @@ func collectorCommandFlags(args []string) (containsJSONFlag bool, containsDevice
 }
 
 func (c *configuration) GetDeviceOverrides() []models.ScanOverride {
-	// we have to support 2 types of device types.
-	// - simple device type (device_type: 'sat')
-	// and list of device types (type: \n- 3ware,0 \n- 3ware,1 \n- 3ware,2)
-	// GetString will return "" if this is a list of device types.
-
+	// We support 2 shapes for a device's type:
+	// - a single device type   (type: 'sat')
+	// - a list of device types (type: \n- 3ware,0 \n- 3ware,1 \n- 3ware,2)
+	//
+	// A comma is part of the smartctl device-type grammar ('megaraid,14',
+	// 'sat,auto', 'jmb39x-q,0'), not a separator between types. Viper's default
+	// decode hook splits a scalar string on ',' when the destination is a slice,
+	// which turns 'jmb39x-q,0' into the two bogus types 'jmb39x-q' and '0'.
+	// Override the hook so WeaklyTypedInput simply lifts the scalar into a
+	// one-element slice verbatim; a YAML list still yields one entry per item.
+	// Fixes #418, #663.
 	if c.deviceOverrides == nil {
 		overrides := []models.ScanOverride{}
-		c.UnmarshalKey("devices", &overrides, func(c *mapstructure.DecoderConfig) { c.WeaklyTypedInput = true })
-		c.deviceOverrides = overrides
+		err := c.UnmarshalKey("devices", &overrides, func(decoderConfig *mapstructure.DecoderConfig) {
+			decoderConfig.WeaklyTypedInput = true
+			decoderConfig.DecodeHook = mapstructure.ComposeDecodeHookFunc(
+				mapstructure.StringToTimeDurationHookFunc(),
+			)
+		})
+		if err != nil {
+			logrus.Errorf("Could not parse the 'devices' section of the collector config; no device overrides will be applied: %v", err)
+			c.deviceOverrides = []models.ScanOverride{}
+			return c.deviceOverrides
+		}
+		c.deviceOverrides = normalizeDeviceOverrides(overrides)
 	}
 
 	return c.deviceOverrides
+}
+
+// normalizeDeviceOverrides trims surrounding whitespace from every configured
+// device type and drops the empty ones. Whitespace matters because the type is
+// handed verbatim to smartctl's --device flag. Empty entries matter because the
+// decode hook removed above used to map an explicitly empty type to an empty
+// slice, whereas WeaklyTypedInput lifting maps it to a slice holding one empty
+// string.
+//
+// An all-empty type deliberately becomes an empty (but non-nil) slice, matching
+// the old behavior so that buildOverrideDeviceGroup keeps dropping the device
+// rather than falling back to the scanned type.
+func normalizeDeviceOverrides(overrides []models.ScanOverride) []models.ScanOverride {
+	for i := range overrides {
+		if overrides[i].DeviceType == nil {
+			continue
+		}
+		cleaned := make([]string, 0, len(overrides[i].DeviceType))
+		for _, deviceType := range overrides[i].DeviceType {
+			if trimmed := strings.TrimSpace(deviceType); trimmed != "" {
+				cleaned = append(cleaned, trimmed)
+			}
+		}
+		overrides[i].DeviceType = cleaned
+	}
+	return overrides
 }
 
 func (c *configuration) GetCommandMetricsInfoArgs(deviceName string) string {

--- a/collector/pkg/config/config_test.go
+++ b/collector/pkg/config/config_test.go
@@ -43,7 +43,7 @@ func TestConfiguration_GetScanOverrides_Simple(t *testing.T) {
 	require.Equal(t, []models.ScanOverride{{Device: "/dev/sda", DeviceType: []string{"sat"}, Ignore: false}}, scanOverrides)
 }
 
-// fixes #418
+// fixes #418, #663
 func TestConfiguration_GetScanOverrides_DeviceTypeComma(t *testing.T) {
 	t.Parallel()
 
@@ -56,10 +56,72 @@ func TestConfiguration_GetScanOverrides_DeviceTypeComma(t *testing.T) {
 	scanOverrides := testConfig.GetDeviceOverrides()
 
 	//assert
+	// a comma is part of the smartctl device type, so both the scalar and the list
+	// form must yield exactly one type.
 	require.Equal(t, []models.ScanOverride{
-		{Device: "/dev/sda", DeviceType: []string{"sat", "auto"}, Ignore: false},
+		{Device: "/dev/sda", DeviceType: []string{"sat,auto"}, Ignore: false},
 		{Device: "/dev/sdb", DeviceType: []string{"sat,auto"}, Ignore: false},
 	}, scanOverrides)
+}
+
+// fixes #663: QNAP TR-004 enclosures address each bay as `jmb39x-q,N`.
+func TestConfiguration_GetScanOverrides_DeviceTypeJmb39x(t *testing.T) {
+	t.Parallel()
+
+	//setup
+	testConfig, _ := config.Create()
+
+	//test
+	err := testConfig.ReadConfig(path.Join("testdata", "device_type_jmb39x.yaml"), testLogger())
+	require.NoError(t, err, "should correctly load jmb39x device config")
+	scanOverrides := testConfig.GetDeviceOverrides()
+
+	//assert
+	require.Equal(t, []models.ScanOverride{
+		{Device: "/dev/sda", DeviceType: []string{"jmb39x-q,0"}, Ignore: false},
+		{
+			Device:     "/dev/sdb",
+			DeviceType: []string{"jmb39x-q,0", "jmb39x-q,1", "jmb39x-q,2", "jmb39x-q,3"},
+			Ignore:     false,
+		},
+	}, scanOverrides)
+}
+
+func TestConfiguration_GetScanOverrides_DeviceTypeWhitespace(t *testing.T) {
+	t.Parallel()
+
+	//setup
+	testConfig, _ := config.Create()
+
+	//test
+	err := testConfig.ReadConfig(path.Join("testdata", "device_type_whitespace.yaml"), testLogger())
+	require.NoError(t, err, "should correctly load whitespace device config")
+	scanOverrides := testConfig.GetDeviceOverrides()
+
+	//assert
+	require.Equal(t, []models.ScanOverride{
+		{Device: "/dev/sda", DeviceType: []string{"jmb39x-q,0"}, Ignore: false},
+		{Device: "/dev/sdb", DeviceType: []string{"sat,auto", "megaraid,14"}, Ignore: false},
+	}, scanOverrides)
+}
+
+func TestConfiguration_GetScanOverrides_DeviceTypeEmpty(t *testing.T) {
+	t.Parallel()
+
+	//setup
+	testConfig, _ := config.Create()
+
+	//test
+	err := testConfig.ReadConfig(path.Join("testdata", "device_type_empty.yaml"), testLogger())
+	require.NoError(t, err, "should correctly load empty device type config")
+	scanOverrides := testConfig.GetDeviceOverrides()
+
+	//assert
+	// an explicit empty type must stay non-nil, otherwise buildOverrideDeviceGroup
+	// would fall back to the scanned type instead of dropping the device.
+	require.Len(t, scanOverrides, 1)
+	require.NotNil(t, scanOverrides[0].DeviceType)
+	require.Empty(t, scanOverrides[0].DeviceType)
 }
 
 func TestConfiguration_GetScanOverrides_Ignore(t *testing.T) {

--- a/collector/pkg/config/testdata/device_type_comma.yaml
+++ b/collector/pkg/config/testdata/device_type_comma.yaml
@@ -1,7 +1,8 @@
 version: 1
 devices:
-  # the scrutiny config parser will detect `sat,auto` as two separate items in a list. If you want to use `-d sat,auto` you must
-  # set 'sat,auto' in a list (see eg. /dev/sbd)
+  # A comma belongs to the smartctl device type itself (`-d sat,auto`), it does not
+  # separate two types. Both the scalar form (/dev/sda) and the list form (/dev/sdb)
+  # must preserve it as a single value.
   - device: /dev/sda
     type: 'sat,auto'
   - device: /dev/sdb

--- a/collector/pkg/config/testdata/device_type_empty.yaml
+++ b/collector/pkg/config/testdata/device_type_empty.yaml
@@ -1,0 +1,6 @@
+version: 1
+devices:
+  # An explicitly empty type must stay an empty (but non-nil) list, so the device
+  # is dropped rather than falling back to the scanned type.
+  - device: /dev/sda
+    type: ''

--- a/collector/pkg/config/testdata/device_type_jmb39x.yaml
+++ b/collector/pkg/config/testdata/device_type_jmb39x.yaml
@@ -1,0 +1,13 @@
+version: 1
+devices:
+  # QNAP TR-004 in Individual mode. A single bay addressed with the scalar form.
+  - device: /dev/sda
+    type: 'jmb39x-q,0'
+  # All four bays of one enclosure, each its own smartctl device type on the same
+  # device file.
+  - device: /dev/sdb
+    type:
+      - 'jmb39x-q,0'
+      - 'jmb39x-q,1'
+      - 'jmb39x-q,2'
+      - 'jmb39x-q,3'

--- a/collector/pkg/config/testdata/device_type_whitespace.yaml
+++ b/collector/pkg/config/testdata/device_type_whitespace.yaml
@@ -1,0 +1,10 @@
+version: 1
+devices:
+  # Surrounding whitespace must be trimmed: the type is handed verbatim to
+  # smartctl's --device flag.
+  - device: /dev/sda
+    type: ' jmb39x-q,0 '
+  - device: /dev/sdb
+    type:
+      - '  sat,auto '
+      - 'megaraid,14  '

--- a/collector/pkg/detect/detect.go
+++ b/collector/pkg/detect/detect.go
@@ -14,6 +14,7 @@ import (
 	"github.com/analogj/scrutiny/collector/pkg/config"
 	"github.com/analogj/scrutiny/collector/pkg/models"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/models/collector"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/smartctl"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/version"
 	"github.com/sirupsen/logrus"
 )
@@ -129,25 +130,33 @@ func (d *Detect) SmartCtlInfo(device *models.Device) error {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	availableDeviceInfoJson, err := d.Shell.CommandContext(ctx, d.Logger, d.Config.GetString("commands.metrics_smartctl_bin"), args, "", os.Environ())
-	var exitErr *exec.ExitError
-	if errors.As(err, &exitErr) {
-		exitCode := exitErr.ExitCode()
-		if exitCode&0xBF == 0 {
-			d.Logger.Warnf("Successfully retrieved device information for %s, but received exit code %d, which is a non-fatal exit code. Continuing.", device.DeviceName, exitCode)
-		} else {
+	if err != nil {
+		var exitErr *exec.ExitError
+		if !errors.As(err, &exitErr) {
+			// not a smartctl exit status at all (binary missing, context deadline, ...), so there is no output to salvage.
 			d.Logger.Errorf("Could not retrieve device information for %s: %v", device.DeviceName, err)
 			return err
 		}
+		exitCode := exitErr.ExitCode()
+		if smartctl.IsFatal(exitCode) {
+			d.Logger.Errorf("Could not retrieve device information for %s: smartctl exited with fatal code %d: %v", device.DeviceName, exitCode, err)
+			return err
+		}
+		// Every non-fatal bit describes a condition of the disk rather than of the
+		// output, and smartctl still prints a complete JSON document alongside it.
+		// QNAP TR-004 enclosures behind the jmb39x-q backend report
+		// "Read Device Statistics page 0x00 failed" and exit 4 on every run.
+		d.Logger.Warnf("smartctl returned non-fatal exit code %d while reading device information for %s; using the returned JSON", exitCode, device.DeviceName)
 	}
 
-	if err != nil {
-		d.Logger.Errorf("Could not retrieve device information for %s: %v", device.DeviceName, err)
-		return err
+	if strings.TrimSpace(availableDeviceInfoJson) == "" {
+		d.Logger.Errorf("Could not retrieve device information for %s: smartctl returned no output", device.DeviceName)
+		return fmt.Errorf("smartctl returned no output for device %s", device.DeviceName)
 	}
 
 	var availableDeviceInfo collector.SmartInfo
-	err = json.Unmarshal([]byte(availableDeviceInfoJson), &availableDeviceInfo)
-	if err != nil {
+	// shadow err deliberately: the outer err may still hold a tolerated *exec.ExitError.
+	if err := json.Unmarshal([]byte(availableDeviceInfoJson), &availableDeviceInfo); err != nil {
 		d.Logger.Errorf("Could not decode device information for %s: %v", device.DeviceName, err)
 		return err
 	}

--- a/collector/pkg/detect/detect_test.go
+++ b/collector/pkg/detect/detect_test.go
@@ -1,7 +1,10 @@
 package detect_test
 
 import (
+	"fmt"
 	"os"
+	"os/exec"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -222,6 +225,50 @@ func TestDetect_TransformDetectedDevices_Raid(t *testing.T) {
 
 	// assert
 	require.Equal(t, 12, len(transformedDevices))
+}
+
+// fixes #663: a QNAP TR-004 in Individual mode addresses all four bays through one
+// device file, one `jmb39x-q,N` device type per bay.
+func TestDetect_TransformDetectedDevices_Jmb39xIndividualMode(t *testing.T) {
+	// setup
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	fakeConfig := mock_config.NewMockInterface(mockCtrl)
+	fakeConfig.EXPECT().GetString("host.id").AnyTimes().Return("")
+	fakeConfig.EXPECT().IsAllowlistedDevice(gomock.Any()).AnyTimes().Return(true)
+	fakeConfig.EXPECT().GetDeviceOverrides().AnyTimes().Return([]models.ScanOverride{
+		{
+			Device:     "/dev/sda",
+			DeviceType: []string{"jmb39x-q,0", "jmb39x-q,1", "jmb39x-q,2", "jmb39x-q,3"},
+			Ignore:     false,
+		},
+	})
+	detectedDevices := models.Scan{
+		Devices: []models.ScanDevice{
+			{
+				Name:     "/dev/sda",
+				InfoName: "/dev/sda",
+				Protocol: "ATA",
+				Type:     "scsi",
+			},
+		},
+	}
+
+	d := detect.Detect{
+		Config: fakeConfig,
+	}
+
+	// test
+	transformedDevices := d.TransformDetectedDevices(detectedDevices)
+
+	// assert
+	require.Equal(t, 4, len(transformedDevices))
+	deviceTypes := []string{}
+	for _, transformedDevice := range transformedDevices {
+		assert.Equal(t, "sda", transformedDevice.DeviceName)
+		deviceTypes = append(deviceTypes, transformedDevice.DeviceType)
+	}
+	require.Equal(t, []string{"jmb39x-q,0", "jmb39x-q,1", "jmb39x-q,2", "jmb39x-q,3"}, deviceTypes)
 }
 
 func TestDetect_TransformDetectedDevices_Simple(t *testing.T) {
@@ -449,6 +496,148 @@ func TestDetect_SmartCtlInfo(t *testing.T) {
 		require.NotNil(t, someDevice.SmartSupport.Enabled)
 		require.True(t, *someDevice.SmartSupport.Enabled)
 	})
+
+	// fixes #663: a QNAP TR-004 enclosure reports "Read Device Statistics page 0x00
+	// failed" and exits 4 on every run, while still printing a complete JSON document.
+	t.Run("should accept usable JSON on a non-fatal exit status", func(t *testing.T) {
+		fakeShell, fakeConfig, someLogger := setupSmartCtlInfoMocks(t, "sda", "jmb39x-q,0",
+			"testdata/smartctl_info_jmb39x_exit4.json", exitErrorWithCode(t, 4))
+
+		d := detect.Detect{Logger: someLogger, Shell: fakeShell, Config: fakeConfig}
+		someDevice := &models.Device{DeviceName: "sda", DeviceType: "jmb39x-q,0"}
+
+		require.NoError(t, d.SmartCtlInfo(someDevice))
+
+		assert.Equal(t, "WDC WD40EFRX-68N32N0", someDevice.ModelName)
+		assert.Equal(t, "WD-WCC7K0000000", someDevice.SerialNumber)
+		assert.Equal(t, "82.00A82", someDevice.Firmware)
+		assert.Equal(t, int64(4000787030016), someDevice.Capacity)
+		assert.Equal(t, 5400, someDevice.RotationSpeed)
+		// an empty WWN is what produced the "No Data" dashboard: every InfluxDB query
+		// keys on the device_wwn tag.
+		require.NotEmpty(t, someDevice.WWN)
+		assert.Equal(t, strings.ToLower(someDevice.WWN), someDevice.WWN)
+		// invariant: a user-supplied device type is never overwritten by smartctl's own
+		assert.Equal(t, "jmb39x-q,0", someDevice.DeviceType)
+	})
+
+	t.Run("should reject output on a fatal exit status", func(t *testing.T) {
+		fakeShell, fakeConfig, someLogger := setupSmartCtlInfoMocks(t, "sda", "jmb39x-q,0",
+			"testdata/smartctl_info_jmb39x_exit4.json", exitErrorWithCode(t, 2))
+
+		d := detect.Detect{Logger: someLogger, Shell: fakeShell, Config: fakeConfig}
+		someDevice := &models.Device{DeviceName: "sda", DeviceType: "jmb39x-q,0"}
+
+		require.Error(t, d.SmartCtlInfo(someDevice))
+
+		// nothing may be copied out of output we decided not to trust
+		assert.Empty(t, someDevice.ModelName)
+		assert.Empty(t, someDevice.SerialNumber)
+		assert.Empty(t, someDevice.WWN)
+	})
+
+	t.Run("should reject empty output on a non-fatal exit status", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		fakeConfig := mock_config.NewMockInterface(ctrl)
+		fakeConfig.EXPECT().GetCommandMetricsInfoArgs("/dev/sda").Return("--info --json")
+		fakeConfig.EXPECT().GetString("commands.metrics_smartctl_bin").Return("smartctl")
+		fakeConfig.EXPECT().GetInt("commands.metrics_smartctl_timeout").Return(120)
+
+		someLogger := logrus.WithFields(logrus.Fields{})
+		fakeShell := mock_shell.NewMockInterface(ctrl)
+		fakeShell.EXPECT().
+			CommandContext(gomock.Any(), someLogger, "smartctl", gomock.Any(), "", gomock.Any()).
+			Return("   ", exitErrorWithCode(t, 4))
+
+		d := detect.Detect{Logger: someLogger, Shell: fakeShell, Config: fakeConfig}
+		someDevice := &models.Device{DeviceName: "sda"}
+
+		require.Error(t, d.SmartCtlInfo(someDevice))
+	})
+
+	// fixes #663: `jmb39x-q,0` must reach smartctl as one --device argument. The nvme
+	// subtest above uses an empty device type, so it never exercises this branch.
+	t.Run("should pass a comma-containing device type as one --device argument", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		fakeConfig := mock_config.NewMockInterface(ctrl)
+		fakeConfig.EXPECT().GetCommandMetricsInfoArgs("/dev/sda").Return("--info --json")
+		fakeConfig.EXPECT().GetString("commands.metrics_smartctl_bin").Return("smartctl")
+		fakeConfig.EXPECT().GetInt("commands.metrics_smartctl_timeout").Return(120)
+
+		smartctlInfoResults, err := os.ReadFile("testdata/smartctl_info_jmb39x_exit4.json")
+		require.NoError(t, err)
+
+		someLogger := logrus.WithFields(logrus.Fields{})
+		fakeShell := mock_shell.NewMockInterface(ctrl)
+		fakeShell.EXPECT().
+			CommandContext(gomock.Any(), someLogger, "smartctl",
+				[]string{"--info", "--json", "--device", "jmb39x-q,0", "/dev/sda"},
+				"", gomock.Any()).
+			Return(string(smartctlInfoResults), nil)
+
+		d := detect.Detect{Logger: someLogger, Shell: fakeShell, Config: fakeConfig}
+		someDevice := &models.Device{DeviceName: "sda", DeviceType: "jmb39x-q,0"}
+
+		require.NoError(t, d.SmartCtlInfo(someDevice))
+	})
+}
+
+// setupSmartCtlInfoMocks wires a shell that returns the given fixture and error for
+// any smartctl invocation. Use it when the assertion is about the parsed result
+// rather than about the exact argv.
+func setupSmartCtlInfoMocks(t *testing.T, deviceName string, deviceType string, fixturePath string, shellErr error) (*mock_shell.MockInterface, *mock_config.MockInterface, *logrus.Entry) {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	fakeConfig := mock_config.NewMockInterface(ctrl)
+	fakeConfig.EXPECT().GetCommandMetricsInfoArgs("/dev/" + deviceName).Return("--info --json")
+	fakeConfig.EXPECT().GetString("commands.metrics_smartctl_bin").Return("smartctl")
+	fakeConfig.EXPECT().GetInt("commands.metrics_smartctl_timeout").Return(120)
+
+	smartctlInfoResults, err := os.ReadFile(fixturePath)
+	require.NoError(t, err)
+
+	someLogger := logrus.WithFields(logrus.Fields{})
+	fakeShell := mock_shell.NewMockInterface(ctrl)
+	fakeShell.EXPECT().
+		CommandContext(gomock.Any(), someLogger, "smartctl",
+			[]string{"--info", "--json", "--device", deviceType, "/dev/" + deviceName},
+			"", gomock.Any()).
+		Return(string(smartctlInfoResults), shellErr)
+
+	return fakeShell, fakeConfig, someLogger
+}
+
+// exitErrorWithCode returns a genuine *exec.ExitError carrying the requested exit
+// status. os.ProcessState cannot be constructed directly, so a child process is
+// required; re-executing the test binary keeps this working on every platform the
+// collector builds for, unlike shelling out to `sh -c "exit N"`.
+func exitErrorWithCode(t *testing.T, code int) *exec.ExitError {
+	t.Helper()
+	cmd := exec.Command(os.Args[0], "-test.run=^TestDetectExitCodeHelperProcess$")
+	cmd.Env = append(os.Environ(), fmt.Sprintf("GO_DETECT_HELPER_EXIT_CODE=%d", code))
+
+	var exitErr *exec.ExitError
+	require.ErrorAs(t, cmd.Run(), &exitErr, "helper process should fail with an ExitError")
+	require.Equal(t, code, exitErr.ExitCode())
+	return exitErr
+}
+
+// TestDetectExitCodeHelperProcess is not a real test. It is the child process that
+// exitErrorWithCode re-executes in order to produce a real *exec.ExitError.
+func TestDetectExitCodeHelperProcess(t *testing.T) {
+	code := os.Getenv("GO_DETECT_HELPER_EXIT_CODE")
+	if code == "" {
+		t.Skip("helper process; not meant to be run directly")
+	}
+	parsed, err := strconv.Atoi(code)
+	require.NoError(t, err)
+	os.Exit(parsed)
 }
 
 func TestDetect_TransformDetectedDevices_LabelWithDeviceType(t *testing.T) {

--- a/collector/pkg/detect/testdata/smartctl_info_jmb39x_exit4.json
+++ b/collector/pkg/detect/testdata/smartctl_info_jmb39x_exit4.json
@@ -1,0 +1,88 @@
+{
+  "json_format_version": [
+    1,
+    0
+  ],
+  "smartctl": {
+    "version": [
+      7,
+      4
+    ],
+    "svn_revision": "5530",
+    "platform_info": "x86_64-linux-6.6.44",
+    "build_info": "(local build)",
+    "argv": [
+      "smartctl",
+      "--info",
+      "--json",
+      "--device",
+      "jmb39x-q,0",
+      "/dev/sda"
+    ],
+    "messages": [
+      {
+        "string": "Read Device Statistics page 0x00 failed: Invalid argument",
+        "severity": "error"
+      }
+    ],
+    "exit_status": 4
+  },
+  "device": {
+    "name": "/dev/sda",
+    "info_name": "/dev/sda [SAT], JMB39x-Q port 0",
+    "type": "jmb39x-q,0",
+    "protocol": "ATA"
+  },
+  "model_family": "Western Digital Red",
+  "model_name": "WDC WD40EFRX-68N32N0",
+  "serial_number": "WD-WCC7K0000000",
+  "wwn": {
+    "naa": 5,
+    "oui": 3274,
+    "id": 6606201856
+  },
+  "firmware_version": "82.00A82",
+  "user_capacity": {
+    "blocks": 7814037168,
+    "bytes": 4000787030016
+  },
+  "logical_block_size": 512,
+  "physical_block_size": 4096,
+  "rotation_rate": 5400,
+  "form_factor": {
+    "ata_value": 2,
+    "name": "3.5 inches"
+  },
+  "in_smartctl_database": true,
+  "ata_version": {
+    "string": "ACS-3 T13/2161-D revision 5",
+    "major_value": 1020,
+    "minor_value": 110
+  },
+  "sata_version": {
+    "string": "SATA 3.3",
+    "value": 63
+  },
+  "interface_speed": {
+    "max": {
+      "sata_value": 14,
+      "string": "6.0 Gb/s",
+      "units_per_second": 60,
+      "bits_per_unit": 100000000
+    },
+    "current": {
+      "sata_value": 3,
+      "string": "6.0 Gb/s",
+      "units_per_second": 60,
+      "bits_per_unit": 100000000
+    }
+  },
+  "smart_support": {
+    "available": true,
+    "enabled": true
+  },
+  "local_time": {
+    "time_t": 1753660800,
+    "asctime": "Sun Jul 27 00:00:00 2025 UTC"
+  }
+}

--- a/docs/TROUBLESHOOTING_DEVICE_COLLECTOR.md
+++ b/docs/TROUBLESHOOTING_DEVICE_COLLECTOR.md
@@ -135,6 +135,56 @@ devices:
 
 >
 
+### USB/SATA Enclosures (JMicron JMB39x - QNAP TR-004/TR-002)
+
+Multi-bay enclosures built on the JMicron JMB39x bridge present every bay through a single
+device file. smartctl reaches the individual disks with the `jmb39x-q,N` device type, where
+`N` is the zero-based bay index. This requires smartmontools 7.3 or newer on the host that
+runs the collector.
+
+The enclosure must be in **Individual** mode. In the hardware RAID modes the bridge hides the
+member disks and no per-disk SMART data is available at all.
+
+Confirm the backend works before configuring Scrutiny:
+
+```bash
+# which device file the enclosure is behind
+smartctl --scan
+
+# probe each bay; repeat for 1, 2, 3
+smartctl -i -d jmb39x-q,0 /dev/sdb
+```
+
+Then list one type per populated bay:
+
+```yaml
+# /opt/scrutiny/config/collector.yaml
+devices:
+  - device: /dev/sdb
+    type:
+      - 'jmb39x-q,0'
+      - 'jmb39x-q,1'
+      - 'jmb39x-q,2'
+      - 'jmb39x-q,3'
+```
+
+A single bay can also be written as a plain value, `type: 'jmb39x-q,0'`. The comma belongs to
+the device type and is not a separator.
+
+> NOTE: as with RAID controllers, if you use docker you **must** pass the device file through
+> to the container with `--device=/dev/sdb`, and add `--cap-add SYS_RAWIO`.
+
+On many of these enclosures smartctl prints `Read Device Statistics page 0x00 failed` and
+exits with code 4 on every run. That is a warning about one optional log page, not a failure:
+the identity and SMART attributes in the same response are complete, and the collector uses
+them. See [Exit Codes](#exit-codes) below.
+
+> If you monitored one of these disks on a Scrutiny release older than the fix for
+> [#663](https://github.com/Starosdev/scrutiny/issues/663), it was registered without a model,
+> serial or WWN. Once the collector can read its identity the disk registers under a new
+> device id, and the old entry remains behind showing no data. Delete the stale entry; its
+> history is empty and cannot be merged usefully.
+
 ### NVMe Drives
 
 As mentioned in the [README.md](../README.md), NVMe devices require both `--cap-add SYS_RAWIO` and `--cap-add SYS_ADMIN`

--- a/example.collector.yaml
+++ b/example.collector.yaml
@@ -56,9 +56,19 @@ devices:
 #  - device: /dev/sda
 #    type: 'sat'
 #
-#  # example for using `-d sat,auto`, notice the square brackets (workaround for #418)
+#  # a device type containing a comma is still a single type, so quote it and leave
+#  # it as a plain value. A list is only needed to give one device several types.
 #  - device: /dev/sda
-#    type: ['sat,auto']
+#    type: 'sat,auto'
+#
+#  # example for a QNAP TR-004 (or other JMicron JMB39x enclosure) in Individual
+#  # mode: every bay is addressed through the same device file, with its own type.
+#  - device: /dev/sdb
+#    type:
+#      - 'jmb39x-q,0'
+#      - 'jmb39x-q,1'
+#      - 'jmb39x-q,2'
+#      - 'jmb39x-q,3'
 #
 #  # example to show how to ignore a specific disk/device.
 #  - device: /dev/sda

--- a/webapp/backend/pkg/smartctl/exit_status.go
+++ b/webapp/backend/pkg/smartctl/exit_status.go
@@ -1,0 +1,36 @@
+// Package smartctl holds shared knowledge about the smartctl command-line tool
+// that both the collector and the web server need to agree on.
+package smartctl
+
+// smartctl reports its result through a bitmask exit status. The bits below are
+// defined by the smartctl manpage, "RETURN VALUES":
+// http://www.linuxguide.it/command_line/linux-manpage/do.php?file=smartctl#sect7
+const (
+	ExitCommandLineError      = 0x01 // command line did not parse
+	ExitDeviceOpenFailed      = 0x02 // device open failed, or device did not return an IDENTIFY DEVICE structure
+	ExitChecksumError         = 0x04 // some SMART command failed, or there was a checksum error in a SMART data structure
+	ExitDiskFailing           = 0x08 // SMART status check returned "DISK FAILING"
+	ExitPrefailBelowThreshold = 0x10 // found prefail attributes at or below threshold
+	ExitUsageBelowThreshold   = 0x20 // some attributes have been at or below threshold at some time in the past
+	ExitErrorLogHasRecords    = 0x40 // the device error log contains records of errors
+	ExitSelfTestLogHasErrors  = 0x80 // the device self-test log contains records of errors
+)
+
+// FatalMask is the set of exit-status bits that mean the JSON payload smartctl
+// printed cannot be trusted: the command was never understood (0x01), or the
+// device was never opened and so no IDENTIFY structure was read (0x02).
+//
+// Every other bit describes a condition of the *disk*, not of the output.
+// smartctl still emits complete, well-formed JSON alongside them. Treating any
+// of those as fatal throws away usable data - see issue 663, where a QNAP TR-004
+// enclosure reports "Read Device Statistics page 0x00 failed" and exits 4 while
+// returning a full identity and attribute set.
+const FatalMask = ExitCommandLineError | ExitDeviceOpenFailed
+
+// IsFatal reports whether a smartctl exit status means the accompanying output
+// must be discarded. This single rule is applied at every point that inspects an
+// exit status: device detection, metrics collection, and server-side upload
+// validation.
+func IsFatal(exitStatus int) bool {
+	return exitStatus&FatalMask != 0
+}

--- a/webapp/backend/pkg/web/handler/upload_device_metrics.go
+++ b/webapp/backend/pkg/web/handler/upload_device_metrics.go
@@ -13,6 +13,7 @@ import (
 	"github.com/analogj/scrutiny/webapp/backend/pkg/models/measurements"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/mqtt"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/notify"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/smartctl"
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
 )
@@ -120,8 +121,8 @@ func bindAndValidateSmartInfo(c *gin.Context, logger *logrus.Entry, deviceWWN st
 }
 
 func validateSmartExitStatus(c *gin.Context, logger *logrus.Entry, deviceWWN string, exitStatus int) bool {
-	if exitStatus&0x03 != 0 {
-		logger.Warnf("Rejecting SMART data for device %s: smartctl exit_status %d has fatal bits set (mask 0x03)", deviceWWN, exitStatus)
+	if smartctl.IsFatal(exitStatus) {
+		logger.Warnf("Rejecting SMART data for device %s: smartctl exit_status %d has fatal bits set (mask 0x%02x)", deviceWWN, exitStatus, smartctl.FatalMask)
 		c.JSON(http.StatusUnprocessableEntity, gin.H{
 			"success": false,
 			"error":   fmt.Sprintf("smartctl exit_status %d indicates unreliable data (bits 0-1 set)", exitStatus),


### PR DESCRIPTION
Fixes #663.

## Summary

QNAP TR-004 enclosures in Individual mode address each bay through the smartmontools `jmb39x-q,N` backend. Two independent collector defects made those disks unmonitorable. Both are fixed here.

## Bug A: comma-containing device types were split at config parse time

The argument construction was never at fault. All three `--device` sites already append the type as a single element, and the shell layer uses `exec.CommandContext` with no re-tokenization. The damage happened earlier: viper installs its own `stringToWeakSliceHookFunc(",")` decode hook, which splits a scalar string when the destination is a slice. `type: 'jmb39x-q,0'` therefore decoded to the two bogus types `jmb39x-q` and `0`.

A comma belongs to the smartctl device-type grammar (`megaraid,14`, `sat,auto`, `jmb39x-q,0`), it is not a separator between types. `GetDeviceOverrides` now overrides `DecodeHook` for the `devices` key so `WeaklyTypedInput` lifts a scalar into a one-element slice verbatim. The list form is unchanged.

Two edge cases that removing the hook opens up are handled by a new `normalizeDeviceOverrides`: configured types are trimmed, and an explicitly empty type stays an empty but non-nil slice so `buildOverrideDeviceGroup` keeps dropping the device rather than falling back to the scanned type.

## Bug B: any non-zero smartctl exit aborted device identification

`SmartCtlInfo` masked the exit code with `0xBF`, but the tolerant branch logged "Continuing." and then fell straight into the pre-existing `if err != nil { return err }`. It was dead code: no non-zero smartctl exit had ever survived detection, including the bit-6 case the mask was added for.

These enclosures report `Read Device Statistics page 0x00 failed` and exit 4 on every run while printing a complete JSON document. The disk was therefore registered with no model, serial or WWN. The empty WWN is the actual cause of the reported "No Data": every InfluxDB query filters on the `device_wwn` tag. This means users on the documented list-form workaround were still broken, because their `Collect` calls were publishing fine under the existing `0x03` rule while detection threw the identity away.

Detection now applies the same rule the collection path and the server's `validateSmartExitStatus` already used: only bits `0x01` and `0x02` mean the payload cannot be trusted, since every other bit describes a condition of the disk rather than of the output. The three copies of that rule are replaced by a shared `webapp/backend/pkg/smartctl` package. Detection additionally rejects empty output, so genuinely unusable results are still refused.

## Behavior changes reviewers should weigh

**Scalar comma semantics.** `type: 'sat,auto'` previously yielded the two types `sat` and `auto`. It now yields one. Both old outputs were nonsense as smartctl device types and neither has ever worked, so no realistic configuration can depend on the old behavior, and no compatibility path is included. The list form is unaffected; `TestConfiguration_GetScanOverrides_Raid` is the unchanged proof.

**Affected devices re-register under a new id.** `deviceid` is untouched and `DeviceType` is not an identity input, so the parsing change cannot re-id anything by itself. But a drive that is identity-less today resolves through the `device_name`+`host_id` fallback; once its model, serial and WWN can be read it hashes differently and appears as a new device, orphaning the old "No Data" row. This is unavoidable, and is the desired outcome. The troubleshooting doc tells affected users to delete the stale entry, whose history is empty-WWN and cannot be merged usefully.

**This supersedes a documented asymmetry.** The knowledge base recorded the two exit-code masks as deliberately different and instructed against unifying them. `git log -S 0xBF` shows the mask arrived as a narrow bit-6 spot-fix whose lines were inserted above the existing `return err`, so the documented tolerance never executed. The invariant described an intent the code never implemented. ADR 0008 records the decision.

## Tests

13 new tests, all passing.

- Config: comma preservation in scalar and list form, the four-bay `jmb39x-q` layout, whitespace trimming, and the empty-vs-nil device type distinction.
- Detect: valid JSON accepted on a non-fatal exit 4 with identity and a lowercase WWN populated; output rejected on fatal exit 2 with no fields copied; empty output rejected; `jmb39x-q,0` asserted as one `--device` argument. The existing `SmartCtlInfo` test used an empty device type, so that branch had no coverage at all.
- Metrics collector: `--device` argv asserted on both the `--xall` and FARM calls (the two sites besides detection that must stay identical), publish on non-fatal exit, and error report without publish on fatal exit. `Collect` previously had no coverage.

Exit statuses come from a real `*exec.ExitError`, produced by re-executing the test binary as a helper process rather than shelling out to `sh -c`, so the tests stay portable.

Verified: `go test ./collector/...`, backend handler exit-status tests, `go vet`, `gofmt`, `go mod vendor` clean, and `grep 0xBF` returns nothing.

## Not covered here

No TR-004 hardware was available, so the end-to-end acceptance criterion is unverified on real hardware. The detect fixture is modeled on a standard SAT `--info --json` response rather than captured from a real `jmb39x-q` device; replacing it with sanitized real output would make the regression test stronger.
