### PR TITLE
Paginate SMART dashboard devices

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -173,6 +173,38 @@ paths:
     get:
       tags: [Devices]
       summary: Get dashboard device summary
+      description: Without `page`, returns the legacy unpaginated summary. Supplying `page` enables global device pagination while retaining host-first ordering.
+      parameters:
+        - name: page
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+          description: One-based page number. Omit for the legacy unpaginated response.
+        - name: page_size
+          in: query
+          schema:
+            type: integer
+            enum: [25, 50, 100, 250]
+          description: Devices per page. Defaults to the saved dashboard setting.
+        - name: archived
+          in: query
+          schema:
+            type: boolean
+            default: false
+          description: Return archived devices instead of active devices.
+        - name: sort
+          in: query
+          schema:
+            type: string
+            enum: [status, status_asc, status_desc, title, title_asc, title_desc, age, age_asc, age_desc, capacity_asc, capacity_desc, temperature_asc, temperature_desc]
+          description: Dashboard device sort. Defaults to the saved dashboard setting.
+        - name: display
+          in: query
+          schema:
+            type: string
+            enum: [name, serial_id, uuid, label]
+          description: Title source used by title sorting. Defaults to the saved dashboard setting.
       responses:
         "200":
           description: Device summary payload
@@ -180,6 +212,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/DeviceSummaryWrapper"
+        "400":
+          $ref: "#/components/responses/ErrorResponse"
         "500":
           $ref: "#/components/responses/ErrorResponse"
   /api/summary/temp:
@@ -1820,6 +1854,10 @@ components:
           type: integer
         dashboard_density:
           type: string
+        dashboard_page_size:
+          type: integer
+          enum: [25, 50, 100, 250]
+          default: 25
         temperature_unit:
           type: string
         line_stroke:
@@ -2752,6 +2790,27 @@ components:
               type: object
               additionalProperties:
                 $ref: "#/components/schemas/DeviceSummary"
+            pagination:
+              $ref: "#/components/schemas/PaginationMetadata"
+    PaginationMetadata:
+      type: object
+      required: [page, page_size, total_items, total_pages, attention_count]
+      properties:
+        page:
+          type: integer
+          minimum: 1
+        page_size:
+          type: integer
+          enum: [25, 50, 100, 250]
+        total_items:
+          type: integer
+          minimum: 0
+        total_pages:
+          type: integer
+          minimum: 0
+        attention_count:
+          type: integer
+          minimum: 0
     DeviceSummary:
       type: object
       properties:

