### PR TITLE
fix(collector): pass explicitly configured smartctl device types verbatim

### DIFF
--- a/collector/pkg/collector/metrics.go
+++ b/collector/pkg/collector/metrics.go
@@ -194,10 +194,7 @@ func (mc *MetricsCollector) Collect(deviceID string, deviceName string, deviceTy
 
 	fullDeviceName := detect.DeviceFullPath(deviceName)
 	args := strings.Split(mc.config.GetCommandMetricsSmartArgs(fullDeviceName), " ")
-	//only include the device type if its a non-standard one. In some cases ata drives are detected as scsi in docker, and metadata is lost.
-	if len(deviceType) > 0 && deviceType != "scsi" && deviceType != "ata" {
-		args = append(args, "--device", deviceType)
-	}
+	args = detect.AppendDeviceTypeArgs(args, mc.config.GetDeviceOverrides(), fullDeviceName, deviceType)
 	args = append(args, fullDeviceName)
 
 	timeout := time.Duration(mc.config.GetInt("commands.metrics_smartctl_timeout")) * time.Second
@@ -247,9 +244,7 @@ func (mc *MetricsCollector) Collect(deviceID string, deviceName string, deviceTy
 // unmodified if FARM collection fails or the drive does not support FARM.
 func (mc *MetricsCollector) collectAndMergeFarm(smartJson []byte, fullDeviceName string, deviceType string, deviceName string) []byte {
 	farmArgs := strings.Split(mc.config.GetString("commands.metrics_farm_args"), " ")
-	if len(deviceType) > 0 && deviceType != "scsi" && deviceType != "ata" {
-		farmArgs = append(farmArgs, "--device", deviceType)
-	}
+	farmArgs = detect.AppendDeviceTypeArgs(farmArgs, mc.config.GetDeviceOverrides(), fullDeviceName, deviceType)
 	farmArgs = append(farmArgs, fullDeviceName)
 
 	farmTimeout := time.Duration(mc.config.GetInt("commands.metrics_smartctl_timeout")) * time.Second

--- a/collector/pkg/collector/metrics_collect_test.go
+++ b/collector/pkg/collector/metrics_collect_test.go
@@ -68,6 +68,76 @@ func TestMetricsCollector_Collect_PassesCommaDeviceTypeToFarmCall(t *testing.T) 
 	mc.Collect("some-device-id", "sda", "jmb39x-q,0")
 }
 
+// fixes #664: an explicit type is the documented remedy for Hitachi and Toshiba
+// drives that report a false failure and zero SMART values under auto-detection, so
+// it has to reach the SMART and FARM calls, not only the detection call.
+func TestMetricsCollector_Collect_PassesConfiguredDeviceType(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	fakeShell := mock_shell.NewMockInterface(ctrl)
+	fakeShell.EXPECT().
+		CommandContext(gomock.Any(), gomock.Any(), "smartctl",
+			[]string{"--xall", "--json", "--device", "sat", "/dev/sda"},
+			"", gomock.Any()).
+		Return(someSmartPayload, nil)
+	fakeShell.EXPECT().
+		CommandContext(gomock.Any(), gomock.Any(), "smartctl",
+			[]string{"-l", "farm", "--json", "--device", "sat", "/dev/sda"},
+			"", gomock.Any()).
+		Return(`{"seagate_farm_log":{}}`, nil)
+
+	mc := newTestCollectCollector(t, fakeShell, nil)
+	mc.config.Set("commands.metrics_farm_enabled", true)
+	setDeviceOverrides(mc, map[string]interface{}{"device": "/dev/sda", "type": "sat"})
+
+	mc.Collect("some-device-id", "sda", "sat")
+}
+
+// fixes #664: "scsi" and "ata" are suppressed only because `smartctl --scan`
+// mislabels ATA drives as scsi in docker. A configured type is an instruction and is
+// passed even when it is one of those two.
+func TestMetricsCollector_Collect_PassesConfiguredStandardDeviceType(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	fakeShell := mock_shell.NewMockInterface(ctrl)
+	fakeShell.EXPECT().
+		CommandContext(gomock.Any(), gomock.Any(), "smartctl",
+			[]string{"--xall", "--json", "--device", "scsi", "/dev/sda"},
+			"", gomock.Any()).
+		Return(someSmartPayload, nil)
+
+	mc := newTestCollectCollector(t, fakeShell, nil)
+	setDeviceOverrides(mc, map[string]interface{}{"device": "/dev/sda", "type": "scsi"})
+
+	mc.Collect("some-device-id", "sda", "scsi")
+}
+
+// A scanned "scsi" with nothing configured keeps today's behavior: no --device, so a
+// drive that docker mislabels as scsi still reports its ATA metadata.
+func TestMetricsCollector_Collect_SuppressesScannedStandardDeviceType(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	fakeShell := mock_shell.NewMockInterface(ctrl)
+	fakeShell.EXPECT().
+		CommandContext(gomock.Any(), gomock.Any(), "smartctl",
+			[]string{"--xall", "--json", "/dev/sda"},
+			"", gomock.Any()).
+		Return(someSmartPayload, nil)
+	fakeShell.EXPECT().
+		CommandContext(gomock.Any(), gomock.Any(), "smartctl",
+			[]string{"-l", "farm", "--json", "/dev/sda"},
+			"", gomock.Any()).
+		Return(`{"seagate_farm_log":{}}`, nil)
+
+	mc := newTestCollectCollector(t, fakeShell, nil)
+	mc.config.Set("commands.metrics_farm_enabled", true)
+
+	mc.Collect("some-device-id", "sda", "scsi")
+}
+
 // Only exit-status bits 0-1 invalidate the payload. Bit 2 accompanies the QNAP
 // TR-004 "Read Device Statistics page 0x00 failed" warning and must still publish.
 func TestMetricsCollector_Collect_PublishesOnNonFatalExitStatus(t *testing.T) {
@@ -148,6 +218,13 @@ func newTestCollectCollector(t *testing.T, fakeShell *mock_shell.MockInterface, 
 			httpClient: client,
 		},
 	}
+}
+
+// setDeviceOverrides writes a 'devices' section into the collector's config, the way
+// a user would in collector.yaml. GetDeviceOverrides memoizes its result, so this has
+// to run before the first call that reads it.
+func setDeviceOverrides(mc MetricsCollector, overrides ...map[string]interface{}) {
+	mc.config.Set("devices", overrides)
 }
 
 // collectExitErrorWithCode returns a genuine *exec.ExitError carrying the requested

--- a/collector/pkg/detect/detect.go
+++ b/collector/pkg/detect/detect.go
@@ -78,6 +78,64 @@ func normalizeDeviceName(deviceName string) string {
 	return strings.TrimSpace(stripDevicePrefix(deviceName))
 }
 
+// isAutoDetectedDeviceType reports whether a device type is one that smartctl
+// determines on its own just as well as we can. "ata" and "scsi" are the two
+// values `smartctl --scan` hands back for ordinary disks, and in docker an ATA
+// drive is frequently reported as scsi; forcing "--device scsi" on it loses
+// metadata. "nvme" is not in this set because it has always been passed through.
+func isAutoDetectedDeviceType(deviceType string) bool {
+	switch strings.ToLower(strings.TrimSpace(deviceType)) {
+	case "ata", "scsi":
+		return true
+	default:
+		return false
+	}
+}
+
+// IsConfiguredDeviceType reports whether deviceType was written by the user in the
+// 'devices' section of collector.yaml for fullDeviceName, rather than derived from
+// `smartctl --scan`. The device path is matched case-insensitively, matching
+// config.GetCommandMetricsInfoArgs; the type is matched trimmed and
+// case-insensitively, because the configured value is what ends up in
+// models.Device.DeviceType verbatim.
+func IsConfiguredDeviceType(overrides []models.ScanOverride, fullDeviceName string, deviceType string) bool {
+	wanted := strings.ToLower(strings.TrimSpace(deviceType))
+	if wanted == "" {
+		return false
+	}
+	for _, override := range overrides {
+		if !strings.EqualFold(strings.TrimSpace(override.Device), strings.TrimSpace(fullDeviceName)) {
+			continue
+		}
+		for _, configuredType := range override.DeviceType {
+			if strings.ToLower(strings.TrimSpace(configuredType)) == wanted {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// AppendDeviceTypeArgs appends "--device <type>" to args when the type has to reach
+// smartctl. A type written in collector.yaml is always passed verbatim, including
+// "ata" and "scsi", because an explicit type is the documented remedy for drives
+// (some Hitachi and Toshiba models) that report a false failure and zero SMART
+// values under auto-detection. A type that only came from `smartctl --scan` keeps
+// the historical behavior and is suppressed when it is "ata" or "scsi".
+//
+// This is the single place where the device type is turned into smartctl arguments;
+// the detection, SMART collection and FARM calls all route through it so they cannot
+// drift apart. Fixes #664.
+func AppendDeviceTypeArgs(args []string, overrides []models.ScanOverride, fullDeviceName string, deviceType string) []string {
+	if strings.TrimSpace(deviceType) == "" {
+		return args
+	}
+	if !IsConfiguredDeviceType(overrides, fullDeviceName, deviceType) && isAutoDetectedDeviceType(deviceType) {
+		return args
+	}
+	return append(args, "--device", deviceType)
+}
+
 //private/common functions
 
 // This function calls smartctl --scan which can be used to detect storage devices.
@@ -120,10 +178,7 @@ func (d *Detect) SmartCtlInfo(device *models.Device) error {
 	}
 	fullDeviceName := DeviceFullPath(device.DeviceName)
 	args := strings.Split(d.Config.GetCommandMetricsInfoArgs(fullDeviceName), " ")
-	//only include the device type if its a non-standard one. In some cases ata drives are detected as scsi in docker, and metadata is lost.
-	if len(device.DeviceType) > 0 && device.DeviceType != "scsi" && device.DeviceType != "ata" {
-		args = append(args, "--device", device.DeviceType)
-	}
+	args = AppendDeviceTypeArgs(args, d.Config.GetDeviceOverrides(), fullDeviceName, device.DeviceType)
 	args = append(args, fullDeviceName)
 
 	timeout := time.Duration(d.Config.GetInt("commands.metrics_smartctl_timeout")) * time.Second

--- a/collector/pkg/detect/detect_test.go
+++ b/collector/pkg/detect/detect_test.go
@@ -630,8 +630,10 @@ func TestDetect_SmartCtlInfo(t *testing.T) {
 
 		assert.Empty(t, someDevice.ModelName)
 		assert.Empty(t, someDevice.SerialNumber)
-		assert.Empty(t, someDevice.WWN)
 		assert.False(t, someDevice.SmartSupport.Available)
+		// WWN is deliberately not asserted: with no wwn block in the response the
+		// platform-specific wwnFallback runs, and on a Linux host it reports whatever
+		// real disk happens to sit at /dev/sda.
 	})
 
 	// fixes #664: "scsi" and "ata" are suppressed only because `smartctl --scan`

--- a/collector/pkg/detect/detect_test.go
+++ b/collector/pkg/detect/detect_test.go
@@ -461,6 +461,10 @@ func TestDetect_SmartCtlInfo(t *testing.T) {
 		fakeConfig.EXPECT().
 			GetInt("commands.metrics_smartctl_timeout").
 			Return(120)
+		fakeConfig.EXPECT().
+			GetDeviceOverrides().
+			Return(nil).
+			AnyTimes()
 
 		someLogger := logrus.WithFields(logrus.Fields{})
 
@@ -544,6 +548,7 @@ func TestDetect_SmartCtlInfo(t *testing.T) {
 		fakeConfig.EXPECT().GetCommandMetricsInfoArgs("/dev/sda").Return("--info --json")
 		fakeConfig.EXPECT().GetString("commands.metrics_smartctl_bin").Return("smartctl")
 		fakeConfig.EXPECT().GetInt("commands.metrics_smartctl_timeout").Return(120)
+		fakeConfig.EXPECT().GetDeviceOverrides().Return(nil).AnyTimes()
 
 		someLogger := logrus.WithFields(logrus.Fields{})
 		fakeShell := mock_shell.NewMockInterface(ctrl)
@@ -567,6 +572,7 @@ func TestDetect_SmartCtlInfo(t *testing.T) {
 		fakeConfig.EXPECT().GetCommandMetricsInfoArgs("/dev/sda").Return("--info --json")
 		fakeConfig.EXPECT().GetString("commands.metrics_smartctl_bin").Return("smartctl")
 		fakeConfig.EXPECT().GetInt("commands.metrics_smartctl_timeout").Return(120)
+		fakeConfig.EXPECT().GetDeviceOverrides().Return(nil).AnyTimes()
 
 		smartctlInfoResults, err := os.ReadFile("testdata/smartctl_info_jmb39x_exit4.json")
 		require.NoError(t, err)
@@ -584,6 +590,151 @@ func TestDetect_SmartCtlInfo(t *testing.T) {
 
 		require.NoError(t, d.SmartCtlInfo(someDevice))
 	})
+
+	// fixes #664: some Hitachi and Toshiba drives report a false failure and zero
+	// SMART values under auto-detection, and only return usable data with an explicit
+	// type. The configured type must therefore reach smartctl on the detection call.
+	t.Run("should pass an explicitly configured device type", func(t *testing.T) {
+		fakeShell, fakeConfig, someLogger := setupSmartCtlInfoArgvMocks(t, "sda",
+			[]string{"--info", "--json", "--device", "sat", "/dev/sda"},
+			"testdata/smartctl_info_hitachi_sat.json", nil,
+			[]models.ScanOverride{{Device: "/dev/sda", DeviceType: []string{"sat"}}})
+
+		d := detect.Detect{Logger: someLogger, Shell: fakeShell, Config: fakeConfig}
+		someDevice := &models.Device{DeviceName: "sda", DeviceType: "sat"}
+
+		require.NoError(t, d.SmartCtlInfo(someDevice))
+
+		// the zero-metric symptom: without the explicit type this drive answers with no
+		// model, no serial, no WWN and smart_support.available false.
+		assert.Equal(t, "Hitachi HDS723030ALA640", someDevice.ModelName)
+		assert.Equal(t, "MK0000000000000", someDevice.SerialNumber)
+		assert.Equal(t, int64(3000592982016), someDevice.Capacity)
+		assert.Equal(t, 7200, someDevice.RotationSpeed)
+		require.NotEmpty(t, someDevice.WWN)
+		require.True(t, someDevice.SmartSupport.Available)
+		assert.Equal(t, "sat", someDevice.DeviceType)
+	})
+
+	// the failure this fixture captures is what the user sees before configuring an
+	// explicit type: smartctl auto-detects the drive as scsi and reports nothing usable.
+	t.Run("should record the zero-metric response when the type is auto-detected", func(t *testing.T) {
+		fakeShell, fakeConfig, someLogger := setupSmartCtlInfoArgvMocks(t, "sda",
+			[]string{"--info", "--json", "/dev/sda"},
+			"testdata/smartctl_info_hitachi_autodetect.json", exitErrorWithCode(t, 4), nil)
+
+		d := detect.Detect{Logger: someLogger, Shell: fakeShell, Config: fakeConfig}
+		someDevice := &models.Device{DeviceName: "sda", DeviceType: "scsi"}
+
+		require.NoError(t, d.SmartCtlInfo(someDevice))
+
+		assert.Empty(t, someDevice.ModelName)
+		assert.Empty(t, someDevice.SerialNumber)
+		assert.Empty(t, someDevice.WWN)
+		assert.False(t, someDevice.SmartSupport.Available)
+	})
+
+	// fixes #664: "scsi" and "ata" are suppressed only because `smartctl --scan`
+	// mislabels ATA drives as scsi in docker. A type the user wrote down is an
+	// instruction, not a guess, and must be passed even when it is one of those two.
+	t.Run("should pass an explicitly configured standard device type", func(t *testing.T) {
+		fakeShell, fakeConfig, someLogger := setupSmartCtlInfoArgvMocks(t, "sda",
+			[]string{"--info", "--json", "--device", "scsi", "/dev/sda"},
+			"testdata/smartctl_info_hitachi_sat.json", nil,
+			[]models.ScanOverride{{Device: "/dev/sda", DeviceType: []string{"scsi"}}})
+
+		d := detect.Detect{Logger: someLogger, Shell: fakeShell, Config: fakeConfig}
+		someDevice := &models.Device{DeviceName: "sda", DeviceType: "scsi"}
+
+		require.NoError(t, d.SmartCtlInfo(someDevice))
+	})
+
+	// a configured device with no type of its own inherits the scanned type, which is
+	// still a guess, so the suppression has to survive the override lookup.
+	t.Run("should suppress a scanned standard device type for a configured device", func(t *testing.T) {
+		fakeShell, fakeConfig, someLogger := setupSmartCtlInfoArgvMocks(t, "sda",
+			[]string{"--info", "--json", "/dev/sda"},
+			"testdata/smartctl_info_hitachi_sat.json", nil,
+			[]models.ScanOverride{{Device: "/dev/sda", Label: "some label"}})
+
+		d := detect.Detect{Logger: someLogger, Shell: fakeShell, Config: fakeConfig}
+		someDevice := &models.Device{DeviceName: "sda", DeviceType: "scsi"}
+
+		require.NoError(t, d.SmartCtlInfo(someDevice))
+	})
+
+	// the old guard compared the raw string, so an uppercase scanned type slipped
+	// through as `--device SCSI` while its lowercase twin was suppressed.
+	t.Run("should suppress an uppercase scanned standard device type", func(t *testing.T) {
+		fakeShell, fakeConfig, someLogger := setupSmartCtlInfoArgvMocks(t, "sda",
+			[]string{"--info", "--json", "/dev/sda"},
+			"testdata/smartctl_info_hitachi_sat.json", nil, nil)
+
+		d := detect.Detect{Logger: someLogger, Shell: fakeShell, Config: fakeConfig}
+		someDevice := &models.Device{DeviceName: "sda", DeviceType: "SCSI"}
+
+		require.NoError(t, d.SmartCtlInfo(someDevice))
+	})
+}
+
+func TestDetect_AppendDeviceTypeArgs(t *testing.T) {
+	someOverrides := []models.ScanOverride{
+		{Device: "/dev/sda", DeviceType: []string{"sat"}},
+		{Device: "/dev/SDB", DeviceType: []string{"ata"}},
+		{Device: "/dev/sdc", DeviceType: []string{"jmb39x-q,0", "jmb39x-q,1"}},
+	}
+
+	testCases := []struct {
+		name           string
+		fullDeviceName string
+		deviceType     string
+		expected       []string
+	}{
+		{"no type", "/dev/sdz", "", []string{"--info"}},
+		{"whitespace only type", "/dev/sdz", "   ", []string{"--info"}},
+		{"scanned scsi is suppressed", "/dev/sdz", "scsi", []string{"--info"}},
+		{"scanned ata is suppressed", "/dev/sdz", "ata", []string{"--info"}},
+		{"scanned nvme is passed", "/dev/sdz", "nvme", []string{"--info", "--device", "nvme"}},
+		{"scanned controller type is passed", "/dev/sdz", "megaraid,4", []string{"--info", "--device", "megaraid,4"}},
+		{"configured sat is passed", "/dev/sda", "sat", []string{"--info", "--device", "sat"}},
+		{"configured ata is passed with a case-insensitive path match", "/dev/sdb", "ata", []string{"--info", "--device", "ata"}},
+		{"configured type list member is passed", "/dev/sdc", "jmb39x-q,1", []string{"--info", "--device", "jmb39x-q,1"}},
+		{"type configured for another device is not honored", "/dev/sdz", "sat", []string{"--info", "--device", "sat"}},
+		{"standard type configured for another device is suppressed", "/dev/sdz", "ata", []string{"--info"}},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			assert.Equal(t, testCase.expected,
+				detect.AppendDeviceTypeArgs([]string{"--info"}, someOverrides, testCase.fullDeviceName, testCase.deviceType))
+		})
+	}
+}
+
+// setupSmartCtlInfoArgvMocks wires a shell that only answers the exact argv given,
+// with the configured device overrides in place. Use it when the assertion is about
+// which arguments reach smartctl; an argv mismatch fails the test through gomock.
+func setupSmartCtlInfoArgvMocks(t *testing.T, deviceName string, expectedArgs []string, fixturePath string, shellErr error, overrides []models.ScanOverride) (*mock_shell.MockInterface, *mock_config.MockInterface, *logrus.Entry) {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	fakeConfig := mock_config.NewMockInterface(ctrl)
+	fakeConfig.EXPECT().GetCommandMetricsInfoArgs("/dev/" + deviceName).Return("--info --json")
+	fakeConfig.EXPECT().GetString("commands.metrics_smartctl_bin").Return("smartctl")
+	fakeConfig.EXPECT().GetInt("commands.metrics_smartctl_timeout").Return(120)
+	fakeConfig.EXPECT().GetDeviceOverrides().Return(overrides).AnyTimes()
+
+	smartctlInfoResults, err := os.ReadFile(fixturePath)
+	require.NoError(t, err)
+
+	someLogger := logrus.WithFields(logrus.Fields{})
+	fakeShell := mock_shell.NewMockInterface(ctrl)
+	fakeShell.EXPECT().
+		CommandContext(gomock.Any(), someLogger, "smartctl", expectedArgs, "", gomock.Any()).
+		Return(string(smartctlInfoResults), shellErr)
+
+	return fakeShell, fakeConfig, someLogger
 }
 
 // setupSmartCtlInfoMocks wires a shell that returns the given fixture and error for
@@ -598,6 +749,7 @@ func setupSmartCtlInfoMocks(t *testing.T, deviceName string, deviceType string, 
 	fakeConfig.EXPECT().GetCommandMetricsInfoArgs("/dev/" + deviceName).Return("--info --json")
 	fakeConfig.EXPECT().GetString("commands.metrics_smartctl_bin").Return("smartctl")
 	fakeConfig.EXPECT().GetInt("commands.metrics_smartctl_timeout").Return(120)
+	fakeConfig.EXPECT().GetDeviceOverrides().Return(nil).AnyTimes()
 
 	smartctlInfoResults, err := os.ReadFile(fixturePath)
 	require.NoError(t, err)

--- a/collector/pkg/detect/testdata/smartctl_info_hitachi_autodetect.json
+++ b/collector/pkg/detect/testdata/smartctl_info_hitachi_autodetect.json
@@ -1,0 +1,49 @@
+{
+  "json_format_version": [
+    1,
+    0
+  ],
+  "smartctl": {
+    "version": [
+      7,
+      4
+    ],
+    "svn_revision": "5530",
+    "platform_info": "x86_64-linux-6.6.44",
+    "build_info": "(local build)",
+    "argv": [
+      "smartctl",
+      "--info",
+      "--json",
+      "/dev/sda"
+    ],
+    "messages": [
+      {
+        "string": "Device does not support SMART",
+        "severity": "error"
+      }
+    ],
+    "exit_status": 4
+  },
+  "device": {
+    "name": "/dev/sda",
+    "info_name": "/dev/sda",
+    "type": "scsi",
+    "protocol": "SCSI"
+  },
+  "vendor": "Hitachi",
+  "product": "HDS723030ALA640",
+  "user_capacity": {
+    "blocks": 0,
+    "bytes": 0
+  },
+  "logical_block_size": 512,
+  "rotation_rate": 0,
+  "smart_support": {
+    "available": false
+  },
+  "local_time": {
+    "time_t": 1753660800,
+    "asctime": "Sun Jul 27 00:00:00 2025 UTC"
+  }
+}

--- a/collector/pkg/detect/testdata/smartctl_info_hitachi_sat.json
+++ b/collector/pkg/detect/testdata/smartctl_info_hitachi_sat.json
@@ -1,0 +1,82 @@
+{
+  "json_format_version": [
+    1,
+    0
+  ],
+  "smartctl": {
+    "version": [
+      7,
+      4
+    ],
+    "svn_revision": "5530",
+    "platform_info": "x86_64-linux-6.6.44",
+    "build_info": "(local build)",
+    "argv": [
+      "smartctl",
+      "--info",
+      "--json",
+      "--device",
+      "sat",
+      "/dev/sda"
+    ],
+    "exit_status": 0
+  },
+  "device": {
+    "name": "/dev/sda",
+    "info_name": "/dev/sda [SAT]",
+    "type": "sat",
+    "protocol": "ATA"
+  },
+  "model_family": "Hitachi Deskstar 7K3000",
+  "model_name": "Hitachi HDS723030ALA640",
+  "serial_number": "MK0000000000000",
+  "wwn": {
+    "naa": 5,
+    "oui": 3274,
+    "id": 6606201857
+  },
+  "firmware_version": "MKAOA3B0",
+  "user_capacity": {
+    "blocks": 5860533168,
+    "bytes": 3000592982016
+  },
+  "logical_block_size": 512,
+  "physical_block_size": 512,
+  "rotation_rate": 7200,
+  "form_factor": {
+    "ata_value": 2,
+    "name": "3.5 inches"
+  },
+  "in_smartctl_database": true,
+  "ata_version": {
+    "string": "ATA8-ACS T13/1699-D revision 4",
+    "major_value": 1008,
+    "minor_value": 41
+  },
+  "sata_version": {
+    "string": "SATA 3.0",
+    "value": 63
+  },
+  "interface_speed": {
+    "max": {
+      "sata_value": 14,
+      "string": "6.0 Gb/s",
+      "units_per_second": 60,
+      "bits_per_unit": 100000000
+    },
+    "current": {
+      "sata_value": 3,
+      "string": "6.0 Gb/s",
+      "units_per_second": 60,
+      "bits_per_unit": 100000000
+    }
+  },
+  "smart_support": {
+    "available": true,
+    "enabled": true
+  },
+  "local_time": {
+    "time_t": 1753660800,
+    "asctime": "Sun Jul 27 00:00:00 2025 UTC"
+  }
+}

--- a/docs/TROUBLESHOOTING_DEVICE_COLLECTOR.md
+++ b/docs/TROUBLESHOOTING_DEVICE_COLLECTOR.md
@@ -84,6 +84,12 @@ the container.
 In some cases `--scan` does not correctly detect the device type, returning incomplete SMART data.
 Scrutiny will supports overriding the detected device type via the config file.
 
+A type written in `collector.yaml` is passed to smartctl verbatim as `-d <type>` on every call
+the collector makes for that device: identification, SMART collection and the Seagate FARM log.
+This includes `scsi` and `ata`. A type that only came from `smartctl --scan` is treated as a
+guess instead: `scsi` and `ata` are dropped so smartctl can auto-detect, because container scans
+routinely label ATA disks as SCSI and forcing `-d scsi` on them loses the ATA attributes.
+
 [example.collector.yaml](https://github.com/Starosdev/scrutiny/blob/master/example.collector.yaml)
 
 ### RAID Controllers (Megaraid/3ware/HBA/Adaptec/HPE/etc)
@@ -184,6 +190,43 @@ them. See [Exit Codes](#exit-codes) below.
 > serial or WWN. Once the collector can read its identity the disk registers under a new
 > device id, and the old entry remains behind showing no data. Delete the stale entry; its
 > history is empty and cannot be merged usefully.
+
+### Drives Reported As Failed With Zero SMART Values (Hitachi/Toshiba)
+
+Some Hitachi and Toshiba drives, most often behind a USB bridge or a SAS/SATA controller,
+answer an auto-detected smartctl query with no model, no serial, `SMART support is: Unavailable`
+and no attributes. Scrutiny then shows the disk as failed with empty metrics, because that is
+what smartctl reported. The drive itself is usually fine: the wrong device type was used.
+
+Diagnose by comparing the two calls on the host that runs the collector:
+
+```bash
+# auto-detected: reports no model and no SMART support
+smartctl -a --json /dev/sdX | jq '.model_name, .smart_support'
+
+# with an explicit type: returns the real identity and attributes
+smartctl -a --json -d sat /dev/sdX | jq '.model_name, .smart_support'
+```
+
+If the second call works, pin the type in the collector config:
+
+```yaml
+# /opt/scrutiny/config/collector.yaml
+devices:
+  - device: /dev/sdX
+    type: 'sat'
+```
+
+`sat` is the usual answer for these drives. Other values worth trying are `sat,auto`,
+`sat,12`, `scsi`, and `usbjmicron` / `usbsunplus` for specific USB bridges; the full list is in
+`man smartctl` under `-d TYPE`. Whatever you configure is passed through verbatim on every
+smartctl call for that device.
+
+> NOTE: `scsi` and `ata` used to be ignored when configured, because the collector could not
+> tell a configured type from a scanned one. As of the fix for
+> [#664](https://github.com/Starosdev/scrutiny/issues/664) they are honored. If you have either
+> of them in your `collector.yaml` from an older release, where it was a no-op, it now takes
+> effect; remove the entry if you actually want auto-detection.
 
 ### NVMe Drives
 

--- a/example.collector.yaml
+++ b/example.collector.yaml
@@ -51,8 +51,15 @@ host:
 # Scrutiny via `smartctl --scan`
 # See the "--device=TYPE" section of https://linux.die.net/man/8/smartctl
 # type can be a 'string' or a 'list'
+#
+# A type set here is passed to smartctl verbatim as '-d <type>' on every call made for
+# that device, including the standard 'scsi' and 'ata' types. A type that only came from
+# `smartctl --scan` is treated as a guess: 'scsi' and 'ata' are dropped so smartctl can
+# auto-detect, because container scans routinely label ATA disks as SCSI.
 devices:
-#  # example for forcing device type detection for a single disk
+#  # example for forcing device type detection for a single disk. Some Hitachi and
+#  # Toshiba drives report a false failure and zero SMART values under auto-detection
+#  # and need this; see docs/TROUBLESHOOTING_DEVICE_COLLECTOR.md
 #  - device: /dev/sda
 #    type: 'sat'
 #


### PR DESCRIPTION
## Summary

Some Hitachi and Toshiba drives answer an auto-detected `smartctl` query with no identity, `SMART support is: Unavailable` and no attributes. Scrutiny renders that as a failed disk with zero metrics. The documented remedy is to pin the device type in `collector.yaml`; for most of these drives that type is `sat`, which already reached smartctl. A configured type of `scsi` or `ata` did not.

All three smartctl call sites (detection `--info`, collection `--xall`, FARM log) carried a hand-copied guard:

```go
if len(deviceType) > 0 && deviceType != "scsi" && deviceType != "ata" {
    args = append(args, "--device", deviceType)
}
```

The guard is correct for a type that came from `smartctl --scan`: container scans routinely mislabel ATA disks as SCSI, and forcing `-d scsi` on one loses its ATA attributes. It is wrong for a type the user wrote down, but `models.Device` carries no provenance, so the two were indistinguishable. The comparison was also exact-case, so `type: 'ATA'` was passed through while `type: 'ata'` was dropped.

## Changes

- New `detect.AppendDeviceTypeArgs` is now the only place a device type becomes smartctl arguments. All three call sites route through it, so they cannot drift apart.
- A type configured for that device path in `collector.yaml` is passed verbatim, including `scsi` and `ata`. A type that is not configured keeps the existing suppression, now trimmed and case-insensitive.
- Provenance is resolved per call from `Config.GetDeviceOverrides()` (already on the interface, memoized). It cannot be a field on `models.Device`: the device type round-trips through `/api/devices/register` before `Collect` reads it back, so a collector-only field would not survive.
- `nvme` is unchanged and still passed through.

## Behavior change on upgrade

A `type: 'scsi'` or `type: 'ata'` entry that was a silent no-op in earlier releases now takes effect. For a drive that was working through auto-detection, that can lose attributes. The troubleshooting doc calls this out and tells users to delete the entry if they want auto-detection. Worth repeating in the release notes.

## Tests

`go test ./collector/...` passes. New coverage:

- `detect_test.go`: configured `sat` reaches the `--info` argv and populates model, serial, WWN and `smart_support.available`; the auto-detected response for the same drive yields the empty identity that produces the false failure; configured `scsi` is now passed; a configured device that inherits a scanned `scsi` still suppresses it; an uppercase scanned `SCSI` is suppressed.
- `TestDetect_AppendDeviceTypeArgs`: table over the resolution rules, including a type configured for a different device path.
- `metrics_collect_test.go`: configured `sat` reaches both the `--xall` and FARM calls; configured `scsi` is passed; a scanned `scsi` with nothing configured produces neither `--device`.
- Two new fixtures under `collector/pkg/detect/testdata/`.

## Docs

- `docs/TROUBLESHOOTING_DEVICE_COLLECTOR.md`: new section on drives reported as failed with zero SMART values, with the `smartctl -a` vs `smartctl -a -d sat` diagnosis and the upgrade note.
- `example.collector.yaml`: states that a configured type is passed verbatim.

Fixes #664