### PR TITLE
Add standalone omnibus collector packages

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -111,6 +111,8 @@ jobs:
       - name: Build Binaries
         run: |
           make binary-clean binary-all
+      - name: Package Collector Omnibus
+        run: make package-collector-omnibus
       - name: Archive
         uses: actions/upload-artifact@v7
         with:
@@ -118,7 +120,10 @@ jobs:
           path: |
             scrutiny-web-*
             scrutiny-collector-metrics-*
+            scrutiny-collector-mdadm-*
             scrutiny-collector-zfs-*
             scrutiny-collector-btrfs-*
             scrutiny-collector-performance-*
             scrutiny-collector-filesystem-*
+            scrutiny-collector-omnibus-*.tar.gz
+            scrutiny-collector-omnibus-*.zip

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -170,6 +170,12 @@ jobs:
           GOARCH: ${{ matrix.cfg.goarch }}
           GOARM: ${{ matrix.cfg.goarm }}
         run: make binary-clean binary-all
+      - name: Package Collector Omnibus
+        env:
+          GOOS: ${{ matrix.cfg.goos }}
+          GOARCH: ${{ matrix.cfg.goarch }}
+          GOARM: ${{ matrix.cfg.goarm }}
+        run: make package-collector-omnibus
       - name: Upload artifacts
         uses: actions/upload-artifact@v7
         with:
@@ -182,6 +188,8 @@ jobs:
             scrutiny-collector-btrfs-*
             scrutiny-collector-performance-*
             scrutiny-collector-filesystem-*
+            scrutiny-collector-omnibus-*.tar.gz
+            scrutiny-collector-omnibus-*.zip
 
   upload-assets:
     name: Upload Release Assets

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ COLLECTOR_PERF_BINARY_NAME = scrutiny-collector-performance
 COLLECTOR_MDADM_BINARY_NAME = scrutiny-collector-mdadm
 COLLECTOR_FILESYSTEM_BINARY_NAME = scrutiny-collector-filesystem
 COLLECTOR_BTRFS_BINARY_NAME = scrutiny-collector-btrfs
+COLLECTOR_OMNIBUS_BINARY_NAME = scrutiny-collector-omnibus
 WEB_BINARY_NAME = scrutiny-web
 LD_FLAGS =
 
@@ -36,6 +37,7 @@ COLLECTOR_PERF_BINARY_NAME := $(COLLECTOR_PERF_BINARY_NAME)-$(GOOS)
 COLLECTOR_MDADM_BINARY_NAME := $(COLLECTOR_MDADM_BINARY_NAME)-$(GOOS)
 COLLECTOR_FILESYSTEM_BINARY_NAME := $(COLLECTOR_FILESYSTEM_BINARY_NAME)-$(GOOS)
 COLLECTOR_BTRFS_BINARY_NAME := $(COLLECTOR_BTRFS_BINARY_NAME)-$(GOOS)
+COLLECTOR_OMNIBUS_BINARY_NAME := $(COLLECTOR_OMNIBUS_BINARY_NAME)-$(GOOS)
 WEB_BINARY_NAME := $(WEB_BINARY_NAME)-$(GOOS)
 LD_FLAGS := $(LD_FLAGS) -X main.goos=$(GOOS)
 endif
@@ -46,6 +48,7 @@ COLLECTOR_PERF_BINARY_NAME := $(COLLECTOR_PERF_BINARY_NAME)-$(GOARCH)
 COLLECTOR_MDADM_BINARY_NAME := $(COLLECTOR_MDADM_BINARY_NAME)-$(GOARCH)
 COLLECTOR_FILESYSTEM_BINARY_NAME := $(COLLECTOR_FILESYSTEM_BINARY_NAME)-$(GOARCH)
 COLLECTOR_BTRFS_BINARY_NAME := $(COLLECTOR_BTRFS_BINARY_NAME)-$(GOARCH)
+COLLECTOR_OMNIBUS_BINARY_NAME := $(COLLECTOR_OMNIBUS_BINARY_NAME)-$(GOARCH)
 WEB_BINARY_NAME := $(WEB_BINARY_NAME)-$(GOARCH)
 LD_FLAGS := $(LD_FLAGS) -X main.goarch=$(GOARCH)
 endif
@@ -56,6 +59,7 @@ COLLECTOR_PERF_BINARY_NAME := $(COLLECTOR_PERF_BINARY_NAME)-$(GOARM)
 COLLECTOR_MDADM_BINARY_NAME := $(COLLECTOR_MDADM_BINARY_NAME)-$(GOARM)
 COLLECTOR_FILESYSTEM_BINARY_NAME := $(COLLECTOR_FILESYSTEM_BINARY_NAME)-$(GOARM)
 COLLECTOR_BTRFS_BINARY_NAME := $(COLLECTOR_BTRFS_BINARY_NAME)-$(GOARM)
+COLLECTOR_OMNIBUS_BINARY_NAME := $(COLLECTOR_OMNIBUS_BINARY_NAME)-$(GOARM)
 WEB_BINARY_NAME := $(WEB_BINARY_NAME)-$(GOARM)
 endif
 # Add .exe extension when building for Windows (native or cross-compile)
@@ -63,8 +67,10 @@ ifeq ($(OS),Windows_NT)
 COLLECTOR_BINARY_NAME := $(COLLECTOR_BINARY_NAME).exe
 COLLECTOR_ZFS_BINARY_NAME := $(COLLECTOR_ZFS_BINARY_NAME).exe
 COLLECTOR_PERF_BINARY_NAME := $(COLLECTOR_PERF_BINARY_NAME).exe
+COLLECTOR_MDADM_BINARY_NAME := $(COLLECTOR_MDADM_BINARY_NAME).exe
 COLLECTOR_FILESYSTEM_BINARY_NAME := $(COLLECTOR_FILESYSTEM_BINARY_NAME).exe
 COLLECTOR_BTRFS_BINARY_NAME := $(COLLECTOR_BTRFS_BINARY_NAME).exe
+COLLECTOR_OMNIBUS_BINARY_NAME := $(COLLECTOR_OMNIBUS_BINARY_NAME).exe
 WEB_BINARY_NAME := $(WEB_BINARY_NAME).exe
 else ifeq ($(GOOS),windows)
 COLLECTOR_BINARY_NAME := $(COLLECTOR_BINARY_NAME).exe
@@ -73,6 +79,7 @@ COLLECTOR_PERF_BINARY_NAME := $(COLLECTOR_PERF_BINARY_NAME).exe
 COLLECTOR_MDADM_BINARY_NAME := $(COLLECTOR_MDADM_BINARY_NAME).exe
 COLLECTOR_FILESYSTEM_BINARY_NAME := $(COLLECTOR_FILESYSTEM_BINARY_NAME).exe
 COLLECTOR_BTRFS_BINARY_NAME := $(COLLECTOR_BTRFS_BINARY_NAME).exe
+COLLECTOR_OMNIBUS_BINARY_NAME := $(COLLECTOR_OMNIBUS_BINARY_NAME).exe
 WEB_BINARY_NAME := $(WEB_BINARY_NAME).exe
 endif
 
@@ -83,8 +90,8 @@ endif
 all: binary-all
 
 .PHONY: binary-all
-binary-all: binary-collector binary-collector-zfs binary-collector-performance binary-collector-mdadm binary-web binary-collector-filesystem binary-collector-btrfs
-	@echo "built binary-collector, binary-collector-zfs, binary-collector-performance, binary-collector-mdadm and binary-web targets"
+binary-all: binary-collector binary-collector-zfs binary-collector-performance binary-collector-mdadm binary-web binary-collector-filesystem binary-collector-btrfs binary-collector-omnibus
+	@echo "built all web and collector binary targets"
 
 
 .PHONY: binary-clean
@@ -170,6 +177,22 @@ ifneq ($(OS),Windows_NT)
 	ldd $(COLLECTOR_BTRFS_BINARY_NAME) || true
 	./$(COLLECTOR_BTRFS_BINARY_NAME) || true
 endif
