### PR TITLE
fix(frontend): keep scroll position when a menu closes (#672)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,19 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: '24'
+      - name: Guard menu triggers
+        # Every component that renders a mat-menu trigger must import
+        # MenuTriggerRestoreFocusDirective, otherwise it silently keeps the scroll jump of #672.
+        run: |
+          missing=$(comm -23 \
+            <(grep -rl 'matMenuTriggerFor' webapp/frontend/src/app --include='*.component.html' | sed 's/\.html$/.ts/' | sort) \
+            <(grep -rl 'MenuTriggerRestoreFocusDirective' webapp/frontend/src/app --include='*.ts' | sort))
+          if [ -n "$missing" ]; then
+            echo "These components render a mat-menu trigger without importing MenuTriggerRestoreFocusDirective:"
+            echo "$missing"
+            echo "Add it to the component's imports array, see webapp/frontend/src/app/shared/menu-trigger-restore-focus.directive.ts"
+            exit 1
+          fi
       - name: Test Frontend
         run: |
           make binary-frontend-test-coverage

--- a/webapp/frontend/src/app/layout/common/btrfs-filesystem-card/btrfs-filesystem-card.component.ts
+++ b/webapp/frontend/src/app/layout/common/btrfs-filesystem-card/btrfs-filesystem-card.component.ts
@@ -10,6 +10,7 @@ import { RouterLink } from '@angular/router';
 import { MatIcon } from '@angular/material/icon';
 import { MatIconButton } from '@angular/material/button';
 import { MatMenuTrigger, MatMenu, MatMenuItem } from '@angular/material/menu';
+import { MenuTriggerRestoreFocusDirective } from 'app/shared/menu-trigger-restore-focus.directive';
 
 dayjs.extend(relativeTime);
 
@@ -17,7 +18,7 @@ dayjs.extend(relativeTime);
     selector: 'app-btrfs-filesystem-card',
     templateUrl: './btrfs-filesystem-card.component.html',
     styleUrls: ['./btrfs-filesystem-card.component.scss'],
-    imports: [NgClass, RouterLink, MatIcon, MatIconButton, MatMenuTrigger, MatMenu, MatMenuItem, DatePipe],
+    imports: [NgClass, RouterLink, MatIcon, MatIconButton, MatMenuTrigger, MenuTriggerRestoreFocusDirective, MatMenu, MatMenuItem, DatePipe],
 })
 export class BtrfsFilesystemCardComponent {
     private readonly _btrfsFilesystemsService = inject(BtrfsFilesystemsService);

--- a/webapp/frontend/src/app/layout/common/dashboard-device/dashboard-device.component.ts
+++ b/webapp/frontend/src/app/layout/common/dashboard-device/dashboard-device.component.ts
@@ -16,6 +16,7 @@ import { MatIcon } from '@angular/material/icon';
 import { RouterLink } from '@angular/router';
 import { MatIconButton } from '@angular/material/button';
 import { MatMenuTrigger, MatMenu, MatMenuItem } from '@angular/material/menu';
+import { MenuTriggerRestoreFocusDirective } from 'app/shared/menu-trigger-restore-focus.directive';
 import { FileSizePipe } from '../../../shared/file-size.pipe';
 import { TemperaturePipe } from '../../../shared/temperature.pipe';
 import { DeviceHoursPipe } from '../../../shared/device-hours.pipe';
@@ -24,7 +25,21 @@ import { DeviceHoursPipe } from '../../../shared/device-hours.pipe';
     selector: 'app-dashboard-device',
     templateUrl: './dashboard-device.component.html',
     styleUrls: ['./dashboard-device.component.scss'],
-    imports: [NgClass, MatIcon, RouterLink, MatIconButton, MatMenuTrigger, MatMenu, MatMenuItem, TitleCasePipe, DatePipe, FileSizePipe, TemperaturePipe, DeviceHoursPipe],
+    imports: [
+        NgClass,
+        MatIcon,
+        RouterLink,
+        MatIconButton,
+        MatMenuTrigger,
+        MenuTriggerRestoreFocusDirective,
+        MatMenu,
+        MatMenuItem,
+        TitleCasePipe,
+        DatePipe,
+        FileSizePipe,
+        TemperaturePipe,
+        DeviceHoursPipe,
+    ],
 })
 export class DashboardDeviceComponent implements OnInit {
     private readonly _configService = inject(ScrutinyConfigService);

--- a/webapp/frontend/src/app/layout/common/zfs-pool-card/zfs-pool-card.component.ts
+++ b/webapp/frontend/src/app/layout/common/zfs-pool-card/zfs-pool-card.component.ts
@@ -13,13 +13,14 @@ import { MatIcon } from '@angular/material/icon';
 import { RouterLink } from '@angular/router';
 import { MatIconButton } from '@angular/material/button';
 import { MatMenuTrigger, MatMenu, MatMenuItem } from '@angular/material/menu';
+import { MenuTriggerRestoreFocusDirective } from 'app/shared/menu-trigger-restore-focus.directive';
 import { FileSizePipe } from '../../../shared/file-size.pipe';
 
 @Component({
     selector: 'app-zfs-pool-card',
     templateUrl: './zfs-pool-card.component.html',
     styleUrls: ['./zfs-pool-card.component.scss'],
-    imports: [NgClass, MatIcon, RouterLink, MatIconButton, MatMenuTrigger, MatMenu, MatMenuItem, DatePipe, FileSizePipe],
+    imports: [NgClass, MatIcon, RouterLink, MatIconButton, MatMenuTrigger, MenuTriggerRestoreFocusDirective, MatMenu, MatMenuItem, DatePipe, FileSizePipe],
 })
 export class ZFSPoolCardComponent {
     private readonly _zfsPoolsService = inject(ZFSPoolsService);

--- a/webapp/frontend/src/app/layout/layouts/mobile/mobile-layout.component.html
+++ b/webapp/frontend/src/app/layout/layouts/mobile/mobile-layout.component.html
@@ -18,7 +18,7 @@
     </div>
 
     <!-- Page content -->
-    <div class="mobile-content">
+    <div class="mobile-content" cdkScrollable>
         @if (true) {
         <router-outlet></router-outlet>
         }

--- a/webapp/frontend/src/app/layout/layouts/mobile/mobile-layout.component.ts
+++ b/webapp/frontend/src/app/layout/layouts/mobile/mobile-layout.component.ts
@@ -9,13 +9,14 @@ import { MatIconButton } from '@angular/material/button';
 import { MatTooltip } from '@angular/material/tooltip';
 import { MatIcon } from '@angular/material/icon';
 import { MobileTabBarComponent } from '../../common/mobile-tab-bar/mobile-tab-bar.component';
+import { CdkScrollable } from '@angular/cdk/scrolling';
 
 @Component({
     selector: 'mobile-layout',
     templateUrl: './mobile-layout.component.html',
     styleUrls: ['./mobile-layout.component.scss'],
     encapsulation: ViewEncapsulation.None,
-    imports: [RouterLink, ThemeToggleComponent, MatIconButton, MatTooltip, MatIcon, RouterOutlet, MobileTabBarComponent],
+    imports: [RouterLink, ThemeToggleComponent, MatIconButton, MatTooltip, MatIcon, RouterOutlet, MobileTabBarComponent, CdkScrollable],
 })
 export class MobileLayoutComponent implements OnInit, OnDestroy {
     private readonly _authService = inject(AuthService);

--- a/webapp/frontend/src/app/modules/dashboard/dashboard.component.ts
+++ b/webapp/frontend/src/app/modules/dashboard/dashboard.component.ts
@@ -20,6 +20,7 @@ import { MatIcon } from '@angular/material/icon';
 import { MatTooltip } from '@angular/material/tooltip';
 import { MatProgressSpinner } from '@angular/material/progress-spinner';
 import { MatMenuTrigger, MatMenu, MatMenuItem } from '@angular/material/menu';
+import { MenuTriggerRestoreFocusDirective } from 'app/shared/menu-trigger-restore-focus.directive';
 import { DashboardDeviceComponent } from '../../layout/common/dashboard-device/dashboard-device.component';
 import { DOCUMENT, NgClass, DecimalPipe, TitleCasePipe, DatePipe, KeyValuePipe } from '@angular/common';
 import { MatCheckbox } from '@angular/material/checkbox';
@@ -47,6 +48,7 @@ const DASHBOARD_SHELL_WIDTHS: Record<DashboardColumns, string> = {
         MatProgressSpinner,
         MatIconButton,
         MatMenuTrigger,
+        MenuTriggerRestoreFocusDirective,
         MatMenu,
         MatMenuItem,
         DashboardDeviceComponent,

--- a/webapp/frontend/src/app/modules/detail/detail.component.ts
+++ b/webapp/frontend/src/app/modules/detail/detail.component.ts
@@ -47,6 +47,7 @@ import { MatIconButton, MatButton } from '@angular/material/button';
 import { MatIcon } from '@angular/material/icon';
 import { MatTooltip } from '@angular/material/tooltip';
 import { MatMenuTrigger, MatMenu, MatMenuItem } from '@angular/material/menu';
+import { MenuTriggerRestoreFocusDirective } from 'app/shared/menu-trigger-restore-focus.directive';
 import { TreoCardComponent } from '../../../@treo/components/card/card.component';
 import { MatButtonToggleGroup, MatButtonToggle } from '@angular/material/button-toggle';
 import { MatProgressBar } from '@angular/material/progress-bar';
@@ -80,6 +81,7 @@ const AttributeStatusFailedScrutiny = 4;
         MatTooltip,
         MatButton,
         MatMenuTrigger,
+        MenuTriggerRestoreFocusDirective,
         MatMenu,
         MatMenuItem,
         TreoCardComponent,

--- a/webapp/frontend/src/app/modules/zfs-pools/zfs-pools.component.ts
+++ b/webapp/frontend/src/app/modules/zfs-pools/zfs-pools.component.ts
@@ -9,6 +9,7 @@ import { ZFSPoolModel } from 'app/core/models/zfs-pool-model';
 import { MatButton, MatIconButton } from '@angular/material/button';
 import { MatIcon } from '@angular/material/icon';
 import { MatMenuTrigger, MatMenu, MatMenuItem } from '@angular/material/menu';
+import { MenuTriggerRestoreFocusDirective } from 'app/shared/menu-trigger-restore-focus.directive';
 import { ZFSPoolCardComponent } from '../../layout/common/zfs-pool-card/zfs-pool-card.component';
 import { KeyValuePipe } from '@angular/common';
 
@@ -18,7 +19,7 @@ import { KeyValuePipe } from '@angular/common';
     styleUrls: ['./zfs-pools.component.scss'],
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush,
-    imports: [MatButton, MatIcon, MatIconButton, MatMenuTrigger, MatMenu, MatMenuItem, ZFSPoolCardComponent, KeyValuePipe],
+    imports: [MatButton, MatIcon, MatIconButton, MatMenuTrigger, MenuTriggerRestoreFocusDirective, MatMenu, MatMenuItem, ZFSPoolCardComponent, KeyValuePipe],
 })
 export class ZFSPoolsComponent implements OnInit, OnDestroy {
     private readonly _zfsPoolsService = inject(ZFSPoolsService);

--- a/webapp/frontend/src/app/shared/menu-trigger-restore-focus.directive.spec.ts
+++ b/webapp/frontend/src/app/shared/menu-trigger-restore-focus.directive.spec.ts
@@ -1,0 +1,251 @@
+import { Component, ElementRef, ViewChild } from '@angular/core';
+import { ComponentFixture, TestBed, fakeAsync, flush } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { OverlayContainer } from '@angular/cdk/overlay';
+import { MatButtonModule } from '@angular/material/button';
+import { MatMenuModule, MatMenuTrigger } from '@angular/material/menu';
+import { MenuTriggerRestoreFocusDirective } from './menu-trigger-restore-focus.directive';
+
+// The trigger sits between two tall spacers inside its own scroll container, so the assertions do not
+// depend on the size of the karma browser window. Focusing an element scrolls every scrollable
+// ancestor into view, and { preventScroll: true } suppresses all of them.
+const SCROLLER_TEMPLATE = `
+    <div #scroller style="height: 120px; overflow-y: auto;">
+        <div style="height: 600px;"></div>
+        <button mat-icon-button [matMenuTriggerFor]="menu">Open</button>
+        <div style="height: 600px;"></div>
+    </div>
+    <mat-menu #menu="matMenu">
+        <button mat-menu-item>Item</button>
+    </mat-menu>
+`;
+
+@Component({
+    selector: 'app-patched-menu-host',
+    template: SCROLLER_TEMPLATE,
+    imports: [MatButtonModule, MatMenuModule, MenuTriggerRestoreFocusDirective],
+})
+class PatchedMenuHostComponent {
+    @ViewChild('scroller', { static: true }) scroller: ElementRef<HTMLElement>;
+    @ViewChild(MatMenuTrigger, { static: true }) trigger: MatMenuTrigger;
+}
+
+// Control host: identical, but without the directive. Proves the specs above can actually detect the
+// bug, and fails loudly if Angular Material ever passes { preventScroll: true } itself - at which
+// point the directive can be deleted.
+@Component({
+    selector: 'app-unpatched-menu-host',
+    template: SCROLLER_TEMPLATE,
+    imports: [MatButtonModule, MatMenuModule],
+})
+class UnpatchedMenuHostComponent {
+    @ViewChild('scroller', { static: true }) scroller: ElementRef<HTMLElement>;
+    @ViewChild(MatMenuTrigger, { static: true }) trigger: MatMenuTrigger;
+}
+
+@Component({
+    selector: 'app-opted-out-menu-host',
+    template: `
+        <button mat-icon-button [matMenuTriggerFor]="menu" [matMenuTriggerRestoreFocus]="false">Open</button>
+        <mat-menu #menu="matMenu">
+            <button mat-menu-item>Item</button>
+        </mat-menu>
+    `,
+    imports: [MatButtonModule, MatMenuModule, MenuTriggerRestoreFocusDirective],
+})
+class OptedOutMenuHostComponent {
+    @ViewChild(MatMenuTrigger, { static: true }) trigger: MatMenuTrigger;
+}
+
+@Component({
+    selector: 'app-submenu-host',
+    template: `
+        <button mat-icon-button [matMenuTriggerFor]="rootMenu">Open</button>
+        <mat-menu #rootMenu="matMenu">
+            <button mat-menu-item [matMenuTriggerFor]="subMenu">Sub</button>
+        </mat-menu>
+        <mat-menu #subMenu="matMenu">
+            <button mat-menu-item>Leaf</button>
+        </mat-menu>
+    `,
+    imports: [MatButtonModule, MatMenuModule, MenuTriggerRestoreFocusDirective],
+})
+class SubmenuHostComponent {}
+
+describe('MenuTriggerRestoreFocusDirective', () => {
+    afterEach(() => {
+        TestBed.inject(OverlayContainer).ngOnDestroy();
+    });
+
+    describe('with the directive applied', () => {
+        let fixture: ComponentFixture<PatchedMenuHostComponent>;
+        let host: PatchedMenuHostComponent;
+        let triggerElement: HTMLElement;
+        let focusSpy: jasmine.Spy;
+
+        beforeEach(() => {
+            TestBed.configureTestingModule({
+                imports: [NoopAnimationsModule, MatButtonModule, MatMenuModule, PatchedMenuHostComponent],
+            }).compileComponents();
+
+            fixture = TestBed.createComponent(PatchedMenuHostComponent);
+            host = fixture.componentInstance;
+            fixture.detectChanges();
+
+            triggerElement = fixture.debugElement.query(By.directive(MatMenuTrigger)).nativeElement;
+            focusSpy = spyOn(triggerElement, 'focus').and.callThrough();
+        });
+
+        it('restores focus to the trigger without scrolling it back into view', fakeAsync(() => {
+            host.scroller.nativeElement.scrollTop = 600;
+
+            host.trigger.openMenu();
+            fixture.detectChanges();
+            flush();
+
+            host.scroller.nativeElement.scrollTop = 0;
+
+            host.trigger.closeMenu();
+            fixture.detectChanges();
+            flush();
+
+            expect(focusSpy).toHaveBeenCalledOnceWith({ preventScroll: true });
+            expect(host.scroller.nativeElement.scrollTop).toBe(0);
+            expect(document.activeElement).toBe(triggerElement);
+        }));
+
+        it('takes focus restoration over from the menu trigger', fakeAsync(() => {
+            expect(host.trigger.restoreFocus).toBeTrue();
+
+            host.trigger.openMenu();
+            fixture.detectChanges();
+            flush();
+
+            expect(host.trigger.restoreFocus).toBeFalse();
+        }));
+    });
+
+    describe('without the directive applied', () => {
+        let fixture: ComponentFixture<UnpatchedMenuHostComponent>;
+        let host: UnpatchedMenuHostComponent;
+        let focusSpy: jasmine.Spy;
+
+        beforeEach(() => {
+            TestBed.configureTestingModule({
+                imports: [NoopAnimationsModule, MatButtonModule, MatMenuModule, UnpatchedMenuHostComponent],
+            }).compileComponents();
+
+            fixture = TestBed.createComponent(UnpatchedMenuHostComponent);
+            host = fixture.componentInstance;
+            fixture.detectChanges();
+
+            focusSpy = spyOn(fixture.debugElement.query(By.directive(MatMenuTrigger)).nativeElement, 'focus').and.callThrough();
+        });
+
+        it('reproduces the scroll jump, so the specs above are not tautological', fakeAsync(() => {
+            host.scroller.nativeElement.scrollTop = 600;
+
+            host.trigger.openMenu();
+            fixture.detectChanges();
+            flush();
+
+            host.scroller.nativeElement.scrollTop = 0;
+
+            host.trigger.closeMenu();
+            fixture.detectChanges();
+            flush();
+
+            expect(focusSpy).toHaveBeenCalledOnceWith(undefined);
+            expect(host.scroller.nativeElement.scrollTop).toBeGreaterThan(0);
+        }));
+    });
+
+    describe('when the template opts out of focus restoration', () => {
+        it('does not restore focus', fakeAsync(() => {
+            TestBed.configureTestingModule({
+                imports: [NoopAnimationsModule, MatButtonModule, MatMenuModule, OptedOutMenuHostComponent],
+            }).compileComponents();
+
+            const fixture = TestBed.createComponent(OptedOutMenuHostComponent);
+            fixture.detectChanges();
+
+            const focusSpy = spyOn(fixture.debugElement.query(By.directive(MatMenuTrigger)).nativeElement, 'focus').and.callThrough();
+
+            fixture.componentInstance.trigger.openMenu();
+            fixture.detectChanges();
+            flush();
+
+            fixture.componentInstance.trigger.closeMenu();
+            fixture.detectChanges();
+            flush();
+
+            expect(focusSpy).not.toHaveBeenCalled();
+        }));
+    });
+
+    describe('with a submenu trigger', () => {
+        it('leaves the submenu trigger to Angular Material', fakeAsync(() => {
+            TestBed.configureTestingModule({
+                imports: [NoopAnimationsModule, MatButtonModule, MatMenuModule, SubmenuHostComponent],
+            }).compileComponents();
+
+            const fixture = TestBed.createComponent(SubmenuHostComponent);
+            fixture.detectChanges();
+
+            const rootTrigger = fixture.debugElement.query(By.directive(MatMenuTrigger)).injector.get(MatMenuTrigger);
+
+            rootTrigger.openMenu();
+            fixture.detectChanges();
+            flush();
+
+            // The submenu trigger only exists once the root menu has rendered its content
+            const subTrigger = fixture.debugElement
+                .queryAll(By.directive(MatMenuTrigger))
+                .map((debugElement) => debugElement.injector.get(MatMenuTrigger))
+                .find((trigger) => trigger.triggersSubmenu());
+
+            expect(subTrigger).toBeDefined();
+
+            subTrigger.openMenu();
+            fixture.detectChanges();
+            flush();
+
+            expect(subTrigger.restoreFocus).toBeTrue();
+
+            rootTrigger.closeMenu();
+            fixture.detectChanges();
+            flush();
+        }));
+    });
+
+    describe('when the trigger is detached before the menu closes', () => {
+        it('does not try to restore focus', fakeAsync(() => {
+            TestBed.configureTestingModule({
+                imports: [NoopAnimationsModule, MatButtonModule, MatMenuModule, PatchedMenuHostComponent],
+            }).compileComponents();
+
+            const fixture = TestBed.createComponent(PatchedMenuHostComponent);
+            const host = fixture.componentInstance;
+            fixture.detectChanges();
+
+            const triggerElement: HTMLElement = fixture.debugElement.query(By.directive(MatMenuTrigger)).nativeElement;
+            const focusSpy = spyOn(triggerElement, 'focus').and.callThrough();
+
+            host.trigger.openMenu();
+            fixture.detectChanges();
+            flush();
+
+            // Stands in for a menu item that navigated away and took the trigger with it
+            triggerElement.remove();
+
+            expect(() => {
+                host.trigger.closeMenu();
+                fixture.detectChanges();
+                flush();
+            }).not.toThrow();
+
+            expect(focusSpy).not.toHaveBeenCalled();
+        }));
+    });
+});

--- a/webapp/frontend/src/app/shared/menu-trigger-restore-focus.directive.ts
+++ b/webapp/frontend/src/app/shared/menu-trigger-restore-focus.directive.ts
@@ -1,0 +1,92 @@
+import { Directive, ElementRef, OnDestroy, OnInit, inject } from '@angular/core';
+import { MatMenuTrigger } from '@angular/material/menu';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+
+// -----------------------------------------------------------------------------------------------------
+// Workaround for Starosdev/scrutiny#672
+//
+// When a mat-menu closes, MatMenuTrigger._destroyMenu() restores focus to the trigger by calling
+// focus() without any FocusOptions. The browser then scrolls the trigger back into view, so the page
+// jumps back to wherever it was when the menu was opened.
+//
+// This directive piggybacks on Angular Material's own trigger selector, takes focus restoration over
+// from MatMenuTrigger, and restores focus itself with { preventScroll: true }. Keyboard users still
+// get focus back on the trigger, but the page no longer moves.
+//
+// Because it shadows a Material selector, it only applies to components that list it in their
+// `imports`. Any new standalone component that renders a [matMenuTriggerFor] must add it too - the
+// `Guard menu triggers` step in .github/workflows/ci.yaml enforces that.
+// -----------------------------------------------------------------------------------------------------
+@Directive({
+    // Intentionally matches Angular Material's trigger selector, so the repo prefix rule cannot apply.
+    // eslint-disable-next-line @angular-eslint/directive-selector
+    selector: '[matMenuTriggerFor]',
+})
+export class MenuTriggerRestoreFocusDirective implements OnInit, OnDestroy {
+    private readonly _menuTrigger = inject(MatMenuTrigger, { self: true });
+    private readonly _elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
+
+    // Private
+    private _restoreFocus: boolean;
+    private readonly _unsubscribeAll: Subject<void>;
+
+    /**
+     * Constructor
+     */
+    constructor() {
+        // Set the private defaults
+        this._restoreFocus = true;
+        this._unsubscribeAll = new Subject();
+    }
+
+    // -----------------------------------------------------------------------------------------------------
+    // @ Lifecycle hooks
+    // -----------------------------------------------------------------------------------------------------
+
+    /**
+     * On init
+     */
+    ngOnInit(): void {
+        // Submenu triggers live inside the menu overlay, which is fixed positioned and cannot scroll
+        // the page. Material already skips restoring focus to them on non-keyboard closes, so leave
+        // that behaviour alone.
+        if (this._menuTrigger.triggersSubmenu()) {
+            return;
+        }
+
+        // Take focus restoration over from Material. The snapshot is refreshed on every open so that
+        // a later [matMenuTriggerRestoreFocus] binding write cannot re-arm Material's own focus call.
+        this._menuTrigger.menuOpened.pipe(takeUntil(this._unsubscribeAll)).subscribe(() => {
+            this._restoreFocus = this._menuTrigger.restoreFocus;
+            this._menuTrigger.restoreFocus = false;
+        });
+
+        this._menuTrigger.menuClosed.pipe(takeUntil(this._unsubscribeAll)).subscribe(() => {
+            // The template opted out of focus restoration
+            if (!this._restoreFocus) {
+                return;
+            }
+
+            // The trigger may already be detached, e.g. a menu item that navigated away via routerLink
+            if (!this._elementRef.nativeElement.isConnected) {
+                return;
+            }
+
+            // Passing no FocusOrigin makes MatMenuTrigger.focus() call the native focus() with our
+            // options instead of routing through FocusMonitor.focusVia(), which drops them. The
+            // FocusMonitor still derives the origin from the last input modality, so the
+            // cdk-mouse-focused / cdk-keyboard-focused classes stay correct.
+            this._menuTrigger.focus(undefined, { preventScroll: true });
+        });
+    }
+
+    /**
+     * On destroy
+     */
+    ngOnDestroy(): void {
+        // Unsubscribe from all subscriptions
+        this._unsubscribeAll.next();
+        this._unsubscribeAll.complete();
+    }
+}


### PR DESCRIPTION
Fixes #672.

## Problem

Opening a three-dot menu, scrolling the page, then clicking anywhere made the page jump back to the scroll position it had when the menu was opened.

`MatMenuTrigger._destroyMenu()` restores focus to the trigger on close by calling `focus()` with no `FocusOptions`, which routes to `nativeElement.focus(undefined)`. Without `{ preventScroll: true }` the browser scrolls the trigger back into view.

Menus use the default reposition scroll strategy, so `BlockScrollStrategy` was not involved, and `MAT_MENU_DEFAULT_OPTIONS` has no `restoreFocus` field, so there is no provider-level lever.

## Changes

1. `MenuTriggerRestoreFocusDirective` (`app/shared/`) shadows Material's `[matMenuTriggerFor]` selector, takes focus restoration over from the trigger and restores focus with `{ preventScroll: true }`. Keyboard users still get focus back on the trigger, so this is not the `[matMenuTriggerRestoreFocus]="false"` trade that drops focus return (WCAG 2.4.3). Submenu triggers are skipped: they live inside the fixed overlay and cannot scroll the page. Added to the six components that render root-level triggers.

   Deliberately excluded: `@treo/components/navigation/horizontal/components/branch` - the live layout uses `treo-vertical-navigation`, so that component is dead code, and wiring it would create a `@treo -> app/shared` dependency.

2. CI guard in the `Test Frontend` job. The directive only applies to components that import it, and a component that forgets it still compiles, so the job fails when a component template renders a menu trigger and its sibling component file does not reference the directive.

3. Separate commit: `cdkScrollable` on the mobile layout's scroll container. That div is the scroller on narrow viewports but was never registered with the CDK `ScrollDispatcher`, so overlays never saw its scroll events - an open menu stayed frozen in place while content slid underneath it, and tooltips did not hide on scroll.

## Tests

New spec `menu-trigger-restore-focus.directive.spec.ts` (6 specs) runs the trigger inside its own overflow container so the assertions do not depend on the karma window size. It covers focus restoration with `preventScroll`, the preserved scroll position, focus actually returning to the trigger, the `restoreFocus` handover, the explicit opt-out, submenu triggers being left alone, and a detached trigger.

It also includes a control spec on a host without the directive, which asserts the scroll jump still happens. That proves the other specs are not tautological, and it will fail if Angular Material ever passes `preventScroll` itself, at which point the directive can be deleted.

## Verification

- `npm run lint`: clean
- `npx ng test --watch=false --browsers=ChromeHeadless`: 160 passing
- `npm run build`: clean

Not yet validated against a live instance; the Zeus test host was unreachable from the build session.