--- a/webapp/backend/pkg/database/interface.go
+++ b/webapp/backend/pkg/database/interface.go
@@ -66,6 +66,7 @@ type DeviceRepo interface {
 	SaveSmartTemperature(ctx context.Context, wwn string, deviceID string, collectorSmartData *collector.SmartInfo, retrieveSCTTemperatureHistory bool) error
 
 	GetSummary(ctx context.Context) (map[string]*models.DeviceSummary, error)
+	GetSummaryPage(ctx context.Context, options models.DeviceSummaryPageOptions) (*models.DeviceSummaryPage, error)
 	GetSmartTemperatureHistory(ctx context.Context, durationKey string) (map[string][]measurements.SmartTemperature, error)
 	SaveFilesystemSummary(ctx context.Context, payload models.FilesystemSummaryUpload) error
 	GetFilesystemSummary(ctx context.Context) (map[string][]models.FilesystemCapacity, map[string]*models.FilesystemHostStatus, error)

--- a/webapp/backend/pkg/database/mock/mock_database.go
+++ b/webapp/backend/pkg/database/mock/mock_database.go
@@ -589,6 +589,21 @@ func (mr *MockDeviceRepoMockRecorder) GetSummary(ctx interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSummary", reflect.TypeOf((*MockDeviceRepo)(nil).GetSummary), ctx)
 }
 
+// GetSummaryPage mocks base method.
+func (m *MockDeviceRepo) GetSummaryPage(ctx context.Context, options models.DeviceSummaryPageOptions) (*models.DeviceSummaryPage, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSummaryPage", ctx, options)
+	ret0, _ := ret[0].(*models.DeviceSummaryPage)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetSummaryPage indicates an expected call of GetSummaryPage.
+func (mr *MockDeviceRepoMockRecorder) GetSummaryPage(ctx, options interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSummaryPage", reflect.TypeOf((*MockDeviceRepo)(nil).GetSummaryPage), ctx, options)
+}
+
 // GetWorkloadInsights mocks base method.
 func (m *MockDeviceRepo) GetWorkloadInsights(ctx context.Context, durationKey string) (map[string]*models.WorkloadInsight, error) {
 	m.ctrl.T.Helper()

--- a/webapp/backend/pkg/database/scrutiny_repository.go
+++ b/webapp/backend/pkg/database/scrutiny_repository.go
@@ -434,6 +434,10 @@ func (sr *scrutinyRepository) ensureRetentionBucket(ctx context.Context, org *do
 
 // get a map of all devices and associated SMART data
 func (sr *scrutinyRepository) GetSummary(ctx context.Context) (map[string]*models.DeviceSummary, error) {
+	return sr.getSummary(ctx, true)
+}
+
+func (sr *scrutinyRepository) getSummary(ctx context.Context, includeTemperatureHistory bool) (map[string]*models.DeviceSummary, error) {
 	devices, err := sr.GetDevices(ctx)
 	if err != nil {
 		return nil, err
@@ -460,7 +464,9 @@ func (sr *scrutinyRepository) GetSummary(ctx context.Context) (map[string]*model
 		sr.logger.Errorf("Query error: %s", result.Err().Error())
 	}
 
-	sr.attachTemperatureHistory(ctx, summaries)
+	if includeTemperatureHistory {
+		sr.attachTemperatureHistory(ctx, summaries)
+	}
 
 	return summaries, nil
 }

--- a/webapp/backend/pkg/database/scrutiny_repository_migrations.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_migrations.go
@@ -613,6 +613,17 @@ func (sr *scrutinyRepository) Migrate(ctx context.Context) error {
 			ID:      "m20260701000000", // add consumer drive profile family denylist setting (#552)
 			Migrate: sr.migrateM20260701000000,
 		},
+		{
+			ID: "m20260728000000", // add dashboard page size setting (#682)
+			Migrate: func(tx *gorm.DB) error {
+				return tx.Create(&m20220716214900.Setting{
+					SettingKeyName:        "dashboard_page_size",
+					SettingKeyDescription: "Number of SMART dashboard devices per page (25 | 50 | 100 | 250)",
+					SettingDataType:       "numeric",
+					SettingValueNumeric:   25,
+				}).Error
+			},
+		},
 	})
 
 	if err := m.Migrate(); err != nil {

--- a/webapp/backend/pkg/database/scrutiny_repository_migrations_test.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_migrations_test.go
@@ -517,3 +517,14 @@ func TestMigrateCreatesDeviceSelfTestsTable(t *testing.T) {
 	require.NoError(t, repo.Migrate(context.Background()))
 	require.True(t, repo.gormClient.Migrator().HasTable(&models.DeviceSelfTest{}))
 }
+
+func TestMigrateAddsDashboardPageSizeSetting(t *testing.T) {
+	repo := createMigrationTestRepository(t)
+
+	require.NoError(t, repo.Migrate(context.Background()))
+
+	var setting models.SettingEntry
+	require.NoError(t, repo.gormClient.Where("setting_key_name = ?", "dashboard_page_size").First(&setting).Error)
+	require.Equal(t, "numeric", setting.SettingDataType)
+	require.Equal(t, 25, setting.SettingValueNumeric)
+}

--- a/webapp/backend/pkg/database/scrutiny_repository_summary_page.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_summary_page.go
@@ -105,7 +105,7 @@ func compareDeviceSummaries(left, right *models.DeviceSummary, sortBy, display s
 	comparison := 0
 	switch sortField {
 	case "title":
-		comparison = strings.Compare(deviceTitleForType(left.Device, display), deviceTitleForType(right.Device, display))
+		comparison = strings.Compare(deviceTitleForType(&left.Device, display), deviceTitleForType(&right.Device, display))
 	case "age":
 		comparison = compareInt64(summaryPowerOnHours(left), summaryPowerOnHours(right))
 	case "capacity":
@@ -175,7 +175,7 @@ func compareInt64(left, right int64) int {
 	}
 }
 
-func deviceTitleForType(device models.Device, display string) string {
+func deviceTitleForType(device *models.Device, display string) string {
 	title := ""
 	switch display {
 	case "serial_id":
@@ -202,7 +202,7 @@ func deviceTitleForType(device models.Device, display string) string {
 	return title
 }
 
-func deviceNameTitle(device models.Device) string {
+func deviceNameTitle(device *models.Device) string {
 	parts := make([]string, 0, 3)
 	if device.DeviceName != "" {
 		if strings.HasPrefix(device.DeviceName, "/dev/") {

--- a/webapp/backend/pkg/database/scrutiny_repository_summary_page.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_summary_page.go
@@ -1,0 +1,221 @@
+package database
+
+import (
+	"context"
+	"sort"
+	"strings"
+
+	"github.com/analogj/scrutiny/webapp/backend/pkg/models"
+)
+
+const defaultDashboardPageSize = 25
+
+var validDashboardPageSizes = map[int]struct{}{
+	25:  {},
+	50:  {},
+	100: {},
+	250: {},
+}
+
+func (sr *scrutinyRepository) GetSummaryPage(ctx context.Context, options models.DeviceSummaryPageOptions) (*models.DeviceSummaryPage, error) {
+	summaries, err := sr.getSummary(ctx, true)
+	if err != nil {
+		return nil, err
+	}
+
+	normalizeSummaryPageOptions(sr, &options)
+	return buildSummaryPage(summaries, options), nil
+}
+
+func buildSummaryPage(summaries map[string]*models.DeviceSummary, options models.DeviceSummaryPageOptions) *models.DeviceSummaryPage {
+	ordered := make([]*models.DeviceSummary, 0, len(summaries))
+	attentionCount := 0
+	for _, summary := range summaries {
+		if !summary.Device.Archived && summary.Device.DeviceStatus > 0 {
+			attentionCount++
+		}
+		if summary.Device.Archived == options.Archived {
+			ordered = append(ordered, summary)
+		}
+	}
+
+	sort.SliceStable(ordered, func(i, j int) bool {
+		return compareDeviceSummaries(ordered[i], ordered[j], options.Sort, options.Display) < 0
+	})
+
+	totalItems := len(ordered)
+	totalPages := 0
+	if totalItems > 0 {
+		totalPages = (totalItems + options.PageSize - 1) / options.PageSize
+	}
+
+	start := (options.Page - 1) * options.PageSize
+	if start > totalItems {
+		start = totalItems
+	}
+	end := start + options.PageSize
+	if end > totalItems {
+		end = totalItems
+	}
+
+	pageSummaries := make(map[string]*models.DeviceSummary, end-start)
+	for _, summary := range ordered[start:end] {
+		pageSummaries[summary.Device.DeviceID] = summary
+	}
+
+	return &models.DeviceSummaryPage{
+		Summary: pageSummaries,
+		Pagination: models.PaginationMetadata{
+			Page:           options.Page,
+			PageSize:       options.PageSize,
+			TotalItems:     totalItems,
+			TotalPages:     totalPages,
+			AttentionCount: attentionCount,
+		},
+	}
+}
+
+func normalizeSummaryPageOptions(sr *scrutinyRepository, options *models.DeviceSummaryPageOptions) {
+	if options.Page < 1 {
+		options.Page = 1
+	}
+	if _, ok := validDashboardPageSizes[options.PageSize]; !ok {
+		options.PageSize = sr.appConfig.GetInt("user.dashboard_page_size")
+	}
+	if _, ok := validDashboardPageSizes[options.PageSize]; !ok {
+		options.PageSize = defaultDashboardPageSize
+	}
+	if options.Sort == "" {
+		options.Sort = sr.appConfig.GetString("user.dashboard_sort")
+	}
+	if options.Display == "" {
+		options.Display = sr.appConfig.GetString("user.dashboard_display")
+	}
+}
+
+func compareDeviceSummaries(left, right *models.DeviceSummary, sortBy, display string) int {
+	if hostComparison := strings.Compare(left.Device.HostId, right.Device.HostId); hostComparison != 0 {
+		return hostComparison
+	}
+
+	normalizedSort := normalizeDashboardSort(sortBy)
+	descending := strings.HasSuffix(normalizedSort, "_desc")
+	sortField := strings.TrimSuffix(strings.TrimSuffix(normalizedSort, "_asc"), "_desc")
+
+	comparison := 0
+	switch sortField {
+	case "title":
+		comparison = strings.Compare(deviceTitleForType(left.Device, display), deviceTitleForType(right.Device, display))
+	case "age":
+		comparison = compareInt64(summaryPowerOnHours(left), summaryPowerOnHours(right))
+	case "capacity":
+		comparison = compareInt64(left.Device.Capacity, right.Device.Capacity)
+	case "temperature":
+		comparison = compareInt64(summaryTemperature(left), summaryTemperature(right))
+	default:
+		comparison = compareInt64(summaryStatusValue(left), summaryStatusValue(right))
+	}
+
+	if descending {
+		comparison *= -1
+	}
+	if comparison != 0 {
+		return comparison
+	}
+	return strings.Compare(left.Device.DeviceID, right.Device.DeviceID)
+}
+
+func normalizeDashboardSort(sortBy string) string {
+	switch sortBy {
+	case "status":
+		return "status_desc"
+	case "title":
+		return "title_asc"
+	case "age":
+		return "age_asc"
+	case "":
+		return "status_desc"
+	default:
+		return sortBy
+	}
+}
+
+func summaryStatusValue(summary *models.DeviceSummary) int64 {
+	if summary.SmartResults == nil {
+		return 0
+	}
+	if summary.Device.DeviceStatus == 0 {
+		return 1
+	}
+	return int64(summary.Device.DeviceStatus) * -1
+}
+
+func summaryPowerOnHours(summary *models.DeviceSummary) int64 {
+	if summary.SmartResults == nil {
+		return 0
+	}
+	return summary.SmartResults.PowerOnHours
+}
+
+func summaryTemperature(summary *models.DeviceSummary) int64 {
+	if summary.SmartResults == nil {
+		return int64(^uint64(0) >> 1)
+	}
+	return summary.SmartResults.Temp
+}
+
+func compareInt64(left, right int64) int {
+	switch {
+	case left < right:
+		return -1
+	case left > right:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func deviceTitleForType(device models.Device, display string) string {
+	title := ""
+	switch display {
+	case "serial_id":
+		if device.DeviceSerialID != "" {
+			title = "/by-id/" + device.DeviceSerialID
+		}
+	case "uuid":
+		if device.DeviceUUID != "" {
+			title = "/by-uuid/" + device.DeviceUUID
+		}
+	case "label":
+		switch {
+		case device.Label != "":
+			title = device.Label
+		case device.DeviceLabel != "":
+			title = "/by-label/" + device.DeviceLabel
+		}
+	default:
+		title = deviceNameTitle(device)
+	}
+	if title == "" {
+		title = deviceNameTitle(device)
+	}
+	return title
+}
+
+func deviceNameTitle(device models.Device) string {
+	parts := make([]string, 0, 3)
+	if device.DeviceName != "" {
+		if strings.HasPrefix(device.DeviceName, "/dev/") {
+			parts = append(parts, device.DeviceName)
+		} else {
+			parts = append(parts, "/dev/"+device.DeviceName)
+		}
+	}
+	if device.DeviceType != "" && device.DeviceType != "scsi" && device.DeviceType != "ata" {
+		parts = append(parts, device.DeviceType)
+	}
+	if device.ModelName != "" {
+		parts = append(parts, device.ModelName)
+	}
+	return strings.Join(parts, " - ")
+}

--- a/webapp/backend/pkg/database/scrutiny_repository_summary_page_test.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_summary_page_test.go
@@ -45,7 +45,7 @@ func TestCompareDeviceSummariesPreservesStatusSortSemantics(t *testing.T) {
 func TestDeviceTitleForTypeFallsBackToDeviceName(t *testing.T) {
 	device := models.Device{DeviceName: "sda", DeviceType: "sat", ModelName: "Example"}
 
-	require.Equal(t, "/dev/sda - sat - Example", deviceTitleForType(device, "label"))
+	require.Equal(t, "/dev/sda - sat - Example", deviceTitleForType(&device, "label"))
 }
 
 func TestBuildSummaryPageFiltersSlicesAndCountsAttention(t *testing.T) {

--- a/webapp/backend/pkg/database/scrutiny_repository_summary_page_test.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_summary_page_test.go
@@ -1,0 +1,82 @@
+package database
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+
+	"github.com/analogj/scrutiny/webapp/backend/pkg"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/models"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompareDeviceSummariesKeepsHostsTogetherBeforeDeviceSort(t *testing.T) {
+	summaries := []*models.DeviceSummary{
+		{Device: models.Device{DeviceID: "b-2", HostId: "beta", DeviceName: "sdb"}},
+		{Device: models.Device{DeviceID: "a-2", HostId: "alpha", DeviceName: "sdb"}},
+		{Device: models.Device{DeviceID: "a-1", HostId: "alpha", DeviceName: "sda"}},
+	}
+
+	sort.SliceStable(summaries, func(i, j int) bool {
+		return compareDeviceSummaries(summaries[i], summaries[j], "title_asc", "name") < 0
+	})
+
+	require.Equal(t, []string{"a-1", "a-2", "b-2"}, []string{
+		summaries[0].Device.DeviceID,
+		summaries[1].Device.DeviceID,
+		summaries[2].Device.DeviceID,
+	})
+}
+
+func TestCompareDeviceSummariesPreservesStatusSortSemantics(t *testing.T) {
+	passed := &models.DeviceSummary{
+		Device:       models.Device{DeviceID: "passed"},
+		SmartResults: &models.SmartSummary{},
+	}
+	failed := &models.DeviceSummary{
+		Device:       models.Device{DeviceID: "failed", DeviceStatus: pkg.DeviceStatusFailedScrutiny},
+		SmartResults: &models.SmartSummary{},
+	}
+
+	require.Greater(t, compareDeviceSummaries(failed, passed, "status_desc", "name"), 0)
+	require.Less(t, compareDeviceSummaries(failed, passed, "status_asc", "name"), 0)
+}
+
+func TestDeviceTitleForTypeFallsBackToDeviceName(t *testing.T) {
+	device := models.Device{DeviceName: "sda", DeviceType: "sat", ModelName: "Example"}
+
+	require.Equal(t, "/dev/sda - sat - Example", deviceTitleForType(device, "label"))
+}
+
+func TestBuildSummaryPageFiltersSlicesAndCountsAttention(t *testing.T) {
+	summaries := make(map[string]*models.DeviceSummary)
+	for index := 1; index <= 60; index++ {
+		deviceID := fmt.Sprintf("device-%03d", index)
+		summaries[deviceID] = &models.DeviceSummary{
+			Device: models.Device{
+				DeviceID:     deviceID,
+				DeviceName:   fmt.Sprintf("sd%03d", index),
+				DeviceStatus: pkg.DeviceStatusPassed,
+			},
+		}
+	}
+	summaries["device-001"].Device.DeviceStatus = pkg.DeviceStatusFailedSmart
+	summaries["archived"] = &models.DeviceSummary{
+		Device: models.Device{DeviceID: "archived", DeviceName: "archived", Archived: true},
+	}
+
+	page := buildSummaryPage(summaries, models.DeviceSummaryPageOptions{
+		Page:     2,
+		PageSize: 25,
+		Sort:     "title_asc",
+		Display:  "name",
+	})
+
+	require.Len(t, page.Summary, 25)
+	require.Equal(t, 60, page.Pagination.TotalItems)
+	require.Equal(t, 3, page.Pagination.TotalPages)
+	require.Equal(t, 1, page.Pagination.AttentionCount)
+	require.NotContains(t, page.Summary, "archived")
+	require.Contains(t, page.Summary, "device-026")
+	require.Contains(t, page.Summary, "device-050")
+}

--- a/webapp/backend/pkg/models/device_summary.go
+++ b/webapp/backend/pkg/models/device_summary.go
@@ -7,10 +7,32 @@ import (
 
 type DeviceSummaryWrapper struct {
 	Data struct {
-		Summary map[string]*DeviceSummary `json:"summary"`
+		Summary    map[string]*DeviceSummary `json:"summary"`
+		Pagination *PaginationMetadata       `json:"pagination,omitempty"`
 	} `json:"data"`
 	Errors  []error `json:"errors"`
 	Success bool    `json:"success"`
+}
+
+type PaginationMetadata struct {
+	Page           int `json:"page"`
+	PageSize       int `json:"page_size"`
+	TotalItems     int `json:"total_items"`
+	TotalPages     int `json:"total_pages"`
+	AttentionCount int `json:"attention_count"`
+}
+
+type DeviceSummaryPageOptions struct {
+	Page     int
+	PageSize int
+	Archived bool
+	Sort     string
+	Display  string
+}
+
+type DeviceSummaryPage struct {
+	Summary    map[string]*DeviceSummary
+	Pagination PaginationMetadata
 }
 
 type DeviceSummary struct {

--- a/webapp/backend/pkg/models/device_summary.go
+++ b/webapp/backend/pkg/models/device_summary.go
@@ -23,11 +23,11 @@ type PaginationMetadata struct {
 }
 
 type DeviceSummaryPageOptions struct {
+	Sort     string
+	Display  string
 	Page     int
 	PageSize int
 	Archived bool
-	Sort     string
-	Display  string
 }
 
 type DeviceSummaryPage struct {

--- a/webapp/backend/pkg/models/settings.go
+++ b/webapp/backend/pkg/models/settings.go
@@ -52,6 +52,7 @@ type Settings struct {
 	PoweredOnHoursUnit string `json:"powered_on_hours_unit" mapstructure:"powered_on_hours_unit"`
 	TimeFormat         string `json:"time_format" mapstructure:"time_format"`
 	DashboardColumns   int    `json:"dashboard_columns" mapstructure:"dashboard_columns"`
+	DashboardPageSize  int    `json:"dashboard_page_size" mapstructure:"dashboard_page_size"`
 	FileSizeSIUnits    bool   `json:"file_size_si_units" mapstructure:"file_size_si_units"`
 	Collector          struct {
 		RetrieveSCTHistory bool `json:"retrieve_sct_temperature_history" mapstructure:"retrieve_sct_temperature_history"`
@@ -103,6 +104,7 @@ func (s *Settings) ApplyDefaults() {
 	defaultStr(&s.PoweredOnHoursUnit, "humanize")
 	defaultStr(&s.TimeFormat, "24")
 	defaultInt(&s.DashboardColumns, 2)
+	defaultInt(&s.DashboardPageSize, 25)
 
 	// Metrics: numeric fields where 0 is not a valid value.
 	// Note: StatusFilterAttributes defaults to 0 (All), which is the zero value, so no check needed.

--- a/webapp/backend/pkg/models/settings_test.go
+++ b/webapp/backend/pkg/models/settings_test.go
@@ -20,6 +20,7 @@ func TestApplyDefaults_AllZeroValues(t *testing.T) {
 	require.Equal(t, "smooth", s.LineStroke)
 	require.Equal(t, "humanize", s.PoweredOnHoursUnit)
 	require.Equal(t, 2, s.DashboardColumns)
+	require.Equal(t, 25, s.DashboardPageSize)
 
 	// Metrics numeric defaults
 	require.Equal(t, 2, s.Metrics.NotifyLevel)

--- a/webapp/backend/pkg/web/handler/get_devices_summary.go
+++ b/webapp/backend/pkg/web/handler/get_devices_summary.go
@@ -1,15 +1,24 @@
 package handler
 
 import (
+	"fmt"
+	"net/http"
+	"strconv"
+
 	"github.com/analogj/scrutiny/webapp/backend/pkg/database"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/models"
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
-	"net/http"
 )
 
 func GetDevicesSummary(c *gin.Context) {
 	logger := c.MustGet("LOGGER").(*logrus.Entry)
 	deviceRepo := c.MustGet("DEVICE_REPOSITORY").(database.DeviceRepo)
+
+	if _, paginated := c.GetQuery("page"); paginated {
+		getPaginatedDevicesSummary(c, logger, deviceRepo)
+		return
+	}
 
 	summary, err := deviceRepo.GetSummary(c)
 	if err != nil {
@@ -26,4 +35,87 @@ func GetDevicesSummary(c *gin.Context) {
 			//"temperature": tem
 		},
 	})
+}
+
+func getPaginatedDevicesSummary(c *gin.Context, logger *logrus.Entry, deviceRepo database.DeviceRepo) {
+	options, err := parseSummaryPageOptions(c)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": err.Error()})
+		return
+	}
+
+	result, err := deviceRepo.GetSummaryPage(c, options)
+	if err != nil {
+		logger.Errorln("An error occurred while retrieving paginated device summary", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"success": true,
+		"data": gin.H{
+			"summary":    result.Summary,
+			"pagination": result.Pagination,
+		},
+	})
+}
+
+func parseSummaryPageOptions(c *gin.Context) (models.DeviceSummaryPageOptions, error) {
+	options := models.DeviceSummaryPageOptions{
+		Archived: false,
+		Sort:     c.Query("sort"),
+		Display:  c.Query("display"),
+	}
+
+	page, err := strconv.Atoi(c.Query("page"))
+	if err != nil || page < 1 {
+		return options, fmt.Errorf("page must be a positive integer")
+	}
+	options.Page = page
+
+	if pageSizeValue, exists := c.GetQuery("page_size"); exists {
+		pageSize, parseErr := strconv.Atoi(pageSizeValue)
+		if parseErr != nil || !validSummaryPageSize(pageSize) {
+			return options, fmt.Errorf("page_size must be one of 25, 50, 100, or 250")
+		}
+		options.PageSize = pageSize
+	}
+
+	if archivedValue, exists := c.GetQuery("archived"); exists {
+		archived, parseErr := strconv.ParseBool(archivedValue)
+		if parseErr != nil {
+			return options, fmt.Errorf("archived must be true or false")
+		}
+		options.Archived = archived
+	}
+
+	if options.Sort != "" && !validSummarySort(options.Sort) {
+		return options, fmt.Errorf("unsupported dashboard sort")
+	}
+	if options.Display != "" && !validSummaryDisplay(options.Display) {
+		return options, fmt.Errorf("unsupported dashboard display")
+	}
+
+	return options, nil
+}
+
+func validSummaryPageSize(pageSize int) bool {
+	return pageSize == 25 || pageSize == 50 || pageSize == 100 || pageSize == 250
+}
+
+func validSummarySort(sort string) bool {
+	switch sort {
+	case "status", "status_asc", "status_desc",
+		"title", "title_asc", "title_desc",
+		"age", "age_asc", "age_desc",
+		"capacity_asc", "capacity_desc",
+		"temperature_asc", "temperature_desc":
+		return true
+	default:
+		return false
+	}
+}
+
+func validSummaryDisplay(display string) bool {
+	return display == "name" || display == "serial_id" || display == "uuid" || display == "label"
 }

--- a/webapp/backend/pkg/web/handler/get_devices_summary_test.go
+++ b/webapp/backend/pkg/web/handler/get_devices_summary_test.go
@@ -1,0 +1,111 @@
+package handler_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	mock_database "github.com/analogj/scrutiny/webapp/backend/pkg/database/mock"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/models"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/web/handler"
+	"github.com/gin-gonic/gin"
+	"github.com/golang/mock/gomock"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func setupSummaryRouter(t *testing.T, repo *mock_database.MockDeviceRepo) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	logger := logrus.WithField("test", t.Name())
+	router := gin.New()
+	router.Use(func(c *gin.Context) {
+		c.Set("LOGGER", logger)
+		c.Set("DEVICE_REPOSITORY", repo)
+		c.Next()
+	})
+	router.GET("/api/summary", handler.GetDevicesSummary)
+	return router
+}
+
+func TestGetDevicesSummaryPreservesLegacyUnpaginatedRequest(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	t.Cleanup(mockCtrl.Finish)
+	repo := mock_database.NewMockDeviceRepo(mockCtrl)
+	summary := map[string]*models.DeviceSummary{
+		"device-1": {Device: models.Device{DeviceID: "device-1"}},
+	}
+	repo.EXPECT().GetSummary(gomock.Any()).Return(summary, nil)
+
+	response := httptest.NewRecorder()
+	request, _ := http.NewRequest(http.MethodGet, "/api/summary", nil)
+	setupSummaryRouter(t, repo).ServeHTTP(response, request)
+
+	require.Equal(t, http.StatusOK, response.Code)
+	require.NotContains(t, response.Body.String(), `"pagination"`)
+}
+
+func TestGetDevicesSummaryReturnsPaginatedResponse(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	t.Cleanup(mockCtrl.Finish)
+	repo := mock_database.NewMockDeviceRepo(mockCtrl)
+	options := models.DeviceSummaryPageOptions{
+		Page:     2,
+		PageSize: 50,
+		Archived: true,
+		Sort:     "title_asc",
+		Display:  "label",
+	}
+	page := &models.DeviceSummaryPage{
+		Summary: map[string]*models.DeviceSummary{
+			"device-1": {Device: models.Device{DeviceID: "device-1"}},
+		},
+		Pagination: models.PaginationMetadata{
+			Page:           2,
+			PageSize:       50,
+			TotalItems:     75,
+			TotalPages:     2,
+			AttentionCount: 3,
+		},
+	}
+	repo.EXPECT().GetSummaryPage(gomock.Any(), options).Return(page, nil)
+
+	response := httptest.NewRecorder()
+	request, _ := http.NewRequest(http.MethodGet, "/api/summary?page=2&page_size=50&archived=true&sort=title_asc&display=label", nil)
+	setupSummaryRouter(t, repo).ServeHTTP(response, request)
+
+	require.Equal(t, http.StatusOK, response.Code)
+	var payload models.DeviceSummaryWrapper
+	require.NoError(t, json.Unmarshal(response.Body.Bytes(), &payload))
+	require.True(t, payload.Success)
+	require.NotNil(t, payload.Data.Pagination)
+	require.Equal(t, 75, payload.Data.Pagination.TotalItems)
+	require.Equal(t, 3, payload.Data.Pagination.AttentionCount)
+}
+
+func TestGetDevicesSummaryRejectsInvalidPagination(t *testing.T) {
+	testCases := []string{
+		"/api/summary?page=0",
+		"/api/summary?page=one",
+		"/api/summary?page=1&page_size=10",
+		"/api/summary?page=1&archived=maybe",
+		"/api/summary?page=1&sort=unknown",
+		"/api/summary?page=1&display=unknown",
+	}
+
+	for _, path := range testCases {
+		t.Run(path, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			t.Cleanup(mockCtrl.Finish)
+			repo := mock_database.NewMockDeviceRepo(mockCtrl)
+
+			response := httptest.NewRecorder()
+			request, _ := http.NewRequest(http.MethodGet, path, nil)
+			setupSummaryRouter(t, repo).ServeHTTP(response, request)
+
+			require.Equal(t, http.StatusBadRequest, response.Code)
+			require.Contains(t, response.Body.String(), `"success":false`)
+		})
+	}
+}

--- a/webapp/backend/pkg/web/handler/save_settings.go
+++ b/webapp/backend/pkg/web/handler/save_settings.go
@@ -20,6 +20,11 @@ func SaveSettings(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
 		return
 	}
+	settings.ApplyDefaults()
+	if !validSummaryPageSize(settings.DashboardPageSize) {
+		c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": "dashboard_page_size must be one of 25, 50, 100, or 250"})
+		return
+	}
 
 	err = deviceRepo.SaveSettings(c, settings)
 	if err != nil {

--- a/webapp/backend/pkg/web/handler/settings_test.go
+++ b/webapp/backend/pkg/web/handler/settings_test.go
@@ -86,3 +86,19 @@ func TestSaveSettings_PreservesServerCapabilityFlags(t *testing.T) {
 	_, isBool := response["collector_trigger_enabled"].(bool)
 	require.True(t, isBool, "collector_trigger_enabled must be a boolean")
 }
+
+func TestSaveSettingsRejectsUnsupportedDashboardPageSize(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	t.Cleanup(mockCtrl.Finish)
+	mockRepo := mock_database.NewMockDeviceRepo(mockCtrl)
+	router := setupSettingsRouter(t, mockRepo)
+
+	body := strings.NewReader(`{"dashboard_page_size": 10}`)
+	response := httptest.NewRecorder()
+	request, _ := http.NewRequest(http.MethodPost, "/api/settings", body)
+	request.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(response, request)
+
+	require.Equal(t, http.StatusBadRequest, response.Code)
+	require.Contains(t, response.Body.String(), "dashboard_page_size")
+}

--- a/webapp/frontend/src/app/core/config/app.config.ts
+++ b/webapp/frontend/src/app/core/config/app.config.ts
@@ -10,6 +10,8 @@ export type DashboardColumns = 2 | 3 | 4 | 5;
 
 export type DashboardDensity = 'comfortable' | 'compact';
 
+export type DashboardPageSize = 25 | 50 | 100 | 250;
+
 export type DashboardSort =
     | 'status'
     | 'status_asc'
@@ -102,6 +104,7 @@ export interface AppConfig {
     dashboard_sort?: DashboardSort;
     dashboard_columns?: DashboardColumns;
     dashboard_density?: DashboardDensity;
+    dashboard_page_size?: DashboardPageSize;
 
     temperature_unit?: TemperatureUnit;
 
@@ -187,6 +190,7 @@ export const appConfig: AppConfig = {
     dashboard_sort: 'status',
     dashboard_columns: 2,
     dashboard_density: 'comfortable',
+    dashboard_page_size: 25,
 
     temperature_unit: 'celsius',
     file_size_si_units: false,

--- a/webapp/frontend/src/app/core/models/device-summary-response-wrapper.ts
+++ b/webapp/frontend/src/app/core/models/device-summary-response-wrapper.ts
@@ -1,10 +1,24 @@
 import { DeviceSummaryModel } from 'app/core/models/device-summary-model';
 
+export interface DeviceSummaryPagination {
+    page: number;
+    page_size: number;
+    total_items: number;
+    total_pages: number;
+    attention_count: number;
+}
+
+export interface DeviceSummaryPage {
+    summary: { [key: string]: DeviceSummaryModel };
+    pagination: DeviceSummaryPagination;
+}
+
 // maps to webapp/backend/pkg/models/device_summary.go
 export interface DeviceSummaryResponseWrapper {
     success: boolean;
     errors: any[];
     data: {
         summary: { [key: string]: DeviceSummaryModel };
+        pagination?: DeviceSummaryPagination;
     };
 }

--- a/webapp/frontend/src/app/layout/common/dashboard-settings/dashboard-settings.component.html
+++ b/webapp/frontend/src/app/layout/common/dashboard-settings/dashboard-settings.component.html
@@ -78,6 +78,17 @@
                 </mat-select>
                 <mat-hint>Compact reduces dashboard card spacing and padding.</mat-hint>
             </mat-form-field>
+
+            <mat-form-field class="flex-auto gt-xs:pr-3 gt-md:pl-3">
+                <mat-label>Devices Per Page</mat-label>
+                <mat-select [(ngModel)]="dashboardPageSize">
+                    <mat-option [value]="25">25 Devices</mat-option>
+                    <mat-option [value]="50">50 Devices</mat-option>
+                    <mat-option [value]="100">100 Devices</mat-option>
+                    <mat-option [value]="250">250 Devices</mat-option>
+                </mat-select>
+                <mat-hint>Maximum SMART device cards rendered on one dashboard page.</mat-hint>
+            </mat-form-field>
         </div>
 
         <div class="flex flex-col mt-5 gt-md:flex-row">

--- a/webapp/frontend/src/app/layout/common/dashboard-settings/dashboard-settings.component.ts
+++ b/webapp/frontend/src/app/layout/common/dashboard-settings/dashboard-settings.component.ts
@@ -4,6 +4,7 @@ import {
     AppConfig,
     DashboardColumns,
     DashboardDensity,
+    DashboardPageSize,
     AttributeOverride,
     DashboardDisplay,
     DashboardSort,
@@ -91,6 +92,7 @@ export class DashboardSettingsComponent implements OnInit {
     dashboardSort: DashboardSort;
     dashboardColumns: DashboardColumns;
     dashboardDensity: DashboardDensity;
+    dashboardPageSize: DashboardPageSize;
     temperatureUnit: string;
     fileSizeSIUnits: boolean;
     poweredOnHoursUnit: string;
@@ -213,6 +215,7 @@ export class DashboardSettingsComponent implements OnInit {
             this.dashboardSort = config.dashboard_sort;
             this.dashboardColumns = config.dashboard_columns;
             this.dashboardDensity = config.dashboard_density;
+            this.dashboardPageSize = config.dashboard_page_size;
             this.temperatureUnit = config.temperature_unit;
             this.fileSizeSIUnits = config.file_size_si_units;
             this.poweredOnHoursUnit = config.powered_on_hours_unit;
@@ -537,6 +540,7 @@ export class DashboardSettingsComponent implements OnInit {
             dashboard_sort: this.dashboardSort as DashboardSort,
             dashboard_columns: this.dashboardColumns as DashboardColumns,
             dashboard_density: this.dashboardDensity as DashboardDensity,
+            dashboard_page_size: this.dashboardPageSize as DashboardPageSize,
             temperature_unit: this.temperatureUnit as TemperatureUnit,
             time_format: this.timeFormat as TimeFormat,
             file_size_si_units: this.fileSizeSIUnits,

--- a/webapp/frontend/src/app/layout/common/mobile-tab-bar/mobile-tab-bar.component.spec.ts
+++ b/webapp/frontend/src/app/layout/common/mobile-tab-bar/mobile-tab-bar.component.spec.ts
@@ -23,7 +23,7 @@ describe('MobileTabBarComponent', () => {
             imports: [MobileTabBarComponent],
             providers: [
                 { provide: Router, useValue: routerSpy },
-                { provide: DashboardService, useValue: { data$: of(null) } },
+                { provide: DashboardService, useValue: { data$: of(null), pageData$: of(null) } },
                 { provide: ScrutinyConfigService, useValue: { config$: of(appConfig) } },
             ],
         }).compileComponents();

--- a/webapp/frontend/src/app/layout/common/mobile-tab-bar/mobile-tab-bar.component.ts
+++ b/webapp/frontend/src/app/layout/common/mobile-tab-bar/mobile-tab-bar.component.ts
@@ -91,6 +91,12 @@ export class MobileTabBarComponent implements OnInit, OnDestroy {
                 }
             }
         });
+
+        this._dashboardService.pageData$.pipe(takeUntil(this._unsubscribeAll)).subscribe((data) => {
+            if (data) {
+                this.drivesNeedAttention = data.pagination.attention_count;
+            }
+        });
     }
 
     ngOnDestroy(): void {

--- a/webapp/frontend/src/app/modules/dashboard/dashboard.component.html
+++ b/webapp/frontend/src/app/modules/dashboard/dashboard.component.html
@@ -11,7 +11,7 @@
 
                 <!-- Action buttons (desktop) -->
                 <div class="flex items-center">
-                    <button class="xs:hidden" mat-stroked-button [color]="showArchived ? 'primary' : null" (click)="showArchived = !showArchived">
+                    <button class="xs:hidden" mat-stroked-button [color]="showArchived ? 'primary' : null" (click)="toggleArchived()">
                         <mat-icon class="icon-size-20" [color]="showArchived ? 'primary' : null" [svgIcon]="'archive'"> </mat-icon>
                         <span class="ml-2">Archived</span>
                     </button>
@@ -49,7 +49,7 @@
                         </button>
 
                         <mat-menu #actionsMenu="matMenu">
-                            <button mat-menu-item (click)="showArchived = !showArchived">
+                            <button mat-menu-item (click)="toggleArchived()">
                                 <mat-icon class="icon-size-20" [color]="showArchived ? 'primary' : null" [svgIcon]="'archive'"> </mat-icon>
                                 <span class="ml-2">Archived</span>
                             </button>
@@ -104,6 +104,19 @@
                 </div>
             </div>
             }
+
+            <div class="flex w-full justify-end px-4 mb-6">
+                <mat-paginator
+                    [length]="pagination.total_items"
+                    [pageIndex]="pagination.page - 1"
+                    [pageSize]="pagination.page_size"
+                    [pageSizeOptions]="pageSizeOptions"
+                    [showFirstLastButtons]="true"
+                    aria-label="Select SMART device page"
+                    (page)="onPageChange($event)"
+                >
+                </mat-paginator>
+            </div>
 
             <!-- MDADM RAID Arrays -->
             @if (mdadmArrays.length > 0) {

--- a/webapp/frontend/src/app/modules/dashboard/dashboard.component.ts
+++ b/webapp/frontend/src/app/modules/dashboard/dashboard.component.ts
@@ -5,7 +5,7 @@ import { ApexOptions, ChartComponent } from 'ng-apexcharts';
 import { DashboardService } from 'app/modules/dashboard/dashboard.service';
 import { MatDialog as MatDialog } from '@angular/material/dialog';
 import { DashboardSettingsComponent } from 'app/layout/common/dashboard-settings/dashboard-settings.component';
-import { AppConfig, DashboardColumns, DashboardDensity } from 'app/core/config/app.config';
+import { AppConfig, DashboardColumns, DashboardDensity, DashboardPageSize } from 'app/core/config/app.config';
 import { ScrutinyConfigService } from 'app/core/config/scrutiny-config.service';
 import { Router, RouterLink } from '@angular/router';
 import { TemperaturePipe } from 'app/shared/temperature.pipe';
@@ -27,6 +27,8 @@ import { MatCheckbox } from '@angular/material/checkbox';
 import { MatDivider } from '@angular/material/divider';
 import { FileSizePipe } from '../../shared/file-size.pipe';
 import { DeviceSortPipe } from '../../shared/device-sort.pipe';
+import { MatPaginator, PageEvent } from '@angular/material/paginator';
+import { DeviceSummaryPagination } from 'app/core/models/device-summary-response-wrapper';
 
 const DASHBOARD_SHELL_WIDTHS: Record<DashboardColumns, string> = {
     2: '1440px',
@@ -63,6 +65,7 @@ const DASHBOARD_SHELL_WIDTHS: Record<DashboardColumns, string> = {
         KeyValuePipe,
         FileSizePipe,
         DeviceSortPipe,
+        MatPaginator,
     ],
 })
 export class DashboardComponent implements OnInit, OnDestroy {
@@ -85,6 +88,14 @@ export class DashboardComponent implements OnInit, OnDestroy {
     mdadmArrays: MDADMArrayModel[] = [];
     isTriggering: boolean = false;
     countdown: number = 0;
+    pagination: DeviceSummaryPagination = {
+        page: 1,
+        page_size: 25,
+        total_items: 0,
+        total_pages: 0,
+        attention_count: 0,
+    };
+    readonly pageSizeOptions: DashboardPageSize[] = [25, 50, 100, 250];
 
     // Private
     private readonly _unsubscribeAll: Subject<void>;
@@ -131,9 +142,16 @@ export class DashboardComponent implements OnInit, OnDestroy {
         });
 
         // Get the data
-        this._dashboardService.data$.pipe(takeUntil(this._unsubscribeAll)).subscribe((data) => {
+        this._dashboardService.pageData$.pipe(takeUntil(this._unsubscribeAll)).subscribe((data) => {
+            if (!data) {
+                return;
+            }
+
             // Store the data
-            this.summaryData = data;
+            this.summaryData = data.summary;
+            this.pagination = data.pagination;
+            this.hostGroups = {};
+            this.visibleDrives = {};
 
             // generate group data.
             for (const wwn in this.summaryData) {
@@ -147,6 +165,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
             }
             // Prepare the chart data
             this._prepareChartData();
+            this._changeDetectorRef.markForCheck();
         });
 
         // Get MDADM data
@@ -482,16 +501,45 @@ export class DashboardComponent implements OnInit, OnDestroy {
         dialogRef.afterClosed().subscribe();
     }
 
-    onDeviceDeleted(wwn: string): void {
-        delete this.summaryData[wwn]; // remove the device from the summary list.
+    onDeviceDeleted(_deviceId: string): void {
+        const remainingItems = Math.max(0, this.pagination.total_items - 1);
+        const lastPage = Math.max(1, Math.ceil(remainingItems / this.pagination.page_size));
+        this.loadSummaryPage(Math.min(this.pagination.page, lastPage));
     }
 
-    onDeviceArchived(wwn: string): void {
-        this.summaryData[wwn].device.archived = true;
+    onDeviceArchived(_deviceId: string): void {
+        this.loadSummaryPage(1);
     }
 
-    onDeviceUnarchived(wwn: string): void {
-        this.summaryData[wwn].device.archived = false;
+    onDeviceUnarchived(_deviceId: string): void {
+        this.loadSummaryPage(1);
+    }
+
+    toggleArchived(): void {
+        this.showArchived = !this.showArchived;
+        this.loadSummaryPage(1);
+    }
+
+    onPageChange(event: PageEvent): void {
+        const pageSize = event.pageSize as DashboardPageSize;
+        if (pageSize !== this.pagination.page_size) {
+            this.config = { ...this.config, dashboard_page_size: pageSize };
+            this._configService.config = { dashboard_page_size: pageSize };
+        }
+        this.loadSummaryPage(event.pageIndex + 1, pageSize);
+    }
+
+    private loadSummaryPage(page: number, pageSize?: DashboardPageSize): void {
+        this._dashboardService
+            .getSummaryPage({
+                page,
+                pageSize: pageSize ?? (this.pagination.page_size as DashboardPageSize),
+                archived: this.showArchived,
+                sort: this.config?.dashboard_sort,
+                display: this.config?.dashboard_display,
+            })
+            .pipe(takeUntil(this._unsubscribeAll))
+            .subscribe();
     }
 
     dashboardColumns(): DashboardColumns {

--- a/webapp/frontend/src/app/modules/dashboard/dashboard.resolvers.ts
+++ b/webapp/frontend/src/app/modules/dashboard/dashboard.resolvers.ts
@@ -2,7 +2,7 @@ import { Injectable, inject } from '@angular/core';
 import { ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
 import { Observable } from 'rxjs';
 import { DashboardService } from 'app/modules/dashboard/dashboard.service';
-import { DeviceSummaryModel } from 'app/core/models/device-summary-model';
+import { DeviceSummaryPage } from 'app/core/models/device-summary-response-wrapper';
 
 @Injectable({
     providedIn: 'root',
@@ -20,7 +20,7 @@ export class DashboardResolver {
      * @param route
      * @param state
      */
-    resolve(_route: ActivatedRouteSnapshot, _state: RouterStateSnapshot): Observable<{ [p: string]: DeviceSummaryModel }> {
-        return this._dashboardService.getSummaryData();
+    resolve(_route: ActivatedRouteSnapshot, _state: RouterStateSnapshot): Observable<DeviceSummaryPage> {
+        return this._dashboardService.getSummaryPage({ page: 1 });
     }
 }

--- a/webapp/frontend/src/app/modules/dashboard/dashboard.service.spec.ts
+++ b/webapp/frontend/src/app/modules/dashboard/dashboard.service.spec.ts
@@ -30,6 +30,38 @@ describe('DashboardService', () => {
         expect(httpClientSpy.get.calls.count()).withContext('one call').toBe(1);
     });
 
+    it('should request and publish paginated summary data', (done: DoneFn) => {
+        const page = {
+            success: true,
+            errors: [],
+            data: {
+                summary: summary.data.summary,
+                pagination: {
+                    page: 2,
+                    page_size: 50,
+                    total_items: 75,
+                    total_pages: 2,
+                    attention_count: 4,
+                },
+            },
+        };
+        httpClientSpy.get.and.returnValue(of(page));
+
+        service.getSummaryPage({ page: 2, pageSize: 50, archived: true, sort: 'title_asc', display: 'label' }).subscribe((value) => {
+            expect(value).toEqual(page.data);
+            expect(httpClientSpy.get).toHaveBeenCalledWith(jasmine.stringMatching(/\/api\/summary$/), {
+                params: {
+                    page: '2',
+                    archived: 'true',
+                    page_size: '50',
+                    sort: 'title_asc',
+                    display: 'label',
+                },
+            });
+            done();
+        });
+    });
+
     it('should unwrap and return getSummaryTempData() (HttpClient called once)', (done: DoneFn) => {
         httpClientSpy.get.and.returnValue(of(temp_history));
 

--- a/webapp/frontend/src/app/modules/dashboard/dashboard.service.ts
+++ b/webapp/frontend/src/app/modules/dashboard/dashboard.service.ts
@@ -3,11 +3,20 @@ import { HttpClient } from '@angular/common/http';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { map, tap } from 'rxjs/operators';
 import { getBasePath } from 'app/app.routing';
-import { DeviceSummaryResponseWrapper } from 'app/core/models/device-summary-response-wrapper';
+import { DeviceSummaryPage, DeviceSummaryResponseWrapper } from 'app/core/models/device-summary-response-wrapper';
 import { DeviceSummaryModel } from 'app/core/models/device-summary-model';
 import { SmartTemperatureModel } from 'app/core/models/measurements/smart-temperature-model';
 import { DeviceSummaryTempResponseWrapper } from 'app/core/models/device-summary-temp-response-wrapper';
 import { FilesystemSummaryResponseWrapper, FilesystemCapacityModel, FilesystemHostStatusModel } from 'app/core/models/filesystem-summary-model';
+import { DashboardDisplay, DashboardPageSize, DashboardSort } from 'app/core/config/app.config';
+
+export interface SummaryPageRequest {
+    page: number;
+    pageSize?: DashboardPageSize;
+    archived?: boolean;
+    sort?: DashboardSort;
+    display?: DashboardDisplay;
+}
 
 @Injectable({
     providedIn: 'root',
@@ -17,6 +26,7 @@ export class DashboardService {
 
     // Observables
     private readonly _data: BehaviorSubject<{ [p: string]: DeviceSummaryModel }>;
+    private readonly _pageData: BehaviorSubject<DeviceSummaryPage | null>;
 
     /**
      * Constructor
@@ -26,6 +36,7 @@ export class DashboardService {
     constructor() {
         // Set the private defaults
         this._data = new BehaviorSubject(null);
+        this._pageData = new BehaviorSubject(null);
     }
 
     // -----------------------------------------------------------------------------------------------------
@@ -37,6 +48,10 @@ export class DashboardService {
      */
     get data$(): Observable<{ [p: string]: DeviceSummaryModel }> {
         return this._data.asObservable();
+    }
+
+    get pageData$(): Observable<DeviceSummaryPage | null> {
+        return this._pageData.asObservable();
     }
 
     // -----------------------------------------------------------------------------------------------------
@@ -53,6 +68,34 @@ export class DashboardService {
             }),
             tap((response: { [key: string]: DeviceSummaryModel }) => {
                 this._data.next(response);
+            })
+        );
+    }
+
+    getSummaryPage(request: SummaryPageRequest): Observable<DeviceSummaryPage> {
+        const params: Record<string, string> = {
+            page: request.page.toString(),
+            archived: String(request.archived ?? false),
+        };
+        if (request.pageSize) {
+            params['page_size'] = request.pageSize.toString();
+        }
+        if (request.sort) {
+            params['sort'] = request.sort;
+        }
+        if (request.display) {
+            params['display'] = request.display;
+        }
+
+        return this._httpClient.get<DeviceSummaryResponseWrapper>(getBasePath() + '/api/summary', { params }).pipe(
+            map((response) => {
+                return {
+                    summary: response.data.summary,
+                    pagination: response.data.pagination,
+                } as DeviceSummaryPage;
+            }),
+            tap((response) => {
+                this._pageData.next(response);
             })
         );
     }


### PR DESCRIPTION
## Summary

- add server-backed global pagination for SMART dashboard devices while preserving host-first grouping and existing sort modes
- persist page sizes of 25, 50, 100, or 250 through application settings
- return pagination metadata and deployment-wide attention counts for correct mobile badges
- keep legacy unpaginated `/api/summary` callers compatible and document the expanded API

This phase bounds response size and rendered card count. The all-device temperature-history query remains until the follow-up temperature work in #683.

## Linked Issues

Closes #682

Parent: #674
Follow-up: #683

## Test plan

- `go test ./...`
- `npm --prefix webapp/frontend test -- --watch=false --browsers=ChromeHeadless --include='src/app/modules/dashboard/dashboard.service.spec.ts' --include='src/app/layout/common/mobile-tab-bar/mobile-tab-bar.component.spec.ts'`
- `npm --prefix webapp/frontend run lint`
- `npm --prefix webapp/frontend run build`
- pre-commit gofmt, go vet, Prettier, and Angular lint checks