+
+.PHONY: binary-collector-omnibus
+binary-collector-omnibus: binary-dep
+	go build -buildvcs=false -ldflags "$(LD_FLAGS)" -o $(COLLECTOR_OMNIBUS_BINARY_NAME) $(STATIC_TAGS) ./collector/cmd/collector-omnibus/
+ifneq ($(OS),Windows_NT)
+	chmod +x $(COLLECTOR_OMNIBUS_BINARY_NAME)
+	file $(COLLECTOR_OMNIBUS_BINARY_NAME) || true
+	./$(COLLECTOR_OMNIBUS_BINARY_NAME) || true
+endif
+
+.PHONY: package-collector-omnibus
+package-collector-omnibus:
+	GOOS= GOARCH= GOARM= go run ./build/package-collector-omnibus \
+		--target-os "$(GOOS)" \
+		--target-arch "$(GOARCH)" \
+		--target-arm "$(GOARM)"
 
 .PHONY: binary-web
 binary-web: binary-dep

--- a/README.md
+++ b/README.md
@@ -312,6 +312,8 @@ it is possible to run it manually without much work. You can even mix and match,
 a manual installation for the other.
 
 See [docs/INSTALL_MANUAL.md](docs/INSTALL_MANUAL.md) for instructions.
+For a single download containing every collector plus a built-in scheduler,
+see [Standalone Collector Omnibus](docs/INSTALL_COLLECTOR_OMNIBUS.md).
 
 ## Usage
 

--- a/build/package-collector-omnibus/main.go
+++ b/build/package-collector-omnibus/main.go
@@ -63,7 +63,7 @@ func main() {
 		fmt.Fprintln(os.Stderr, "target-os and target-arch are required")
 		os.Exit(2)
 	}
-	archivePath, err := createArchive(options)
+	archivePath, err := createArchive(&options)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "package collector omnibus: %v\n", err)
 		os.Exit(1)
@@ -71,7 +71,7 @@ func main() {
 	fmt.Println(archivePath)
 }
 
-func createArchive(options packageOptions) (string, error) {
+func createArchive(options *packageOptions) (string, error) {
 	platform := options.targetOS + "-" + options.targetArch
 	if options.targetARM != "" {
 		platform += "-" + options.targetARM

--- a/build/package-collector-omnibus/main.go
+++ b/build/package-collector-omnibus/main.go
@@ -1,0 +1,176 @@
+package main
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"compress/gzip"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+var bundledBinaries = []string{
+	"scrutiny-collector-omnibus",
+	"scrutiny-collector-metrics",
+	"scrutiny-collector-zfs",
+	"scrutiny-collector-mdadm",
+	"scrutiny-collector-btrfs",
+	"scrutiny-collector-filesystem",
+	"scrutiny-collector-performance",
+}
+
+var bundledFiles = []archiveFile{
+	{source: "example.collector-omnibus.yaml", destination: "config/collector-omnibus.yaml", mode: 0o644},
+	{source: "example.collector.yaml", destination: "config/collector.yaml", mode: 0o644},
+	{source: "example.collector-zfs.yaml", destination: "config/collector-zfs.yaml", mode: 0o644},
+	{source: "example.collector-btrfs.yaml", destination: "config/collector-btrfs.yaml", mode: 0o644},
+	{source: "example.collector-performance.yaml", destination: "config/collector-performance.yaml", mode: 0o644},
+	{source: "docs/INSTALL_COLLECTOR_OMNIBUS.md", destination: "INSTALL.md", mode: 0o644},
+	{source: "LICENSE", destination: "LICENSE", mode: 0o644},
+}
+
+var archiveTimestamp = time.Date(1980, time.January, 2, 0, 0, 0, 0, time.UTC)
+
+type archiveFile struct {
+	source      string
+	destination string
+	mode        os.FileMode
+}
+
+type packageOptions struct {
+	sourceDir  string
+	outputDir  string
+	targetOS   string
+	targetArch string
+	targetARM  string
+}
+
+func main() {
+	var options packageOptions
+	flag.StringVar(&options.sourceDir, "source-dir", ".", "repository root containing built binaries")
+	flag.StringVar(&options.outputDir, "output-dir", ".", "directory for the generated archive")
+	flag.StringVar(&options.targetOS, "target-os", "", "target GOOS")
+	flag.StringVar(&options.targetArch, "target-arch", "", "target GOARCH")
+	flag.StringVar(&options.targetARM, "target-arm", "", "target GOARM")
+	flag.Parse()
+
+	if options.targetOS == "" || options.targetArch == "" {
+		fmt.Fprintln(os.Stderr, "target-os and target-arch are required")
+		os.Exit(2)
+	}
+	archivePath, err := createArchive(options)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "package collector omnibus: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println(archivePath)
+}
+
+func createArchive(options packageOptions) (string, error) {
+	platform := options.targetOS + "-" + options.targetArch
+	if options.targetARM != "" {
+		platform += "-" + options.targetARM
+	}
+	root := "scrutiny-collector-omnibus-" + platform
+	files := make([]archiveFile, 0, len(bundledBinaries)+len(bundledFiles))
+	for _, name := range bundledBinaries {
+		sourceName := name + "-" + platform
+		destinationName := name
+		if options.targetOS == "windows" {
+			sourceName += ".exe"
+			destinationName += ".exe"
+		}
+		files = append(files, archiveFile{
+			source:      sourceName,
+			destination: "bin/" + destinationName,
+			mode:        0o755,
+		})
+	}
+	files = append(files, bundledFiles...)
+
+	if err := os.MkdirAll(options.outputDir, 0o755); err != nil {
+		return "", fmt.Errorf("create output directory: %w", err)
+	}
+	if options.targetOS == "windows" {
+		path := filepath.Join(options.outputDir, root+".zip")
+		return path, writeZip(path, options.sourceDir, root, files)
+	}
+	path := filepath.Join(options.outputDir, root+".tar.gz")
+	return path, writeTarGz(path, options.sourceDir, root, files)
+}
+
+func writeTarGz(outputPath, sourceDir, root string, files []archiveFile) (returnErr error) {
+	output, err := os.Create(outputPath)
+	if err != nil {
+		return err
+	}
+	defer closeWithError(output, &returnErr)
+
+	gzipWriter := gzip.NewWriter(output)
+	defer closeWithError(gzipWriter, &returnErr)
+	tarWriter := tar.NewWriter(gzipWriter)
+	defer closeWithError(tarWriter, &returnErr)
+
+	for _, file := range files {
+		data, err := os.ReadFile(filepath.Join(sourceDir, file.source))
+		if err != nil {
+			return fmt.Errorf("read %s: %w", file.source, err)
+		}
+		header := &tar.Header{
+			Name:    filepath.ToSlash(filepath.Join(root, file.destination)),
+			Mode:    int64(file.mode.Perm()),
+			Size:    int64(len(data)),
+			ModTime: archiveTimestamp,
+		}
+		if err := tarWriter.WriteHeader(header); err != nil {
+			return err
+		}
+		if _, err := tarWriter.Write(data); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeZip(outputPath, sourceDir, root string, files []archiveFile) (returnErr error) {
+	output, err := os.Create(outputPath)
+	if err != nil {
+		return err
+	}
+	defer closeWithError(output, &returnErr)
+
+	zipWriter := zip.NewWriter(output)
+	defer closeWithError(zipWriter, &returnErr)
+
+	for _, file := range files {
+		data, err := os.ReadFile(filepath.Join(sourceDir, file.source))
+		if err != nil {
+			return fmt.Errorf("read %s: %w", file.source, err)
+		}
+		header := &zip.FileHeader{
+			Name:   strings.ReplaceAll(filepath.Join(root, file.destination), string(filepath.Separator), "/"),
+			Method: zip.Deflate,
+		}
+		header.SetMode(file.mode)
+		header.SetModTime(archiveTimestamp)
+		writer, err := zipWriter.CreateHeader(header)
+		if err != nil {
+			return err
+		}
+		if _, err := writer.Write(data); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func closeWithError(closer io.Closer, returnErr *error) {
+	if err := closer.Close(); err != nil && !errors.Is(err, os.ErrClosed) && *returnErr == nil {
+		*returnErr = err
+	}
+}

--- a/build/package-collector-omnibus/main.go
+++ b/build/package-collector-omnibus/main.go
@@ -157,7 +157,7 @@ func writeZip(outputPath, sourceDir, root string, files []archiveFile) (returnEr
 			Method: zip.Deflate,
 		}
 		header.SetMode(file.mode)
-		header.SetModTime(archiveTimestamp)
+		header.Modified = archiveTimestamp
 		writer, err := zipWriter.CreateHeader(header)
 		if err != nil {
 			return err

--- a/build/package-collector-omnibus/main_test.go
+++ b/build/package-collector-omnibus/main_test.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"compress/gzip"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateArchiveUnixIncludesCanonicalBundleLayout(t *testing.T) {
+	sourceDir := packageFixture(t, "linux-amd64", "")
+	outputDir := t.TempDir()
+
+	path, err := createArchive(packageOptions{
+		sourceDir:  sourceDir,
+		outputDir:  outputDir,
+		targetOS:   "linux",
+		targetArch: "amd64",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(outputDir, "scrutiny-collector-omnibus-linux-amd64.tar.gz"), path)
+
+	files := readTarFiles(t, path)
+	root := "scrutiny-collector-omnibus-linux-amd64/"
+	for _, binary := range bundledBinaries {
+		assert.Contains(t, files, root+"bin/"+binary)
+		assert.Equal(t, int64(0o755), files[root+"bin/"+binary])
+	}
+	assert.Contains(t, files, root+"config/collector-omnibus.yaml")
+	assert.Contains(t, files, root+"INSTALL.md")
+	assert.Contains(t, files, root+"LICENSE")
+}
+
+func TestCreateArchiveWindowsUsesZipAndExeNames(t *testing.T) {
+	sourceDir := packageFixture(t, "windows-arm64", ".exe")
+	outputDir := t.TempDir()
+
+	path, err := createArchive(packageOptions{
+		sourceDir:  sourceDir,
+		outputDir:  outputDir,
+		targetOS:   "windows",
+		targetArch: "arm64",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(outputDir, "scrutiny-collector-omnibus-windows-arm64.zip"), path)
+
+	reader, err := zip.OpenReader(path)
+	require.NoError(t, err)
+	defer reader.Close()
+	names := make(map[string]struct{}, len(reader.File))
+	for _, file := range reader.File {
+		names[file.Name] = struct{}{}
+	}
+	root := "scrutiny-collector-omnibus-windows-arm64/"
+	for _, binary := range bundledBinaries {
+		assert.Contains(t, names, root+"bin/"+binary+".exe")
+	}
+}
+
+func packageFixture(t *testing.T, platform, extension string) string {
+	t.Helper()
+	dir := t.TempDir()
+	for _, binary := range bundledBinaries {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, binary+"-"+platform+extension), []byte(binary), 0o755))
+	}
+	for _, file := range bundledFiles {
+		path := filepath.Join(dir, file.source)
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+		require.NoError(t, os.WriteFile(path, []byte(file.source), file.mode))
+	}
+	return dir
+}
+
+func readTarFiles(t *testing.T, path string) map[string]int64 {
+	t.Helper()
+	file, err := os.Open(path)
+	require.NoError(t, err)
+	defer file.Close()
+	gzipReader, err := gzip.NewReader(file)
+	require.NoError(t, err)
+	defer gzipReader.Close()
+	reader := tar.NewReader(gzipReader)
+	files := map[string]int64{}
+	for {
+		header, err := reader.Next()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+		files[header.Name] = header.Mode
+	}
+	return files
+}

--- a/build/package-collector-omnibus/main_test.go
+++ b/build/package-collector-omnibus/main_test.go
@@ -17,7 +17,7 @@ func TestCreateArchiveUnixIncludesCanonicalBundleLayout(t *testing.T) {
 	sourceDir := packageFixture(t, "linux-amd64", "")
 	outputDir := t.TempDir()
 
-	path, err := createArchive(packageOptions{
+	path, err := createArchive(&packageOptions{
 		sourceDir:  sourceDir,
 		outputDir:  outputDir,
 		targetOS:   "linux",
@@ -41,7 +41,7 @@ func TestCreateArchiveWindowsUsesZipAndExeNames(t *testing.T) {
 	sourceDir := packageFixture(t, "windows-arm64", ".exe")
 	outputDir := t.TempDir()
 
-	path, err := createArchive(packageOptions{
+	path, err := createArchive(&packageOptions{
 		sourceDir:  sourceDir,
 		outputDir:  outputDir,
 		targetOS:   "windows",

--- a/collector/cmd/collector-omnibus/collector-omnibus.go
+++ b/collector/cmd/collector-omnibus/collector-omnibus.go
@@ -22,7 +22,7 @@ func main() {
 	app := &cli.App{
 		Name:     "scrutiny-collector-omnibus",
 		Usage:    "schedule and supervise Scrutiny collector binaries",
-		Version:  version.VERSION,
+		Version:  buildVersion(),
 		Compiled: time.Now(),
 		Commands: []*cli.Command{
 			{
@@ -43,6 +43,13 @@ func main() {
 	if err := app.Run(os.Args); err != nil {
 		log.Fatal(err)
 	}
+}
+
+func buildVersion() string {
+	if goos != "" && goarch != "" {
+		return fmt.Sprintf("%s.%s-%s", goos, goarch, version.VERSION)
+	}
+	return version.VERSION
 }
 
 func configFlags() []cli.Flag {

--- a/collector/cmd/collector-omnibus/collector-omnibus.go
+++ b/collector/cmd/collector-omnibus/collector-omnibus.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/analogj/scrutiny/collector/pkg/omnibus"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/version"
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli/v2"
+)
+
+var goos string
+var goarch string
+
+func main() {
+	app := &cli.App{
+		Name:     "scrutiny-collector-omnibus",
+		Usage:    "schedule and supervise Scrutiny collector binaries",
+		Version:  version.VERSION,
+		Compiled: time.Now(),
+		Commands: []*cli.Command{
+			{
+				Name:   "run",
+				Usage:  "Run configured collectors on their schedules",
+				Flags:  configFlags(),
+				Action: runManager,
+			},
+			{
+				Name:   "validate",
+				Usage:  "Validate manager configuration and bundled files",
+				Flags:  configFlags(),
+				Action: validateConfig,
+			},
+		},
+	}
+
+	if err := app.Run(os.Args); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func configFlags() []cli.Flag {
+	return []cli.Flag{
+		&cli.StringFlag{
+			Name:     "config",
+			Usage:    "Path to collector-omnibus.yaml",
+			EnvVars:  []string{"COLLECTOR_OMNIBUS_CONFIG"},
+			Required: true,
+		},
+	}
+}
+
+func runManager(cliCtx *cli.Context) error {
+	cfg, err := loadConfig(cliCtx.String("config"))
+	if err != nil {
+		return err
+	}
+
+	logger := logrus.WithField("type", "omnibus")
+	runner := omnibus.ExecRunner{Stdout: os.Stdout, Stderr: os.Stderr}
+	manager := omnibus.NewManager(cfg, runner, logger)
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	return manager.Run(ctx)
+}
+
+func validateConfig(cliCtx *cli.Context) error {
+	if _, err := loadConfig(cliCtx.String("config")); err != nil {
+		return err
+	}
+	fmt.Fprintln(cliCtx.App.Writer, "omnibus configuration is valid")
+	return nil
+}
+
+func loadConfig(path string) (omnibus.Config, error) {
+	executablePath, err := os.Executable()
+	if err != nil {
+		return omnibus.Config{}, fmt.Errorf("resolve omnibus executable: %w", err)
+	}
+	return omnibus.LoadConfig(path, executablePath, os.LookupEnv)
+}

--- a/collector/pkg/omnibus/config.go
+++ b/collector/pkg/omnibus/config.go
@@ -24,7 +24,7 @@ type CollectorSpec struct {
 }
 
 // CollectorSpecs is the stable execution and startup order for bundled collectors.
-var CollectorSpecs = []CollectorSpec{
+var CollectorSpecs = []*CollectorSpec{
 	{
 		Name:             "metrics",
 		BinaryName:       "scrutiny-collector-metrics",
@@ -199,7 +199,7 @@ func (cfg Config) Validate() error {
 	return nil
 }
 
-func applyEnvironmentOverrides(cfg *CollectorConfig, spec CollectorSpec, lookupEnv LookupEnv) error {
+func applyEnvironmentOverrides(cfg *CollectorConfig, spec *CollectorSpec, lookupEnv LookupEnv) error {
 	enabledExplicitlySet := false
 	if value, ok := lookupEnv(spec.EnabledEnv); ok {
 		parsed, err := strconv.ParseBool(value)

--- a/collector/pkg/omnibus/config.go
+++ b/collector/pkg/omnibus/config.go
@@ -1,0 +1,257 @@
+package omnibus
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/robfig/cron/v3"
+	"go.yaml.in/yaml/v3"
+)
+
+// CollectorSpec describes one collector managed by the omnibus process.
+type CollectorSpec struct {
+	Name             string
+	BinaryName       string
+	EnabledEnv       string
+	ScheduleEnv      string
+	RunStartupEnv    string
+	StartupSleepEnv  string
+	ConfigEnv        string
+	SuppressSchedule []string
+}
+
+// CollectorSpecs is the stable execution and startup order for bundled collectors.
+var CollectorSpecs = []CollectorSpec{
+	{
+		Name:             "metrics",
+		BinaryName:       "scrutiny-collector-metrics",
+		EnabledEnv:       "COLLECTOR_METRICS_ENABLED",
+		ScheduleEnv:      "COLLECTOR_CRON_SCHEDULE",
+		RunStartupEnv:    "COLLECTOR_RUN_STARTUP",
+		StartupSleepEnv:  "COLLECTOR_RUN_STARTUP_SLEEP",
+		ConfigEnv:        "COLLECTOR_METRICS_CONFIG",
+		SuppressSchedule: []string{"COLLECTOR_CRON_SCHEDULE", "COLLECTOR_RUN_STARTUP", "COLLECTOR_RUN_STARTUP_SLEEP"},
+	},
+	{
+		Name:             "zfs",
+		BinaryName:       "scrutiny-collector-zfs",
+		EnabledEnv:       "COLLECTOR_ZFS_ENABLED",
+		ScheduleEnv:      "COLLECTOR_ZFS_CRON_SCHEDULE",
+		RunStartupEnv:    "COLLECTOR_ZFS_RUN_STARTUP",
+		StartupSleepEnv:  "COLLECTOR_ZFS_RUN_STARTUP_SLEEP",
+		ConfigEnv:        "COLLECTOR_ZFS_CONFIG",
+		SuppressSchedule: []string{"COLLECTOR_ZFS_CRON_SCHEDULE", "COLLECTOR_ZFS_RUN_STARTUP", "COLLECTOR_ZFS_RUN_STARTUP_SLEEP"},
+	},
+	{
+		Name:             "mdadm",
+		BinaryName:       "scrutiny-collector-mdadm",
+		EnabledEnv:       "COLLECTOR_MDADM_ENABLED",
+		ScheduleEnv:      "COLLECTOR_MDADM_CRON_SCHEDULE",
+		RunStartupEnv:    "COLLECTOR_MDADM_RUN_STARTUP",
+		StartupSleepEnv:  "COLLECTOR_MDADM_RUN_STARTUP_SLEEP",
+		ConfigEnv:        "COLLECTOR_MDADM_CONFIG",
+		SuppressSchedule: []string{"COLLECTOR_MDADM_CRON_SCHEDULE", "COLLECTOR_MDADM_RUN_STARTUP", "COLLECTOR_MDADM_RUN_STARTUP_SLEEP"},
+	},
+	{
+		Name:             "btrfs",
+		BinaryName:       "scrutiny-collector-btrfs",
+		EnabledEnv:       "COLLECTOR_BTRFS_ENABLED",
+		ScheduleEnv:      "COLLECTOR_BTRFS_CRON_SCHEDULE",
+		RunStartupEnv:    "COLLECTOR_BTRFS_RUN_STARTUP",
+		StartupSleepEnv:  "COLLECTOR_BTRFS_RUN_STARTUP_SLEEP",
+		ConfigEnv:        "COLLECTOR_BTRFS_CONFIG",
+		SuppressSchedule: []string{"COLLECTOR_BTRFS_CRON_SCHEDULE", "COLLECTOR_BTRFS_RUN_STARTUP", "COLLECTOR_BTRFS_RUN_STARTUP_SLEEP"},
+	},
+	{
+		Name:             "filesystem",
+		BinaryName:       "scrutiny-collector-filesystem",
+		EnabledEnv:       "COLLECTOR_FILESYSTEM_ENABLED",
+		ScheduleEnv:      "COLLECTOR_FILESYSTEM_CRON_SCHEDULE",
+		RunStartupEnv:    "COLLECTOR_FILESYSTEM_RUN_STARTUP",
+		StartupSleepEnv:  "COLLECTOR_FILESYSTEM_RUN_STARTUP_SLEEP",
+		ConfigEnv:        "COLLECTOR_FILESYSTEM_CONFIG",
+		SuppressSchedule: []string{"COLLECTOR_FILESYSTEM_CRON_SCHEDULE", "COLLECTOR_FILESYSTEM_RUN_STARTUP", "COLLECTOR_FILESYSTEM_RUN_STARTUP_SLEEP"},
+	},
+	{
+		Name:             "performance",
+		BinaryName:       "scrutiny-collector-performance",
+		EnabledEnv:       "COLLECTOR_PERF_ENABLED",
+		ScheduleEnv:      "COLLECTOR_PERF_CRON_SCHEDULE",
+		RunStartupEnv:    "COLLECTOR_PERF_RUN_STARTUP",
+		StartupSleepEnv:  "COLLECTOR_PERF_RUN_STARTUP_SLEEP",
+		ConfigEnv:        "COLLECTOR_PERF_CONFIG",
+		SuppressSchedule: []string{"COLLECTOR_PERF_CRON_SCHEDULE", "COLLECTOR_PERF_RUN_STARTUP", "COLLECTOR_PERF_RUN_STARTUP_SLEEP"},
+	},
+}
+
+// CollectorConfig controls one child collector.
+type CollectorConfig struct {
+	Enabled          bool   `yaml:"enabled"`
+	Schedule         string `yaml:"schedule"`
+	RunOnStartup     bool   `yaml:"run_on_startup"`
+	StartupSleepSecs int    `yaml:"startup_sleep_secs"`
+	ConfigPath       string `yaml:"config"`
+}
+
+// Config controls the standalone omnibus manager.
+type Config struct {
+	BinaryDir  string                     `yaml:"binary_dir"`
+	Collectors map[string]CollectorConfig `yaml:"collectors"`
+}
+
+// LookupEnv allows deterministic environment override tests.
+type LookupEnv func(string) (string, bool)
+
+// LoadConfig reads, resolves, overrides, and validates an omnibus configuration.
+func LoadConfig(path, executablePath string, lookupEnv LookupEnv) (Config, error) {
+	if lookupEnv == nil {
+		lookupEnv = os.LookupEnv
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return Config{}, fmt.Errorf("open omnibus config: %w", err)
+	}
+	defer file.Close()
+
+	var cfg Config
+	decoder := yaml.NewDecoder(file)
+	decoder.KnownFields(true)
+	if err := decoder.Decode(&cfg); err != nil {
+		return Config{}, fmt.Errorf("decode omnibus config: %w", err)
+	}
+	if cfg.Collectors == nil {
+		cfg.Collectors = map[string]CollectorConfig{}
+	}
+
+	configDir, err := filepath.Abs(filepath.Dir(path))
+	if err != nil {
+		return Config{}, fmt.Errorf("resolve omnibus config directory: %w", err)
+	}
+	if cfg.BinaryDir == "" {
+		cfg.BinaryDir = filepath.Dir(executablePath)
+	}
+	if value, ok := lookupEnv("COLLECTOR_OMNIBUS_BINARY_DIR"); ok {
+		cfg.BinaryDir = value
+	}
+	cfg.BinaryDir = resolvePath(configDir, cfg.BinaryDir)
+
+	known := make(map[string]struct{}, len(CollectorSpecs))
+	for _, spec := range CollectorSpecs {
+		known[spec.Name] = struct{}{}
+		collectorCfg := cfg.Collectors[spec.Name]
+		if err := applyEnvironmentOverrides(&collectorCfg, spec, lookupEnv); err != nil {
+			return Config{}, err
+		}
+		if collectorCfg.ConfigPath != "" {
+			collectorCfg.ConfigPath = resolvePath(configDir, collectorCfg.ConfigPath)
+		}
+		cfg.Collectors[spec.Name] = collectorCfg
+	}
+	for name := range cfg.Collectors {
+		if _, ok := known[name]; !ok {
+			return Config{}, fmt.Errorf("unknown collector %q", name)
+		}
+	}
+
+	if err := cfg.Validate(); err != nil {
+		return Config{}, err
+	}
+	return cfg, nil
+}
+
+// Validate checks manager configuration and required local files.
+func (cfg Config) Validate() error {
+	enabled := 0
+	for _, spec := range CollectorSpecs {
+		collectorCfg := cfg.Collectors[spec.Name]
+		if !collectorCfg.Enabled {
+			continue
+		}
+		enabled++
+		if collectorCfg.Schedule == "" && !collectorCfg.RunOnStartup {
+			return fmt.Errorf("collector %q is enabled but has no schedule or startup run", spec.Name)
+		}
+		if collectorCfg.Schedule != "" {
+			if _, err := cron.ParseStandard(collectorCfg.Schedule); err != nil {
+				return fmt.Errorf("collector %q has invalid schedule %q: %w", spec.Name, collectorCfg.Schedule, err)
+			}
+		}
+		if collectorCfg.StartupSleepSecs < 0 {
+			return fmt.Errorf("collector %q startup_sleep_secs must not be negative", spec.Name)
+		}
+		if collectorCfg.ConfigPath == "" {
+			return fmt.Errorf("collector %q requires a config path", spec.Name)
+		}
+		if err := requireRegularFile(collectorCfg.ConfigPath); err != nil {
+			return fmt.Errorf("collector %q config: %w", spec.Name, err)
+		}
+		binaryPath := filepath.Join(cfg.BinaryDir, executableName(spec.BinaryName))
+		if err := requireRegularFile(binaryPath); err != nil {
+			return fmt.Errorf("collector %q binary: %w", spec.Name, err)
+		}
+	}
+	if enabled == 0 {
+		return fmt.Errorf("at least one collector must be enabled")
+	}
+	return nil
+}
+
+func applyEnvironmentOverrides(cfg *CollectorConfig, spec CollectorSpec, lookupEnv LookupEnv) error {
+	enabledExplicitlySet := false
+	if value, ok := lookupEnv(spec.EnabledEnv); ok {
+		parsed, err := strconv.ParseBool(value)
+		if err != nil {
+			return fmt.Errorf("%s must be a boolean: %w", spec.EnabledEnv, err)
+		}
+		cfg.Enabled = parsed
+		enabledExplicitlySet = true
+	}
+	if value, ok := lookupEnv(spec.ScheduleEnv); ok {
+		cfg.Schedule = strings.TrimSpace(value)
+		if cfg.Schedule != "" && !enabledExplicitlySet {
+			cfg.Enabled = true
+		}
+	}
+	if value, ok := lookupEnv(spec.RunStartupEnv); ok {
+		parsed, err := strconv.ParseBool(value)
+		if err != nil {
+			return fmt.Errorf("%s must be a boolean: %w", spec.RunStartupEnv, err)
+		}
+		cfg.RunOnStartup = parsed
+		if parsed && !enabledExplicitlySet {
+			cfg.Enabled = true
+		}
+	}
+	if value, ok := lookupEnv(spec.StartupSleepEnv); ok {
+		parsed, err := strconv.Atoi(value)
+		if err != nil {
+			return fmt.Errorf("%s must be an integer: %w", spec.StartupSleepEnv, err)
+		}
+		cfg.StartupSleepSecs = parsed
+	}
+	if value, ok := lookupEnv(spec.ConfigEnv); ok {
+		cfg.ConfigPath = value
+	}
+	return nil
+}
+
+func resolvePath(base, path string) string {
+	if filepath.IsAbs(path) {
+		return filepath.Clean(path)
+	}
+	return filepath.Clean(filepath.Join(base, path))
+}
+
+func requireRegularFile(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("%s is not a regular file", path)
+	}
+	return nil
+}

--- a/collector/pkg/omnibus/config.go
+++ b/collector/pkg/omnibus/config.go
@@ -89,17 +89,17 @@ var CollectorSpecs = []*CollectorSpec{
 
 // CollectorConfig controls one child collector.
 type CollectorConfig struct {
-	Enabled          bool   `yaml:"enabled"`
 	Schedule         string `yaml:"schedule"`
-	RunOnStartup     bool   `yaml:"run_on_startup"`
-	StartupSleepSecs int    `yaml:"startup_sleep_secs"`
 	ConfigPath       string `yaml:"config"`
+	StartupSleepSecs int    `yaml:"startup_sleep_secs"`
+	Enabled          bool   `yaml:"enabled"`
+	RunOnStartup     bool   `yaml:"run_on_startup"`
 }
 
 // Config controls the standalone omnibus manager.
 type Config struct {
-	BinaryDir  string                     `yaml:"binary_dir"`
 	Collectors map[string]CollectorConfig `yaml:"collectors"`
+	BinaryDir  string                     `yaml:"binary_dir"`
 }
 
 // LookupEnv allows deterministic environment override tests.
@@ -119,8 +119,8 @@ func LoadConfig(path, executablePath string, lookupEnv LookupEnv) (Config, error
 	var cfg Config
 	decoder := yaml.NewDecoder(file)
 	decoder.KnownFields(true)
-	if err := decoder.Decode(&cfg); err != nil {
-		return Config{}, fmt.Errorf("decode omnibus config: %w", err)
+	if decodeErr := decoder.Decode(&cfg); decodeErr != nil {
+		return Config{}, fmt.Errorf("decode omnibus config: %w", decodeErr)
 	}
 	if cfg.Collectors == nil {
 		cfg.Collectors = map[string]CollectorConfig{}

--- a/collector/pkg/omnibus/config_test.go
+++ b/collector/pkg/omnibus/config_test.go
@@ -1,0 +1,118 @@
+package omnibus
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadConfigResolvesPathsAndAppliesEnvironment(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, filepath.Join(dir, "bin", executableName("scrutiny-collector-zfs")))
+	writeTestFile(t, filepath.Join(dir, "config", "collector-zfs.yaml"))
+	configPath := filepath.Join(dir, "collector-omnibus.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte(`
+binary_dir: ./bin
+collectors:
+  zfs:
+    enabled: false
+    config: ./config/collector-zfs.yaml
+`), 0o600))
+
+	env := map[string]string{
+		"COLLECTOR_ZFS_CRON_SCHEDULE":     "*/15 * * * *",
+		"COLLECTOR_ZFS_RUN_STARTUP":       "true",
+		"COLLECTOR_ZFS_RUN_STARTUP_SLEEP": "5",
+	}
+	cfg, err := LoadConfig(configPath, filepath.Join(dir, "unused"), mapLookup(env))
+	require.NoError(t, err)
+
+	zfs := cfg.Collectors["zfs"]
+	assert.True(t, zfs.Enabled)
+	assert.Equal(t, "*/15 * * * *", zfs.Schedule)
+	assert.True(t, zfs.RunOnStartup)
+	assert.Equal(t, 5, zfs.StartupSleepSecs)
+	assert.Equal(t, filepath.Join(dir, "config", "collector-zfs.yaml"), zfs.ConfigPath)
+	assert.Equal(t, filepath.Join(dir, "bin"), cfg.BinaryDir)
+}
+
+func TestLoadConfigExplicitDisableWinsOverScheduleOverride(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "collector-omnibus.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte(`
+collectors:
+  metrics:
+    enabled: true
+    schedule: "0 0 * * *"
+    config: collector.yaml
+`), 0o600))
+
+	env := map[string]string{
+		"COLLECTOR_METRICS_ENABLED": "false",
+		"COLLECTOR_CRON_SCHEDULE":   "*/5 * * * *",
+	}
+	_, err := LoadConfig(configPath, filepath.Join(dir, "scrutiny-collector-omnibus"), mapLookup(env))
+	require.EqualError(t, err, "at least one collector must be enabled")
+}
+
+func TestLoadConfigRejectsUnknownCollector(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "collector-omnibus.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte(`
+collectors:
+  unknown:
+    enabled: true
+`), 0o600))
+
+	_, err := LoadConfig(configPath, filepath.Join(dir, "scrutiny-collector-omnibus"), mapLookup(nil))
+	require.EqualError(t, err, `unknown collector "unknown"`)
+}
+
+func TestLoadConfigRejectsInvalidSchedule(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, filepath.Join(dir, executableName("scrutiny-collector-metrics")))
+	writeTestFile(t, filepath.Join(dir, "collector.yaml"))
+	configPath := filepath.Join(dir, "collector-omnibus.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte(`
+collectors:
+  metrics:
+    enabled: true
+    schedule: invalid
+    config: collector.yaml
+`), 0o600))
+
+	_, err := LoadConfig(configPath, filepath.Join(dir, "scrutiny-collector-omnibus"), mapLookup(nil))
+	require.ErrorContains(t, err, `collector "metrics" has invalid schedule "invalid"`)
+}
+
+func TestLoadConfigRejectsMissingEnabledBinary(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, filepath.Join(dir, "collector.yaml"))
+	configPath := filepath.Join(dir, "collector-omnibus.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte(`
+collectors:
+  metrics:
+    enabled: true
+    run_on_startup: true
+    config: collector.yaml
+`), 0o600))
+
+	_, err := LoadConfig(configPath, filepath.Join(dir, "scrutiny-collector-omnibus"), mapLookup(nil))
+	require.ErrorContains(t, err, `collector "metrics" binary`)
+}
+
+func mapLookup(values map[string]string) LookupEnv {
+	return func(key string) (string, bool) {
+		value, ok := values[key]
+		return value, ok
+	}
+}
+
+func writeTestFile(t *testing.T, path string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte("test"), 0o755))
+}

--- a/collector/pkg/omnibus/executable_unix.go
+++ b/collector/pkg/omnibus/executable_unix.go
@@ -1,0 +1,7 @@
+//go:build !windows
+
+package omnibus
+
+func executableName(name string) string {
+	return name
+}

--- a/collector/pkg/omnibus/executable_windows.go
+++ b/collector/pkg/omnibus/executable_windows.go
@@ -1,0 +1,7 @@
+//go:build windows
+
+package omnibus
+
+func executableName(name string) string {
+	return name + ".exe"
+}

--- a/collector/pkg/omnibus/manager.go
+++ b/collector/pkg/omnibus/manager.go
@@ -13,10 +13,10 @@ import (
 
 // Manager schedules and supervises bundled collectors.
 type Manager struct {
-	config  Config
 	runner  Runner
 	logger  *logrus.Entry
 	running map[string]*atomic.Bool
+	config  Config
 	wg      sync.WaitGroup
 }
 

--- a/collector/pkg/omnibus/manager.go
+++ b/collector/pkg/omnibus/manager.go
@@ -1,0 +1,138 @@
+package omnibus
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/robfig/cron/v3"
+	"github.com/sirupsen/logrus"
+)
+
+// Manager schedules and supervises bundled collectors.
+type Manager struct {
+	config  Config
+	runner  Runner
+	logger  *logrus.Entry
+	running map[string]*atomic.Bool
+	wg      sync.WaitGroup
+}
+
+// NewManager creates an omnibus manager from validated configuration.
+func NewManager(cfg Config, runner Runner, logger *logrus.Entry) *Manager {
+	running := make(map[string]*atomic.Bool, len(CollectorSpecs))
+	for _, spec := range CollectorSpecs {
+		running[spec.Name] = &atomic.Bool{}
+	}
+	return &Manager{
+		config:  cfg,
+		runner:  runner,
+		logger:  logger,
+		running: running,
+	}
+}
+
+// Run starts configured schedules and waits for shutdown.
+func (m *Manager) Run(ctx context.Context) error {
+	scheduler := cron.New()
+	hasSchedule := false
+	for _, spec := range CollectorSpecs {
+		collectorCfg := m.config.Collectors[spec.Name]
+		if !collectorCfg.Enabled || collectorCfg.Schedule == "" {
+			continue
+		}
+		hasSchedule = true
+		currentSpec := spec
+		if _, err := scheduler.AddFunc(collectorCfg.Schedule, func() {
+			m.launch(ctx, currentSpec)
+		}); err != nil {
+			return fmt.Errorf("schedule collector %q: %w", spec.Name, err)
+		}
+		m.logger.WithFields(logrus.Fields{
+			"collector": spec.Name,
+			"schedule":  collectorCfg.Schedule,
+		}).Info("collector scheduled")
+	}
+
+	startupDone := make(chan struct{})
+	go func() {
+		defer close(startupDone)
+		m.runStartupCollectors(ctx)
+	}()
+
+	if !hasSchedule {
+		select {
+		case <-startupDone:
+			m.wg.Wait()
+			return nil
+		case <-ctx.Done():
+			<-startupDone
+			m.wg.Wait()
+			return nil
+		}
+	}
+
+	scheduler.Start()
+	select {
+	case <-ctx.Done():
+	case <-startupDone:
+		// Scheduled collectors keep the manager alive after startup runs finish.
+		<-ctx.Done()
+	}
+
+	m.logger.Info("stopping collector scheduler")
+	stopCtx := scheduler.Stop()
+	<-stopCtx.Done()
+	<-startupDone
+	m.wg.Wait()
+	return nil
+}
+
+func (m *Manager) runStartupCollectors(ctx context.Context) {
+	for _, spec := range CollectorSpecs {
+		cfg := m.config.Collectors[spec.Name]
+		if !cfg.Enabled || !cfg.RunOnStartup {
+			continue
+		}
+		if cfg.StartupSleepSecs > 0 {
+			timer := time.NewTimer(time.Duration(cfg.StartupSleepSecs) * time.Second)
+			select {
+			case <-timer.C:
+			case <-ctx.Done():
+				timer.Stop()
+				return
+			}
+		}
+		if ctx.Err() != nil {
+			return
+		}
+		m.execute(ctx, spec)
+	}
+}
+
+func (m *Manager) launch(ctx context.Context, spec CollectorSpec) {
+	m.wg.Add(1)
+	go func() {
+		defer m.wg.Done()
+		m.execute(ctx, spec)
+	}()
+}
+
+func (m *Manager) execute(ctx context.Context, spec CollectorSpec) {
+	state := m.running[spec.Name]
+	if !state.CompareAndSwap(false, true) {
+		m.logger.WithField("collector", spec.Name).Warn("collector run skipped because previous run is still active")
+		return
+	}
+	defer state.Store(false)
+
+	m.logger.WithField("collector", spec.Name).Info("collector run started")
+	err := m.runner.Run(ctx, spec, m.config.Collectors[spec.Name], m.config.BinaryDir)
+	if err != nil && ctx.Err() == nil {
+		m.logger.WithError(err).WithField("collector", spec.Name).Error("collector run failed")
+		return
+	}
+	m.logger.WithField("collector", spec.Name).Info("collector run finished")
+}

--- a/collector/pkg/omnibus/manager.go
+++ b/collector/pkg/omnibus/manager.go
@@ -112,7 +112,7 @@ func (m *Manager) runStartupCollectors(ctx context.Context) {
 	}
 }
 
-func (m *Manager) launch(ctx context.Context, spec CollectorSpec) {
+func (m *Manager) launch(ctx context.Context, spec *CollectorSpec) {
 	m.wg.Add(1)
 	go func() {
 		defer m.wg.Done()
@@ -120,7 +120,7 @@ func (m *Manager) launch(ctx context.Context, spec CollectorSpec) {
 	}()
 }
 
-func (m *Manager) execute(ctx context.Context, spec CollectorSpec) {
+func (m *Manager) execute(ctx context.Context, spec *CollectorSpec) {
 	state := m.running[spec.Name]
 	if !state.CompareAndSwap(false, true) {
 		m.logger.WithField("collector", spec.Name).Warn("collector run skipped because previous run is still active")

--- a/collector/pkg/omnibus/manager_test.go
+++ b/collector/pkg/omnibus/manager_test.go
@@ -1,0 +1,146 @@
+package omnibus
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type runnerCall struct {
+	name string
+}
+
+type fakeRunner struct {
+	calls   chan runnerCall
+	release chan struct{}
+	errs    map[string]error
+}
+
+func (r *fakeRunner) Run(ctx context.Context, spec CollectorSpec, _ CollectorConfig, _ string) error {
+	r.calls <- runnerCall{name: spec.Name}
+	if r.release != nil {
+		select {
+		case <-r.release:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	return r.errs[spec.Name]
+}
+
+func TestManagerRunsStartupCollectorsInStableOrder(t *testing.T) {
+	runner := &fakeRunner{
+		calls: make(chan runnerCall, 2),
+		errs:  map[string]error{"metrics": errors.New("metrics failed")},
+	}
+	cfg := Config{Collectors: map[string]CollectorConfig{
+		"metrics": {Enabled: true, RunOnStartup: true},
+		"zfs":     {Enabled: true, RunOnStartup: true},
+	}}
+	manager := NewManager(cfg, runner, testLogger())
+
+	require.NoError(t, manager.Run(context.Background()))
+	assert.Equal(t, "metrics", (<-runner.calls).name)
+	assert.Equal(t, "zfs", (<-runner.calls).name)
+}
+
+func TestManagerSkipsOverlappingCollectorRun(t *testing.T) {
+	runner := &fakeRunner{
+		calls:   make(chan runnerCall, 2),
+		release: make(chan struct{}),
+		errs:    map[string]error{},
+	}
+	cfg := Config{Collectors: map[string]CollectorConfig{
+		"metrics": {Enabled: true},
+	}}
+	manager := NewManager(cfg, runner, testLogger())
+	spec := CollectorSpecs[0]
+
+	manager.launch(context.Background(), spec)
+	require.Equal(t, "metrics", (<-runner.calls).name)
+	manager.execute(context.Background(), spec)
+	close(runner.release)
+	manager.wg.Wait()
+	assert.Empty(t, runner.calls)
+}
+
+func TestManagerStopsScheduledModeOnContextCancellation(t *testing.T) {
+	runner := &fakeRunner{
+		calls: make(chan runnerCall, 1),
+		errs:  map[string]error{},
+	}
+	cfg := Config{Collectors: map[string]CollectorConfig{
+		"metrics": {Enabled: true, Schedule: "0 0 * * *"},
+	}}
+	manager := NewManager(cfg, runner, testLogger())
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+
+	go func() {
+		done <- manager.Run(ctx)
+	}()
+	cancel()
+
+	require.NoError(t, <-done)
+}
+
+func TestManagerWaitsForStartupCollectorCancellation(t *testing.T) {
+	runner := &fakeRunner{
+		calls:   make(chan runnerCall, 1),
+		release: make(chan struct{}),
+		errs:    map[string]error{},
+	}
+	cfg := Config{Collectors: map[string]CollectorConfig{
+		"metrics": {Enabled: true, RunOnStartup: true},
+	}}
+	manager := NewManager(cfg, runner, testLogger())
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+
+	go func() {
+		done <- manager.Run(ctx)
+	}()
+	require.Equal(t, "metrics", (<-runner.calls).name)
+	cancel()
+
+	require.NoError(t, <-done)
+}
+
+func TestChildEnvironmentSuppressesManagerSchedulingVariables(t *testing.T) {
+	t.Setenv("COLLECTOR_CRON_SCHEDULE", "0 0 * * *")
+	t.Setenv("COLLECTOR_RUN_STARTUP", "true")
+	t.Setenv("COLLECTOR_ZFS_CRON_SCHEDULE", "*/15 * * * *")
+	t.Setenv("PRESERVED_VALUE", "yes")
+
+	env := childEnvironment()
+	joined := make(map[string]string, len(env))
+	for _, item := range env {
+		key, value, found := strings.Cut(item, "=")
+		if found {
+			joined[key] = value
+		}
+	}
+
+	assert.NotContains(t, joined, "COLLECTOR_CRON_SCHEDULE")
+	assert.NotContains(t, joined, "COLLECTOR_RUN_STARTUP")
+	assert.NotContains(t, joined, "COLLECTOR_ZFS_CRON_SCHEDULE")
+	assert.Equal(t, "yes", joined["PRESERVED_VALUE"])
+	assert.Equal(t, "true", joined["SCRUTINY_SUPPRESS_STARTUP_BANNER"])
+}
+
+func testLogger() *logrus.Entry {
+	logger := logrus.New()
+	logger.SetOutput(ioDiscard{})
+	return logrus.NewEntry(logger)
+}
+
+type ioDiscard struct{}
+
+func (ioDiscard) Write(data []byte) (int, error) {
+	return len(data), nil
+}

--- a/collector/pkg/omnibus/manager_test.go
+++ b/collector/pkg/omnibus/manager_test.go
@@ -21,7 +21,7 @@ type fakeRunner struct {
 	errs    map[string]error
 }
 
-func (r *fakeRunner) Run(ctx context.Context, spec CollectorSpec, _ CollectorConfig, _ string) error {
+func (r *fakeRunner) Run(ctx context.Context, spec *CollectorSpec, _ CollectorConfig, _ string) error {
 	r.calls <- runnerCall{name: spec.Name}
 	if r.release != nil {
 		select {

--- a/collector/pkg/omnibus/runner.go
+++ b/collector/pkg/omnibus/runner.go
@@ -11,7 +11,7 @@ import (
 
 // Runner executes one configured collector.
 type Runner interface {
-	Run(context.Context, CollectorSpec, CollectorConfig, string) error
+	Run(context.Context, *CollectorSpec, CollectorConfig, string) error
 }
 
 // ExecRunner runs bundled collector executables as child processes.
@@ -21,7 +21,7 @@ type ExecRunner struct {
 }
 
 // Run starts one collector in run-once mode.
-func (r ExecRunner) Run(ctx context.Context, spec CollectorSpec, cfg CollectorConfig, binaryDir string) error {
+func (r ExecRunner) Run(ctx context.Context, spec *CollectorSpec, cfg CollectorConfig, binaryDir string) error {
 	binaryPath := filepath.Join(binaryDir, executableName(spec.BinaryName))
 	cmd := exec.CommandContext(ctx, binaryPath, "run", "--config", cfg.ConfigPath)
 	cmd.Stdout = r.Stdout

--- a/collector/pkg/omnibus/runner.go
+++ b/collector/pkg/omnibus/runner.go
@@ -1,0 +1,51 @@
+package omnibus
+
+import (
+	"context"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// Runner executes one configured collector.
+type Runner interface {
+	Run(context.Context, CollectorSpec, CollectorConfig, string) error
+}
+
+// ExecRunner runs bundled collector executables as child processes.
+type ExecRunner struct {
+	Stdout io.Writer
+	Stderr io.Writer
+}
+
+// Run starts one collector in run-once mode.
+func (r ExecRunner) Run(ctx context.Context, spec CollectorSpec, cfg CollectorConfig, binaryDir string) error {
+	binaryPath := filepath.Join(binaryDir, executableName(spec.BinaryName))
+	cmd := exec.CommandContext(ctx, binaryPath, "run", "--config", cfg.ConfigPath)
+	cmd.Stdout = r.Stdout
+	cmd.Stderr = r.Stderr
+	cmd.Env = childEnvironment()
+	return cmd.Run()
+}
+
+func childEnvironment() []string {
+	suppressed := make(map[string]struct{})
+	for _, spec := range CollectorSpecs {
+		for _, name := range spec.SuppressSchedule {
+			suppressed[name] = struct{}{}
+		}
+	}
+
+	env := make([]string, 0, len(os.Environ())+1)
+	for _, item := range os.Environ() {
+		name, _, _ := strings.Cut(item, "=")
+		if _, skip := suppressed[name]; skip {
+			continue
+		}
+		env = append(env, item)
+	}
+	env = append(env, "SCRUTINY_SUPPRESS_STARTUP_BANNER=true")
+	return env
+}

--- a/docs/INSTALL_COLLECTOR_OMNIBUS.md
+++ b/docs/INSTALL_COLLECTOR_OMNIBUS.md
@@ -1,0 +1,90 @@
+# Standalone Collector Omnibus
+
+The standalone collector omnibus is one platform-specific archive containing
+the SMART, ZFS, MDADM, Btrfs, filesystem, and performance collectors plus a
+manager that schedules and supervises them. It is intended for hub/spoke
+installations that do not use Docker.
+
+The manager does not install host tools. Install the tools required by each
+enabled collector:
+
+| Collector | Required host tool |
+| --- | --- |
+| SMART metrics | `smartctl` from smartmontools |
+| ZFS | `zpool` |
+| MDADM | `mdadm` |
+| Btrfs | `btrfs` |
+| Filesystem | OS filesystem utilities and access to monitored mounts |
+| Performance | `fio` |
+
+## Install
+
+Download the archive matching the host from a Scrutiny GitHub release. Unix
+targets use `.tar.gz`; Windows targets use `.zip`.
+
+After extracting, the package contains:
+
+```text
+scrutiny-collector-omnibus-<os>-<arch>/
+├── bin/
+│   ├── scrutiny-collector-omnibus
+│   └── scrutiny-collector-*
+├── config/
+│   ├── collector-omnibus.yaml
+│   └── collector*.yaml
+├── INSTALL.md
+└── LICENSE
+```
+
+Edit `config/collector.yaml` with the hub API endpoint and credentials. Enable
+optional collectors and set their schedules in
+`config/collector-omnibus.yaml`. Each enabled collector must have either a
+schedule or `run_on_startup: true`.
+
+Validate the complete installation before starting it:
+
+```bash
+./bin/scrutiny-collector-omnibus validate \
+  --config ./config/collector-omnibus.yaml
+```
+
+Run the manager under a long-lived platform service such as systemd, launchd,
+Windows Task Scheduler at startup, or a Windows service wrapper:
+
+```bash
+./bin/scrutiny-collector-omnibus run \
+  --config ./config/collector-omnibus.yaml
+```
+
+The manager uses standard five-field cron expressions in the process's local
+timezone. Runs for different collectors may overlap. A second run of the same
+collector is skipped while its previous run is still active. A collector
+failure is logged without stopping other schedules. `SIGINT` or `SIGTERM`
+stops scheduling and cancels active child processes.
+
+## Configuration precedence
+
+The YAML file is the primary configuration surface for fleet-managed
+installations. Environment variables override YAML values:
+
+| YAML field | Metrics | Optional collector example |
+| --- | --- | --- |
+| `enabled` | `COLLECTOR_METRICS_ENABLED` | `COLLECTOR_ZFS_ENABLED` |
+| `schedule` | `COLLECTOR_CRON_SCHEDULE` | `COLLECTOR_ZFS_CRON_SCHEDULE` |
+| `run_on_startup` | `COLLECTOR_RUN_STARTUP` | `COLLECTOR_ZFS_RUN_STARTUP` |
+| `startup_sleep_secs` | `COLLECTOR_RUN_STARTUP_SLEEP` | `COLLECTOR_ZFS_RUN_STARTUP_SLEEP` |
+| `config` | `COLLECTOR_METRICS_CONFIG` | `COLLECTOR_ZFS_CONFIG` |
+
+Optional collector prefixes are `COLLECTOR_ZFS`, `COLLECTOR_MDADM`,
+`COLLECTOR_BTRFS`, `COLLECTOR_FILESYSTEM`, and `COLLECTOR_PERF`. A non-empty
+schedule or a true startup override enables that collector unless its
+`*_ENABLED` variable explicitly disables it.
+
+Use `COLLECTOR_OMNIBUS_CONFIG` instead of `--config` when a service definition
+provides configuration through its environment.
+`COLLECTOR_OMNIBUS_BINARY_DIR` overrides `binary_dir`.
+
+Collector API, host, logging, and device settings remain in their existing
+collector YAML files and environment variables. The manager removes scheduling
+variables from child processes so each scheduled child performs exactly one
+collection and exits.

--- a/docs/INSTALL_HUB_SPOKE.md
+++ b/docs/INSTALL_HUB_SPOKE.md
@@ -116,6 +116,10 @@ Hub. The official
 documentation [describes the manual setup of the Collector](https://github.com/Starosdev/scrutiny/blob/master/docs/INSTALL_MANUAL.md#collector)
 - dependencies and step by step commands. I have a shortened version that does the same thing but in one line of code.
 
+For hosts running several collector types, the
+[standalone collector omnibus](INSTALL_COLLECTOR_OMNIBUS.md) packages all
+collector binaries with one cross-platform scheduler.
+
 ```bash
 # Installing dependencies
 apt install smartmontools -y 

--- a/example.collector-omnibus.yaml
+++ b/example.collector-omnibus.yaml
@@ -1,0 +1,52 @@
+# Standalone collector omnibus manager configuration.
+#
+# Run:
+#   scrutiny-collector-omnibus run --config /path/to/collector-omnibus.yaml
+#
+# Paths are resolved relative to this file. Environment variables override
+# these values; see docs/INSTALL_COLLECTOR_OMNIBUS.md for the full mapping.
+
+binary_dir: ../bin
+
+collectors:
+  metrics:
+    enabled: true
+    schedule: "0 0 * * *"
+    run_on_startup: false
+    startup_sleep_secs: 0
+    config: ./collector.yaml
+
+  zfs:
+    enabled: false
+    schedule: "*/15 * * * *"
+    run_on_startup: false
+    startup_sleep_secs: 0
+    config: ./collector-zfs.yaml
+
+  mdadm:
+    enabled: false
+    schedule: "*/15 * * * *"
+    run_on_startup: false
+    startup_sleep_secs: 0
+    config: ./collector.yaml
+
+  btrfs:
+    enabled: false
+    schedule: "*/15 * * * *"
+    run_on_startup: false
+    startup_sleep_secs: 0
+    config: ./collector-btrfs.yaml
+
+  filesystem:
+    enabled: false
+    schedule: "*/15 * * * *"
+    run_on_startup: false
+    startup_sleep_secs: 0
+    config: ./collector.yaml
+
+  performance:
+    enabled: false
+    schedule: "0 2 * * 0"
+    run_on_startup: false
+    startup_sleep_secs: 0
+    config: ./collector-performance.yaml

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/urfave/cli/v2 v2.27.7
 	go.uber.org/automaxprocs v1.6.0
+	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/sync v0.21.0
 	gorm.io/gorm v1.31.2
 )
@@ -88,7 +89,6 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.mongodb.org/mongo-driver/v2 v2.5.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
-	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/arch v0.22.0 // indirect
 	golang.org/x/crypto v0.51.0 // indirect
 	golang.org/x/net v0.55.0 // indirect


### PR DESCRIPTION
## Summary

- add a cross-platform omnibus manager with strict YAML configuration and environment overrides
- supervise all six collector binaries with startup runs, cron schedules, overlap prevention, failure isolation, and graceful shutdown
- publish deterministic tar.gz or zip bundles for every existing release target while retaining individual binaries
- document installation, host-tool prerequisites, configuration precedence, and service operation
- keep the Docker collector omnibus runtime unchanged

## Linked Issues

Closes #670.

## Test plan

- [x] `go test ./...`
- [x] `go test -race ./collector/pkg/omnibus ./build/package-collector-omnibus`
- [x] `go vet ./collector/pkg/omnibus ./collector/cmd/collector-omnibus ./build/package-collector-omnibus`
- [x] `actionlint -ignore SC2086 .github/workflows/ci.yaml .github/workflows/release.yaml`
- [x] Built and validated the extracted Darwin arm64 omnibus archive
- [x] Cross-compiled and inspected the Windows amd64 omnibus zip
- [x] Confirmed native Windows Make naming includes `.exe` for every bundled collector
