### PR TITLE
Load selected drive temperature history on demand

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -222,6 +222,16 @@ paths:
       summary: Get temperature history for the summary dashboard
       parameters:
         - $ref: "#/components/parameters/DurationKey"
+        - name: device_id
+          in: query
+          description: Device IDs to include. Repeat for each selected drive. Omit to preserve legacy unfiltered behavior.
+          schema:
+            type: array
+            maxItems: 20
+            items:
+              type: string
+          style: form
+          explode: true
       responses:
         "200":
           description: Temperature history
@@ -236,9 +246,38 @@ paths:
                     type: object
                     properties:
                       temp_history:
+                        type: object
+                        additionalProperties:
+                          type: array
+                          items:
+                            $ref: "#/components/schemas/SmartTemperature"
+                required: [success, data]
+        "400":
+          $ref: "#/components/responses/ErrorResponse"
+        "500":
+          $ref: "#/components/responses/ErrorResponse"
+  /api/summary/temp/devices:
+    get:
+      tags: [Devices]
+      summary: List active drives available for temperature history selection
+      responses:
+        "200":
+          description: Lightweight temperature drive options
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      devices:
                         type: array
                         items:
-                          $ref: "#/components/schemas/SmartTemperature"
+                          $ref: "#/components/schemas/TemperatureDeviceOption"
+                    required: [devices]
                 required: [success, data]
         "500":
           $ref: "#/components/responses/ErrorResponse"
@@ -1873,6 +1912,10 @@ components:
           properties:
             retrieve_sct_temperature_history:
               type: boolean
+            store_temperature_history:
+              type: boolean
+              default: true
+              description: Store new temperature history points. Disabling retains existing history and current SMART temperatures.
         metrics:
           type: object
           properties:
@@ -2713,6 +2756,23 @@ components:
         high_priority_unload_events:
           type: integer
           format: int64
+    TemperatureDeviceOption:
+      type: object
+      properties:
+        device_id:
+          type: string
+        host_id:
+          type: string
+        label:
+          type: string
+        device_name:
+          type: string
+        model_name:
+          type: string
+        serial_number:
+          type: string
+      required:
+        [device_id, host_id, label, device_name, model_name, serial_number]
     SmartTemperature:
       type: object
       properties:

--- a/webapp/backend/pkg/database/interface.go
+++ b/webapp/backend/pkg/database/interface.go
@@ -63,11 +63,12 @@ type DeviceRepo interface {
 	// for use in delta evaluation before writing a new submission.
 	GetLatestSmartSubmission(ctx context.Context, wwn string) ([]measurements.Smart, error)
 
-	SaveSmartTemperature(ctx context.Context, wwn string, deviceID string, collectorSmartData *collector.SmartInfo, retrieveSCTTemperatureHistory bool) error
+	SaveSmartTemperature(ctx context.Context, wwn string, deviceID string, collectorSmartData *collector.SmartInfo, retrieveSCTTemperatureHistory bool, storeTemperatureHistory bool) error
 
 	GetSummary(ctx context.Context) (map[string]*models.DeviceSummary, error)
 	GetSummaryPage(ctx context.Context, options models.DeviceSummaryPageOptions) (*models.DeviceSummaryPage, error)
 	GetSmartTemperatureHistory(ctx context.Context, durationKey string) (map[string][]measurements.SmartTemperature, error)
+	GetSmartTemperatureHistoryForDevices(ctx context.Context, durationKey string, deviceIDs []string) (map[string][]measurements.SmartTemperature, error)
 	SaveFilesystemSummary(ctx context.Context, payload models.FilesystemSummaryUpload) error
 	GetFilesystemSummary(ctx context.Context) (map[string][]models.FilesystemCapacity, map[string]*models.FilesystemHostStatus, error)
 

--- a/webapp/backend/pkg/database/mock/mock_database.go
+++ b/webapp/backend/pkg/database/mock/mock_database.go
@@ -574,6 +574,21 @@ func (mr *MockDeviceRepoMockRecorder) GetSmartTemperatureHistory(ctx, durationKe
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSmartTemperatureHistory", reflect.TypeOf((*MockDeviceRepo)(nil).GetSmartTemperatureHistory), ctx, durationKey)
 }
 
+// GetSmartTemperatureHistoryForDevices mocks base method.
+func (m *MockDeviceRepo) GetSmartTemperatureHistoryForDevices(ctx context.Context, durationKey string, deviceIDs []string) (map[string][]measurements.SmartTemperature, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSmartTemperatureHistoryForDevices", ctx, durationKey, deviceIDs)
+	ret0, _ := ret[0].(map[string][]measurements.SmartTemperature)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetSmartTemperatureHistoryForDevices indicates an expected call of GetSmartTemperatureHistoryForDevices.
+func (mr *MockDeviceRepoMockRecorder) GetSmartTemperatureHistoryForDevices(ctx, durationKey, deviceIDs interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSmartTemperatureHistoryForDevices", reflect.TypeOf((*MockDeviceRepo)(nil).GetSmartTemperatureHistoryForDevices), ctx, durationKey, deviceIDs)
+}
+
 // GetSummary mocks base method.
 func (m *MockDeviceRepo) GetSummary(ctx context.Context) (map[string]*models.DeviceSummary, error) {
 	m.ctrl.T.Helper()
@@ -922,17 +937,17 @@ func (mr *MockDeviceRepoMockRecorder) SaveSmartAttributes(ctx, wwn, collectorSma
 }
 
 // SaveSmartTemperature mocks base method.
-func (m *MockDeviceRepo) SaveSmartTemperature(ctx context.Context, wwn, deviceID string, collectorSmartData *collector.SmartInfo, retrieveSCTTemperatureHistory bool) error {
+func (m *MockDeviceRepo) SaveSmartTemperature(ctx context.Context, wwn, deviceID string, collectorSmartData *collector.SmartInfo, retrieveSCTTemperatureHistory, storeTemperatureHistory bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SaveSmartTemperature", ctx, wwn, deviceID, collectorSmartData, retrieveSCTTemperatureHistory)
+	ret := m.ctrl.Call(m, "SaveSmartTemperature", ctx, wwn, deviceID, collectorSmartData, retrieveSCTTemperatureHistory, storeTemperatureHistory)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SaveSmartTemperature indicates an expected call of SaveSmartTemperature.
-func (mr *MockDeviceRepoMockRecorder) SaveSmartTemperature(ctx, wwn, deviceID, collectorSmartData, retrieveSCTTemperatureHistory interface{}) *gomock.Call {
+func (mr *MockDeviceRepoMockRecorder) SaveSmartTemperature(ctx, wwn, deviceID, collectorSmartData, retrieveSCTTemperatureHistory, storeTemperatureHistory interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveSmartTemperature", reflect.TypeOf((*MockDeviceRepo)(nil).SaveSmartTemperature), ctx, wwn, deviceID, collectorSmartData, retrieveSCTTemperatureHistory)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveSmartTemperature", reflect.TypeOf((*MockDeviceRepo)(nil).SaveSmartTemperature), ctx, wwn, deviceID, collectorSmartData, retrieveSCTTemperatureHistory, storeTemperatureHistory)
 }
 
 // SaveZFSPoolMetrics mocks base method.

--- a/webapp/backend/pkg/database/scrutiny_repository_migrations.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_migrations.go
@@ -624,6 +624,17 @@ func (sr *scrutinyRepository) Migrate(ctx context.Context) error {
 				}).Error
 			},
 		},
+		{
+			ID: "m20260729000000", // add temperature history storage setting (#683)
+			Migrate: func(tx *gorm.DB) error {
+				return tx.Create(&m20220716214900.Setting{
+					SettingKeyName:        "store_temperature_history",
+					SettingKeyDescription: "Store new temperature history points",
+					SettingDataType:       "bool",
+					SettingValueBool:      true,
+				}).Error
+			},
+		},
 	})
 
 	if err := m.Migrate(); err != nil {

--- a/webapp/backend/pkg/database/scrutiny_repository_migrations_test.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_migrations_test.go
@@ -528,3 +528,14 @@ func TestMigrateAddsDashboardPageSizeSetting(t *testing.T) {
 	require.Equal(t, "numeric", setting.SettingDataType)
 	require.Equal(t, 25, setting.SettingValueNumeric)
 }
+
+func TestMigrateEnablesTemperatureHistoryStorage(t *testing.T) {
+	repo := createMigrationTestRepository(t)
+
+	require.NoError(t, repo.Migrate(context.Background()))
+
+	var setting models.SettingEntry
+	require.NoError(t, repo.gormClient.Where("setting_key_name = ?", "store_temperature_history").First(&setting).Error)
+	require.Equal(t, "bool", setting.SettingDataType)
+	require.True(t, setting.SettingValueBool)
+}

--- a/webapp/backend/pkg/database/scrutiny_repository_summary_page.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_summary_page.go
@@ -18,7 +18,7 @@ var validDashboardPageSizes = map[int]struct{}{
 }
 
 func (sr *scrutinyRepository) GetSummaryPage(ctx context.Context, options models.DeviceSummaryPageOptions) (*models.DeviceSummaryPage, error) {
-	summaries, err := sr.getSummary(ctx, true)
+	summaries, err := sr.getSummary(ctx, false)
 	if err != nil {
 		return nil, err
 	}

--- a/webapp/backend/pkg/database/scrutiny_repository_temperature.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_temperature.go
@@ -3,6 +3,7 @@ package database
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -14,7 +15,10 @@ import (
 // //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Temperature Data
 // //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-func (sr *scrutinyRepository) SaveSmartTemperature(ctx context.Context, wwn string, deviceID string, collectorSmartData *collector.SmartInfo, retrieveSCTTemperatureHistory bool) error {
+func (sr *scrutinyRepository) SaveSmartTemperature(ctx context.Context, wwn string, deviceID string, collectorSmartData *collector.SmartInfo, retrieveSCTTemperatureHistory bool, storeTemperatureHistory bool) error {
+	if !storeTemperatureHistory {
+		return nil
+	}
 	if len(collectorSmartData.AtaSctTemperatureHistory.Table) > 0 && retrieveSCTTemperatureHistory {
 
 		for ndx, temp := range collectorSmartData.AtaSctTemperatureHistory.Table {
@@ -62,20 +66,44 @@ func (sr *scrutinyRepository) SaveSmartTemperature(ctx context.Context, wwn stri
 }
 
 func (sr *scrutinyRepository) GetSmartTemperatureHistory(ctx context.Context, durationKey string) (map[string][]measurements.SmartTemperature, error) {
+	return sr.getSmartTemperatureHistory(ctx, durationKey, nil)
+}
+
+func (sr *scrutinyRepository) GetSmartTemperatureHistoryForDevices(ctx context.Context, durationKey string, deviceIDs []string) (map[string][]measurements.SmartTemperature, error) {
+	return sr.getSmartTemperatureHistory(ctx, durationKey, deviceIDs)
+}
+
+func (sr *scrutinyRepository) getSmartTemperatureHistory(ctx context.Context, durationKey string, deviceIDs []string) (map[string][]measurements.SmartTemperature, error) {
 	//we can get temp history for "week", "month", DURATION_KEY_YEAR, "forever"
 
 	// Build WWN-to-DeviceID map for re-keying InfluxDB results
 	devices, devErr := sr.GetDevices(ctx)
+	if devErr != nil && len(deviceIDs) > 0 {
+		return nil, fmt.Errorf("failed to resolve selected temperature devices: %w", devErr)
+	}
 	wwnToDeviceID := map[string]string{}
+	selectedIDs := map[string]struct{}{}
+	for _, deviceID := range deviceIDs {
+		selectedIDs[deviceID] = struct{}{}
+	}
+	selectedWWNs := make([]string, 0, len(selectedIDs))
 	if devErr == nil {
 		for i := range devices {
-			wwnToDeviceID[devices[i].WWN] = devices[i].DeviceID
+			if len(selectedIDs) == 0 {
+				wwnToDeviceID[devices[i].WWN] = devices[i].DeviceID
+			} else if _, selected := selectedIDs[devices[i].DeviceID]; selected {
+				wwnToDeviceID[devices[i].WWN] = devices[i].DeviceID
+				selectedWWNs = append(selectedWWNs, devices[i].WWN)
+			}
 		}
 	}
 
 	deviceTempHistory := map[string][]measurements.SmartTemperature{}
+	if len(deviceIDs) > 0 && len(selectedWWNs) == 0 {
+		return deviceTempHistory, nil
+	}
 
-	queryStr := sr.aggregateTempQuery(durationKey)
+	queryStr := sr.aggregateTempQuery(durationKey, selectedWWNs...)
 
 	result, err := sr.influxQueryApi.Query(ctx, queryStr)
 	if err != nil {
@@ -124,7 +152,7 @@ func appendTempRecord(deviceTempHistory map[string][]measurements.SmartTemperatu
 // Helper Methods
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-func (sr *scrutinyRepository) aggregateTempQuery(durationKey string) string {
+func (sr *scrutinyRepository) aggregateTempQuery(durationKey string, deviceWWNs ...string) string {
 
 	/*
 		import "influxdata/influxdb/schema"
@@ -166,6 +194,13 @@ func (sr *scrutinyRepository) aggregateTempQuery(durationKey string) string {
 			fmt.Sprintf(`%sData = from(bucket: "%s")`, nestedDurationKey, bucketName),
 			fmt.Sprintf(`|> range(start: %s, stop: %s)`, durationRange[0], durationRange[1]),
 			`|> filter(fn: (r) => r["_measurement"] == "temp" )`,
+		}
+		if len(deviceWWNs) > 0 {
+			quotedWWNs := make([]string, 0, len(deviceWWNs))
+			for _, wwn := range deviceWWNs {
+				quotedWWNs = append(quotedWWNs, strconv.Quote(wwn))
+			}
+			subQuery = append(subQuery, fmt.Sprintf(`|> filter(fn: (r) => contains(value: r["device_wwn"], set: [%s]))`, strings.Join(quotedWWNs, ", ")))
 		}
 		if durationResolution != "" {
 			subQuery = append(subQuery,

--- a/webapp/backend/pkg/database/scrutiny_repository_temperature_test.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_temperature_test.go
@@ -1,11 +1,60 @@
 package database
 
 import (
+	"context"
 	mock_config "github.com/analogj/scrutiny/webapp/backend/pkg/config/mock"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/models/collector"
 	"github.com/golang/mock/gomock"
+	"github.com/influxdata/influxdb-client-go/v2/api/write"
 	"github.com/stretchr/testify/require"
+	"strings"
 	"testing"
 )
+
+type countingWriteAPI struct {
+	stubWriteAPI
+	points int
+}
+
+func (s *countingWriteAPI) WritePoint(_ context.Context, points ...*write.Point) error {
+	s.points += len(points)
+	return nil
+}
+
+func TestSaveSmartTemperatureSkipsWritesWhenHistoryStorageDisabled(t *testing.T) {
+	writeAPI := &countingWriteAPI{}
+	deviceRepo := scrutinyRepository{influxWriteApi: writeAPI}
+
+	err := deviceRepo.SaveSmartTemperature(context.Background(), "wwn-1", "device-1", &collector.SmartInfo{}, true, false)
+
+	require.NoError(t, err)
+	require.Zero(t, writeAPI.points)
+}
+
+func TestSaveSmartTemperatureStoresCurrentPointWhenHistoryStorageEnabled(t *testing.T) {
+	writeAPI := &countingWriteAPI{}
+	deviceRepo := scrutinyRepository{influxWriteApi: writeAPI}
+
+	err := deviceRepo.SaveSmartTemperature(context.Background(), "wwn-1", "device-1", &collector.SmartInfo{}, false, true)
+
+	require.NoError(t, err)
+	require.Equal(t, 1, writeAPI.points)
+}
+
+func TestAggregateTempQueryFiltersSelectedWWNs(t *testing.T) {
+	t.Parallel()
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	fakeConfig := mock_config.NewMockInterface(mockCtrl)
+	fakeConfig.EXPECT().GetString("web.influxdb.bucket").Return("metrics").AnyTimes()
+
+	deviceRepo := scrutinyRepository{appConfig: fakeConfig}
+	influxDBScript := deviceRepo.aggregateTempQuery(DURATION_KEY_WEEK, "wwn-1", `wwn-"2`)
+
+	require.Contains(t, influxDBScript, `contains(value: r["device_wwn"], set: ["wwn-1", "wwn-\"2"])`)
+	require.Equal(t, 1, strings.Count(influxDBScript, `contains(value: r["device_wwn"]`))
+}
 
 func Test_aggregateTempQuery_Day(t *testing.T) {
 	t.Parallel()

--- a/webapp/backend/pkg/models/device_summary.go
+++ b/webapp/backend/pkg/models/device_summary.go
@@ -35,6 +35,15 @@ type DeviceSummaryPage struct {
 	Pagination PaginationMetadata
 }
 
+type TemperatureDeviceOption struct {
+	DeviceID     string `json:"device_id"`
+	HostID       string `json:"host_id"`
+	Label        string `json:"label"`
+	DeviceName   string `json:"device_name"`
+	ModelName    string `json:"model_name"`
+	SerialNumber string `json:"serial_number"`
+}
+
 type DeviceSummary struct {
 	SmartResults *SmartSummary                   `json:"smart,omitempty"`
 	TempHistory  []measurements.SmartTemperature `json:"temp_history,omitempty"`

--- a/webapp/backend/pkg/models/settings.go
+++ b/webapp/backend/pkg/models/settings.go
@@ -56,6 +56,7 @@ type Settings struct {
 	FileSizeSIUnits    bool   `json:"file_size_si_units" mapstructure:"file_size_si_units"`
 	Collector          struct {
 		RetrieveSCTHistory bool `json:"retrieve_sct_temperature_history" mapstructure:"retrieve_sct_temperature_history"`
+		StoreTempHistory   bool `json:"store_temperature_history" mapstructure:"store_temperature_history"`
 	} `json:"collector" mapstructure:"collector"` // Missed collector ping notification settings
 	Navigation struct {
 		ShowZFSPools bool `json:"show_zfs_pools" mapstructure:"show_zfs_pools"`

--- a/webapp/backend/pkg/web/handler/get_devices_summary_temp_history.go
+++ b/webapp/backend/pkg/web/handler/get_devices_summary_temp_history.go
@@ -1,10 +1,14 @@
 package handler
 
 import (
+	"net/http"
+	"sort"
+
 	"github.com/analogj/scrutiny/webapp/backend/pkg/database"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/models"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/models/measurements"
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
-	"net/http"
 )
 
 func GetDevicesSummaryTempHistory(c *gin.Context) {
@@ -16,7 +20,18 @@ func GetDevicesSummaryTempHistory(c *gin.Context) {
 		durationKey = "week"
 	}
 
-	tempHistory, err := deviceRepo.GetSmartTemperatureHistory(c, durationKey)
+	deviceIDs := c.QueryArray("device_id")
+	if len(deviceIDs) > 20 {
+		c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": "at most 20 device_id values are allowed"})
+		return
+	}
+	var tempHistory map[string][]measurements.SmartTemperature
+	var err error
+	if len(deviceIDs) > 0 {
+		tempHistory, err = deviceRepo.GetSmartTemperatureHistoryForDevices(c, durationKey, deviceIDs)
+	} else {
+		tempHistory, err = deviceRepo.GetSmartTemperatureHistory(c, durationKey)
+	}
 	if err != nil {
 		logger.Errorln("An error occurred while retrieving summary/temp history", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
@@ -27,6 +42,46 @@ func GetDevicesSummaryTempHistory(c *gin.Context) {
 		"success": true,
 		"data": map[string]interface{}{
 			"temp_history": tempHistory,
+		},
+	})
+}
+
+func GetTemperatureDeviceOptions(c *gin.Context) {
+	logger := c.MustGet("LOGGER").(*logrus.Entry)
+	deviceRepo := c.MustGet("DEVICE_REPOSITORY").(database.DeviceRepo)
+
+	devices, err := deviceRepo.GetDevices(c)
+	if err != nil {
+		logger.Errorln("An error occurred while retrieving temperature device options", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
+		return
+	}
+
+	options := make([]models.TemperatureDeviceOption, 0, len(devices))
+	for i := range devices {
+		if devices[i].Archived {
+			continue
+		}
+		options = append(options, models.TemperatureDeviceOption{
+			DeviceID:     devices[i].DeviceID,
+			HostID:       devices[i].HostId,
+			Label:        devices[i].Label,
+			DeviceName:   devices[i].DeviceName,
+			ModelName:    devices[i].ModelName,
+			SerialNumber: devices[i].SerialNumber,
+		})
+	}
+	sort.Slice(options, func(i, j int) bool {
+		if options[i].HostID != options[j].HostID {
+			return options[i].HostID < options[j].HostID
+		}
+		return options[i].DeviceID < options[j].DeviceID
+	})
+
+	c.JSON(http.StatusOK, gin.H{
+		"success": true,
+		"data": map[string]interface{}{
+			"devices": options,
 		},
 	})
 }

--- a/webapp/backend/pkg/web/handler/get_devices_summary_temp_history_test.go
+++ b/webapp/backend/pkg/web/handler/get_devices_summary_temp_history_test.go
@@ -1,0 +1,98 @@
+package handler_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	mock_database "github.com/analogj/scrutiny/webapp/backend/pkg/database/mock"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/models"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/models/measurements"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/web/handler"
+	"github.com/gin-gonic/gin"
+	"github.com/golang/mock/gomock"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func setupTemperatureSummaryRouter(t *testing.T, repo *mock_database.MockDeviceRepo) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.Use(func(c *gin.Context) {
+		c.Set("LOGGER", logrus.WithField("test", t.Name()))
+		c.Set("DEVICE_REPOSITORY", repo)
+		c.Next()
+	})
+	router.GET("/api/summary/temp", handler.GetDevicesSummaryTempHistory)
+	router.GET("/api/summary/temp/devices", handler.GetTemperatureDeviceOptions)
+	return router
+}
+
+func TestGetTemperatureDeviceOptionsReturnsActiveDevices(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	t.Cleanup(mockCtrl.Finish)
+	repo := mock_database.NewMockDeviceRepo(mockCtrl)
+	repo.EXPECT().GetDevices(gomock.Any()).Return([]models.Device{
+		{DeviceID: "active", HostId: "host-b", DeviceName: "sdb", ModelName: "Model B"},
+		{DeviceID: "archived", HostId: "host-a", DeviceName: "sda", Archived: true},
+	}, nil)
+
+	response := httptest.NewRecorder()
+	request, _ := http.NewRequest(http.MethodGet, "/api/summary/temp/devices", nil)
+	setupTemperatureSummaryRouter(t, repo).ServeHTTP(response, request)
+
+	require.Equal(t, http.StatusOK, response.Code)
+	require.Contains(t, response.Body.String(), `"device_id":"active"`)
+	require.NotContains(t, response.Body.String(), `"device_id":"archived"`)
+}
+
+func TestGetDevicesSummaryTempHistoryFiltersSelectedDeviceIDs(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	t.Cleanup(mockCtrl.Finish)
+	repo := mock_database.NewMockDeviceRepo(mockCtrl)
+	repo.EXPECT().
+		GetSmartTemperatureHistoryForDevices(gomock.Any(), "week", []string{"device-1", "device-2"}).
+		Return(map[string][]measurements.SmartTemperature{}, nil)
+
+	response := httptest.NewRecorder()
+	request, _ := http.NewRequest(http.MethodGet, "/api/summary/temp?duration_key=week&device_id=device-1&device_id=device-2", nil)
+	setupTemperatureSummaryRouter(t, repo).ServeHTTP(response, request)
+
+	require.Equal(t, http.StatusOK, response.Code)
+	require.Contains(t, response.Body.String(), `"success":true`)
+}
+
+func TestGetDevicesSummaryTempHistoryPreservesLegacyUnfilteredRequest(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	t.Cleanup(mockCtrl.Finish)
+	repo := mock_database.NewMockDeviceRepo(mockCtrl)
+	repo.EXPECT().
+		GetSmartTemperatureHistory(gomock.Any(), "week").
+		Return(map[string][]measurements.SmartTemperature{}, nil)
+
+	response := httptest.NewRecorder()
+	request, _ := http.NewRequest(http.MethodGet, "/api/summary/temp", nil)
+	setupTemperatureSummaryRouter(t, repo).ServeHTTP(response, request)
+
+	require.Equal(t, http.StatusOK, response.Code)
+}
+
+func TestGetDevicesSummaryTempHistoryRejectsMoreThanTwentyDevices(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	t.Cleanup(mockCtrl.Finish)
+	repo := mock_database.NewMockDeviceRepo(mockCtrl)
+	query := url.Values{"duration_key": []string{"week"}}
+	for i := 0; i < 21; i++ {
+		query.Add("device_id", fmt.Sprintf("device-%d", i))
+	}
+
+	response := httptest.NewRecorder()
+	request, _ := http.NewRequest(http.MethodGet, "/api/summary/temp?"+query.Encode(), nil)
+	setupTemperatureSummaryRouter(t, repo).ServeHTTP(response, request)
+
+	require.Equal(t, http.StatusBadRequest, response.Code)
+	require.Contains(t, response.Body.String(), `"success":false`)
+}

--- a/webapp/backend/pkg/web/handler/upload_device_metrics.go
+++ b/webapp/backend/pkg/web/handler/upload_device_metrics.go
@@ -64,7 +64,14 @@ func UploadDeviceMetrics(c *gin.Context) {
 	}
 
 	// save smart temperature data (InfluxDB - uses WWN)
-	err = deviceRepo.SaveSmartTemperature(c, device.WWN, updatedDevice.DeviceID, &collectorSmartData, appConfig.GetBool(fmt.Sprintf("%s.collector.retrieve_sct_temperature_history", config.DB_USER_SETTINGS_SUBKEY)))
+	err = deviceRepo.SaveSmartTemperature(
+		c,
+		device.WWN,
+		updatedDevice.DeviceID,
+		&collectorSmartData,
+		appConfig.GetBool(fmt.Sprintf("%s.collector.retrieve_sct_temperature_history", config.DB_USER_SETTINGS_SUBKEY)),
+		appConfig.GetBool(fmt.Sprintf("%s.collector.store_temperature_history", config.DB_USER_SETTINGS_SUBKEY)),
+	)
 	if err != nil {
 		logger.Errorln("An error occurred while saving smartctl temp data", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"success": false})

--- a/webapp/backend/pkg/web/handler/upload_device_metrics_test.go
+++ b/webapp/backend/pkg/web/handler/upload_device_metrics_test.go
@@ -91,7 +91,7 @@ func setupMetricsRouterAccept(t *testing.T) *gin.Engine {
 	fakeRepo.EXPECT().UpdateDevice(gomock.Any(), gomock.Any(), gomock.Any()).Return(device, nil).AnyTimes()
 	fakeRepo.EXPECT().SaveSmartAttributes(gomock.Any(), gomock.Any(), gomock.Any()).Return(measurements.Smart{Status: pkg.DeviceStatusPassed}, nil).AnyTimes()
 	fakeRepo.EXPECT().UpdateDeviceHasForcedFailure(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
-	fakeRepo.EXPECT().SaveSmartTemperature(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	fakeRepo.EXPECT().SaveSmartTemperature(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	fakeRepo.EXPECT().LoadSettings(gomock.Any()).Return(&models.Settings{}, nil).AnyTimes()
 
 	fakeConfig.EXPECT().GetBool(gomock.Any()).Return(false).AnyTimes()

--- a/webapp/backend/pkg/web/server.go
+++ b/webapp/backend/pkg/web/server.go
@@ -122,9 +122,10 @@ func (ae *AppEngine) Setup(logger *logrus.Entry) *gin.Engine {
 			api.POST("/health/uptime-kuma-test", handler.TestUptimeKumaPush)   // test Uptime Kuma push monitor
 			api.POST("/health/mqtt-sync", handler.MqttSync)                    // re-sync all MQTT discovery entities with HA
 
-			api.POST("/devices/register", handler.RegisterDevices)            // used by Collector to register new devices and retrieve filtered list
-			api.GET(apiSummaryPath, handler.GetDevicesSummary)                // used by Dashboard
-			api.GET("/summary/temp", handler.GetDevicesSummaryTempHistory)    // used by Dashboard (Temperature history dropdown)
+			api.POST("/devices/register", handler.RegisterDevices)         // used by Collector to register new devices and retrieve filtered list
+			api.GET(apiSummaryPath, handler.GetDevicesSummary)             // used by Dashboard
+			api.GET("/summary/temp", handler.GetDevicesSummaryTempHistory) // used by Dashboard (Temperature history dropdown)
+			api.GET("/summary/temp/devices", handler.GetTemperatureDeviceOptions)
 			api.GET("/summary/workload", handler.GetWorkloadInsights)         // used by Workload Insights page
 			api.GET("/filesystems/summary", handler.GetFilesystemSummary)     // used by Dashboard filesystem capacity panel
 			api.POST("/filesystems/summary", handler.UploadFilesystemSummary) // used by Filesystem Collector to upload data

--- a/webapp/frontend/src/app/core/config/app.config.ts
+++ b/webapp/frontend/src/app/core/config/app.config.ts
@@ -120,6 +120,7 @@ export interface AppConfig {
 
     collector?: {
         retrieve_sct_temperature_history?: boolean;
+        store_temperature_history?: boolean;
     };
 
     metrics?: {
@@ -201,6 +202,7 @@ export const appConfig: AppConfig = {
 
     collector: {
         retrieve_sct_temperature_history: true,
+        store_temperature_history: true,
     },
 
     navigation: {

--- a/webapp/frontend/src/app/core/models/device-summary-temp-response-wrapper.ts
+++ b/webapp/frontend/src/app/core/models/device-summary-temp-response-wrapper.ts
@@ -7,3 +7,20 @@ export interface DeviceSummaryTempResponseWrapper {
         temp_history: { [key: string]: SmartTemperatureModel[] };
     };
 }
+
+export interface TemperatureDeviceOption {
+    device_id: string;
+    host_id: string;
+    label: string;
+    device_name: string;
+    model_name: string;
+    serial_number: string;
+}
+
+export interface TemperatureDeviceOptionsResponseWrapper {
+    success: boolean;
+    errors?: any[];
+    data: {
+        devices: TemperatureDeviceOption[];
+    };
+}

--- a/webapp/frontend/src/app/layout/common/dashboard-settings/dashboard-settings.component.html
+++ b/webapp/frontend/src/app/layout/common/dashboard-settings/dashboard-settings.component.html
@@ -175,6 +175,17 @@
 
         <div class="flex flex-col mt-5 gt-md:flex-row">
             <mat-form-field class="flex-auto gt-xs:pr-3 gt-md:pr-3">
+                <mat-label>Store Temperature History</mat-label>
+                <mat-select [(ngModel)]="storeTemperatureHistory">
+                    <mat-option [value]="true">Enabled</mat-option>
+                    <mat-option [value]="false">Disabled</mat-option>
+                </mat-select>
+                <mat-hint>Disabling stops new temperature history points. Existing history and current dashboard temperatures remain available.</mat-hint>
+            </mat-form-field>
+        </div>
+
+        <div class="flex flex-col mt-5 gt-md:flex-row">
+            <mat-form-field class="flex-auto gt-xs:pr-3 gt-md:pr-3">
                 <mat-label>Consumer Drive Profiles</mat-label>
                 <mat-select [(ngModel)]="consumerDriveProfilesEnabled">
                     <mat-option [value]="true">Enabled</mat-option>

--- a/webapp/frontend/src/app/layout/common/dashboard-settings/dashboard-settings.component.ts
+++ b/webapp/frontend/src/app/layout/common/dashboard-settings/dashboard-settings.component.ts
@@ -100,6 +100,7 @@ export class DashboardSettingsComponent implements OnInit {
     lineStroke: string;
     theme: string;
     retrieveSCTTemperatureHistory: boolean;
+    storeTemperatureHistory: boolean;
     notifyLevel: number;
     statusThreshold: number;
     statusFilterAttributes: number;
@@ -224,6 +225,7 @@ export class DashboardSettingsComponent implements OnInit {
             this.theme = config.theme;
 
             this.retrieveSCTTemperatureHistory = config.collector.retrieve_sct_temperature_history;
+            this.storeTemperatureHistory = config.collector.store_temperature_history ?? true;
 
             this.notifyLevel = config.metrics.notify_level;
             this.statusFilterAttributes = config.metrics.status_filter_attributes;
@@ -549,6 +551,7 @@ export class DashboardSettingsComponent implements OnInit {
             theme: this.theme as Theme,
             collector: {
                 retrieve_sct_temperature_history: this.retrieveSCTTemperatureHistory,
+                store_temperature_history: this.storeTemperatureHistory,
             },
             metrics: {
                 notify_level: this.notifyLevel as MetricsNotifyLevel,

--- a/webapp/frontend/src/app/modules/dashboard/dashboard.component.html
+++ b/webapp/frontend/src/app/modules/dashboard/dashboard.component.html
@@ -275,25 +275,27 @@
 
                                 <button class="h-8 min-h-8 px-3 ml-2" mat-stroked-button [matMenuTriggerFor]="driveFilterMenu">
                                     <mat-icon class="icon-size-4" [svgIcon]="'filter_list'"></mat-icon>
-                                    <span class="font-medium text-sm ml-1">Drives</span>
+                                    <span class="font-medium text-sm ml-1">Drives ({{ temperatureSelection.ids.length }}/{{ temperatureSelection.maxSelected }})</span>
                                     <mat-icon class="icon-size-4 ml-1" [svgIcon]="'expand_more'"></mat-icon>
                                 </button>
 
                                 <mat-menu #driveFilterMenu="matMenu">
-                                    <button mat-menu-item (click)="toggleAllDrives(); $event.stopPropagation()">
-                                        <mat-checkbox
-                                            [checked]="allDrivesVisible"
-                                            [indeterminate]="someDrivesVisible && !allDrivesVisible"
-                                            (click)="toggleAllDrives(); $event.stopPropagation()"
-                                        >
-                                            All Drives
-                                        </mat-checkbox>
-                                    </button>
+                                    <div class="px-3 py-2" (click)="$event.stopPropagation()" (keydown)="$event.stopPropagation()">
+                                        <input matInput type="search" placeholder="Search host, drive, model, or serial" [(ngModel)]="temperatureDeviceSearch" />
+                                    </div>
                                     <mat-divider></mat-divider>
-                                    @for (device of summaryData | keyvalue; track device.key) {
-                                    <button mat-menu-item (click)="toggleDriveVisibility(device.key); $event.stopPropagation()">
-                                        <mat-checkbox [checked]="visibleDrives[device.key]" (click)="toggleDriveVisibility(device.key); $event.stopPropagation()">
-                                            {{ deviceDashboardTitle(device.value) }}
+                                    @for (device of filteredTemperatureDevices(); track device.device_id) {
+                                    <button
+                                        mat-menu-item
+                                        [disabled]="temperatureSelectionDisabled(device.device_id)"
+                                        (click)="toggleTemperatureDevice(device.device_id); $event.stopPropagation()"
+                                    >
+                                        <mat-checkbox
+                                            [checked]="isTemperatureDeviceSelected(device.device_id)"
+                                            [disabled]="temperatureSelectionDisabled(device.device_id)"
+                                            (click)="toggleTemperatureDevice(device.device_id); $event.stopPropagation()"
+                                        >
+                                            {{ temperatureDeviceTitle(device) }}
                                         </mat-checkbox>
                                     </button>
                                     }
@@ -303,7 +305,9 @@
                     </div>
 
                     <div class="flex flex-col flex-auto min-h-0 temp-chart-wrapper">
-                        @if (temperatureOptions) {
+                        @if (temperatureSelection.ids.length === 0) {
+                        <div class="flex flex-auto items-center justify-center text-secondary p-8">Select up to 20 drives to load temperature history.</div>
+                        } @else if (temperatureOptions) {
                         <apx-chart
                             #tempChart
                             class="flex-auto w-full min-h-0"

--- a/webapp/frontend/src/app/modules/dashboard/dashboard.component.ts
+++ b/webapp/frontend/src/app/modules/dashboard/dashboard.component.ts
@@ -29,6 +29,10 @@ import { FileSizePipe } from '../../shared/file-size.pipe';
 import { DeviceSortPipe } from '../../shared/device-sort.pipe';
 import { MatPaginator, PageEvent } from '@angular/material/paginator';
 import { DeviceSummaryPagination } from 'app/core/models/device-summary-response-wrapper';
+import { TemperatureDeviceOption } from 'app/core/models/device-summary-temp-response-wrapper';
+import { SmartTemperatureModel } from 'app/core/models/measurements/smart-temperature-model';
+import { MatInput } from '@angular/material/input';
+import { FormsModule } from '@angular/forms';
 
 const DASHBOARD_SHELL_WIDTHS: Record<DashboardColumns, string> = {
     2: '1440px',
@@ -66,6 +70,8 @@ const DASHBOARD_SHELL_WIDTHS: Record<DashboardColumns, string> = {
         FileSizePipe,
         DeviceSortPipe,
         MatPaginator,
+        MatInput,
+        FormsModule,
     ],
 })
 export class DashboardComponent implements OnInit, OnDestroy {
@@ -81,10 +87,13 @@ export class DashboardComponent implements OnInit, OnDestroy {
     hostGroups: { [hostId: string]: string[] } = {};
     filesystemSummaryData: { filesystems: Record<string, FilesystemCapacityModel[]>; hosts: Record<string, FilesystemHostStatusModel> } | null = null;
     temperatureOptions: ApexOptions;
-    tempDurationKey = 'forever';
+    tempDurationKey = 'week';
     config: AppConfig;
     showArchived: boolean = false;
-    visibleDrives: { [wwn: string]: boolean } = {};
+    temperatureDevices: TemperatureDeviceOption[] = [];
+    temperatureDeviceSearch = '';
+    temperatureHistory: { [deviceID: string]: SmartTemperatureModel[] } = {};
+    readonly temperatureSelection = this._dashboardService.temperatureSelection;
     mdadmArrays: MDADMArrayModel[] = [];
     isTriggering: boolean = false;
     countdown: number = 0;
@@ -100,6 +109,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
     // Private
     private readonly _unsubscribeAll: Subject<void>;
     private readonly systemPrefersDark: boolean;
+    private temperatureRequestID = 0;
     @ViewChild('tempChart', { static: false }) tempChart: ChartComponent;
 
     /**
@@ -151,7 +161,6 @@ export class DashboardComponent implements OnInit, OnDestroy {
             this.summaryData = data.summary;
             this.pagination = data.pagination;
             this.hostGroups = {};
-            this.visibleDrives = {};
 
             // generate group data.
             for (const wwn in this.summaryData) {
@@ -159,14 +168,21 @@ export class DashboardComponent implements OnInit, OnDestroy {
                 const hostDeviceList = this.hostGroups[hostid] || [];
                 hostDeviceList.push(wwn);
                 this.hostGroups[hostid] = hostDeviceList;
-
-                // Initialize drive visibility (default to visible)
-                this.visibleDrives[wwn] ??= true;
             }
             // Prepare the chart data
             this._prepareChartData();
             this._changeDetectorRef.markForCheck();
         });
+        this._dashboardService
+            .getTemperatureDeviceOptions()
+            .pipe(takeUntil(this._unsubscribeAll))
+            .subscribe((devices) => {
+                this.temperatureDevices = devices;
+                if (this.temperatureSelection.ids.length > 0) {
+                    this.loadSelectedTemperatureHistory();
+                }
+                this._changeDetectorRef.markForCheck();
+            });
 
         // Get MDADM data
         this._mdadmService
@@ -220,33 +236,28 @@ export class DashboardComponent implements OnInit, OnDestroy {
     private _deviceDataTemperatureSeries(): any[] {
         const deviceTemperatureSeries = [];
 
-        for (const wwn in this.summaryData) {
-            // Skip drives that are hidden by the filter
-            if (this.visibleDrives[wwn] === false) {
+        for (const deviceID of this.temperatureSelection.ids) {
+            const tempHistory = this.temperatureHistory[deviceID];
+            if (!tempHistory) {
                 continue;
             }
 
-            const deviceSummary = this.summaryData[wwn];
-            if (!deviceSummary.temp_history) {
-                continue;
-            }
-
-            const deviceName = DeviceTitlePipe.deviceDashboardTitle(deviceSummary.device);
+            const deviceName = this.temperatureDeviceTitle(this.temperatureDevices.find((device) => device.device_id === deviceID));
 
             const deviceSeriesMetadata = {
                 name: deviceName,
                 data: [],
             };
 
-            for (const tempHistory of deviceSummary.temp_history) {
-                const newDate = new Date(tempHistory.date);
+            for (const measurement of tempHistory) {
+                const newDate = new Date(measurement.date);
                 let temperature;
                 switch (this.config.temperature_unit) {
                     case 'celsius':
-                        temperature = tempHistory.temp;
+                        temperature = measurement.temp;
                         break;
                     case 'fahrenheit':
-                        temperature = TemperaturePipe.celsiusToFahrenheit(tempHistory.temp);
+                        temperature = TemperaturePipe.celsiusToFahrenheit(measurement.temp);
                         break;
                 }
                 deviceSeriesMetadata.data.push({
@@ -562,29 +573,35 @@ export class DashboardComponent implements OnInit, OnDestroy {
         return this.dashboardDensity() === 'compact';
     }
 
-    get allDrivesVisible(): boolean {
-        const wwns = Object.keys(this.visibleDrives);
-        return wwns.length > 0 && wwns.every((wwn) => this.visibleDrives[wwn]);
-    }
-
-    get someDrivesVisible(): boolean {
-        const wwns = Object.keys(this.visibleDrives);
-        return wwns.some((wwn) => this.visibleDrives[wwn]);
-    }
-
-    toggleAllDrives(): void {
-        const newState = !this.allDrivesVisible;
-        for (const wwn in this.visibleDrives) {
-            this.visibleDrives[wwn] = newState;
+    filteredTemperatureDevices(): TemperatureDeviceOption[] {
+        const search = this.temperatureDeviceSearch.trim().toLowerCase();
+        if (!search) {
+            return this.temperatureDevices;
         }
-        this.tempChart?.updateSeries(this._deviceDataTemperatureSeries());
-        this._changeDetectorRef.markForCheck();
+        return this.temperatureDevices.filter((device) => {
+            return [device.host_id, device.label, device.device_name, device.model_name, device.serial_number].some((value) => value?.toLowerCase().includes(search));
+        });
     }
 
-    toggleDriveVisibility(wwn: string): void {
-        this.visibleDrives[wwn] = !this.visibleDrives[wwn];
-        this.tempChart?.updateSeries(this._deviceDataTemperatureSeries());
-        this._changeDetectorRef.markForCheck();
+    temperatureDeviceTitle(device?: TemperatureDeviceOption): string {
+        if (!device) {
+            return 'Unknown drive';
+        }
+        const title = device.label || [device.device_name ? `/dev/${device.device_name.replace(/^\/dev\//, '')}` : '', device.model_name].filter(Boolean).join(' - ');
+        return device.host_id ? `${device.host_id}: ${title || device.serial_number || device.device_id}` : title || device.serial_number || device.device_id;
+    }
+
+    isTemperatureDeviceSelected(deviceID: string): boolean {
+        return this.temperatureSelection.has(deviceID);
+    }
+
+    temperatureSelectionDisabled(deviceID: string): boolean {
+        return !this.temperatureSelection.has(deviceID) && this.temperatureSelection.ids.length >= this.temperatureSelection.maxSelected;
+    }
+
+    toggleTemperatureDevice(deviceID: string): void {
+        this.temperatureSelection.toggle(deviceID);
+        this.loadSelectedTemperatureHistory();
     }
 
     /*
@@ -597,16 +614,29 @@ export class DashboardComponent implements OnInit, OnDestroy {
 
     changeSummaryTempDuration(durationKey: string): void {
         this.tempDurationKey = durationKey;
+        this.loadSelectedTemperatureHistory();
+    }
 
-        this._dashboardService.getSummaryTempData(durationKey).subscribe((tempHistoryData) => {
-            // given a list of device temp history, override the data in the "summary" object.
-            for (const wwn in this.summaryData) {
-                this.summaryData[wwn].temp_history = tempHistoryData[wwn] || [];
-            }
-
-            // Prepare the chart series data (filtered by visibility)
-            this.tempChart.updateSeries(this._deviceDataTemperatureSeries());
-        });
+    private loadSelectedTemperatureHistory(): void {
+        const selectedDeviceIDs = this.temperatureSelection.ids;
+        const requestID = ++this.temperatureRequestID;
+        if (selectedDeviceIDs.length === 0) {
+            this.temperatureHistory = {};
+            this.tempChart?.updateSeries([]);
+            this._changeDetectorRef.markForCheck();
+            return;
+        }
+        this._dashboardService
+            .getSummaryTempData(this.tempDurationKey, selectedDeviceIDs)
+            .pipe(takeUntil(this._unsubscribeAll))
+            .subscribe((tempHistoryData) => {
+                if (requestID !== this.temperatureRequestID) {
+                    return;
+                }
+                this.temperatureHistory = tempHistoryData;
+                this.tempChart?.updateSeries(this._deviceDataTemperatureSeries());
+                this._changeDetectorRef.markForCheck();
+            });
     }
 
     getMdadmArrayStatusColorClass(array: MDADMArrayModel): string {

--- a/webapp/frontend/src/app/modules/dashboard/dashboard.service.spec.ts
+++ b/webapp/frontend/src/app/modules/dashboard/dashboard.service.spec.ts
@@ -65,11 +65,30 @@ describe('DashboardService', () => {
     it('should unwrap and return getSummaryTempData() (HttpClient called once)', (done: DoneFn) => {
         httpClientSpy.get.and.returnValue(of(temp_history));
 
-        service.getSummaryTempData('weekly').subscribe((value) => {
+        service.getSummaryTempData('weekly', ['device-1', 'device-2']).subscribe((value) => {
             expect(value).toBe(temp_history.data.temp_history as { [key: string]: SmartTemperatureModel[] });
+            const options = httpClientSpy.get.calls.mostRecent().args[1] as any;
+            expect(options.params.get('duration_key')).toBe('weekly');
+            expect(options.params.getAll('device_id')).toEqual(['device-1', 'device-2']);
             done();
         });
         expect(httpClientSpy.get.calls.count()).withContext('one call').toBe(1);
+    });
+
+    it('should load temperature device options independently from dashboard pages', (done: DoneFn) => {
+        const response = {
+            success: true,
+            data: {
+                devices: [{ device_id: 'device-1', host_id: 'host-1', label: '', device_name: 'sda', model_name: 'Model', serial_number: 'Serial' }],
+            },
+        };
+        httpClientSpy.get.and.returnValue(of(response));
+
+        service.getTemperatureDeviceOptions().subscribe((value) => {
+            expect(value).toEqual(response.data.devices);
+            expect(httpClientSpy.get).toHaveBeenCalledWith(jasmine.stringMatching(/\/api\/summary\/temp\/devices$/));
+            done();
+        });
     });
 
     it('should unwrap and return getFilesystemSummaryData() (HttpClient called once)', (done: DoneFn) => {

--- a/webapp/frontend/src/app/modules/dashboard/dashboard.service.ts
+++ b/webapp/frontend/src/app/modules/dashboard/dashboard.service.ts
@@ -1,14 +1,15 @@
 import { Injectable, inject } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { map, tap } from 'rxjs/operators';
 import { getBasePath } from 'app/app.routing';
 import { DeviceSummaryPage, DeviceSummaryResponseWrapper } from 'app/core/models/device-summary-response-wrapper';
 import { DeviceSummaryModel } from 'app/core/models/device-summary-model';
 import { SmartTemperatureModel } from 'app/core/models/measurements/smart-temperature-model';
-import { DeviceSummaryTempResponseWrapper } from 'app/core/models/device-summary-temp-response-wrapper';
+import { DeviceSummaryTempResponseWrapper, TemperatureDeviceOption, TemperatureDeviceOptionsResponseWrapper } from 'app/core/models/device-summary-temp-response-wrapper';
 import { FilesystemSummaryResponseWrapper, FilesystemCapacityModel, FilesystemHostStatusModel } from 'app/core/models/filesystem-summary-model';
 import { DashboardDisplay, DashboardPageSize, DashboardSort } from 'app/core/config/app.config';
+import { TemperatureSelection } from 'app/modules/dashboard/temperature-selection';
 
 export interface SummaryPageRequest {
     page: number;
@@ -27,6 +28,7 @@ export class DashboardService {
     // Observables
     private readonly _data: BehaviorSubject<{ [p: string]: DeviceSummaryModel }>;
     private readonly _pageData: BehaviorSubject<DeviceSummaryPage | null>;
+    readonly temperatureSelection = new TemperatureSelection();
 
     /**
      * Constructor
@@ -100,17 +102,24 @@ export class DashboardService {
         );
     }
 
-    getSummaryTempData(durationKey: string): Observable<{ [key: string]: SmartTemperatureModel[] }> {
-        const params = {};
+    getSummaryTempData(durationKey: string, deviceIDs?: string[]): Observable<{ [key: string]: SmartTemperatureModel[] }> {
+        let params = new HttpParams();
         if (durationKey) {
-            params['duration_key'] = durationKey;
+            params = params.set('duration_key', durationKey);
+        }
+        for (const deviceID of deviceIDs ?? []) {
+            params = params.append('device_id', deviceID);
         }
 
-        return this._httpClient.get(getBasePath() + '/api/summary/temp', { params: params }).pipe(
+        return this._httpClient.get(getBasePath() + '/api/summary/temp', { params }).pipe(
             map((response: DeviceSummaryTempResponseWrapper) => {
                 return response.data.temp_history;
             })
         );
+    }
+
+    getTemperatureDeviceOptions(): Observable<TemperatureDeviceOption[]> {
+        return this._httpClient.get<TemperatureDeviceOptionsResponseWrapper>(getBasePath() + '/api/summary/temp/devices').pipe(map((response) => response.data.devices));
     }
 
     runCollectors(): Observable<any> {

--- a/webapp/frontend/src/app/modules/dashboard/temperature-selection.spec.ts
+++ b/webapp/frontend/src/app/modules/dashboard/temperature-selection.spec.ts
@@ -1,0 +1,24 @@
+import { TemperatureSelection } from './temperature-selection';
+
+describe('TemperatureSelection', () => {
+    it('starts empty, caps selection at twenty, and preserves existing selections', () => {
+        const selection = new TemperatureSelection();
+
+        for (let index = 0; index < 21; index++) {
+            selection.toggle(`device-${index}`);
+        }
+
+        expect(selection.ids.length).toBe(20);
+        expect(selection.ids).toContain('device-0');
+        expect(selection.ids).not.toContain('device-20');
+    });
+
+    it('removes an already selected device', () => {
+        const selection = new TemperatureSelection();
+        selection.toggle('device-1');
+
+        selection.toggle('device-1');
+
+        expect(selection.ids).toEqual([]);
+    });
+});

--- a/webapp/frontend/src/app/modules/dashboard/temperature-selection.ts
+++ b/webapp/frontend/src/app/modules/dashboard/temperature-selection.ts
@@ -1,0 +1,21 @@
+export class TemperatureSelection {
+    readonly maxSelected = 20;
+    private readonly selected = new Set<string>();
+
+    get ids(): string[] {
+        return Array.from(this.selected);
+    }
+
+    has(deviceID: string): boolean {
+        return this.selected.has(deviceID);
+    }
+
+    toggle(deviceID: string): void {
+        if (this.selected.delete(deviceID)) {
+            return;
+        }
+        if (this.selected.size < this.maxSelected) {
+            this.selected.add(deviceID);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- stop paginated dashboard summaries from loading temperature history
- add fleet-wide searchable drive selection with a 20-drive limit and one-week default range
- filter temperature history queries by repeated `device_id` parameters while preserving legacy unfiltered requests
- add a migration-seeded setting that can stop new temperature history writes without removing existing history or current SMART temperatures
- document the API and settings contracts

## Linked Issues

Closes #683

Parent: #674

## Test plan

- `go test ./...`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.4.0 run --timeout=5m --modules-download-mode=mod --new-from-rev=origin/develop`
- `npm --prefix webapp/frontend test -- --watch=false --browsers=ChromeHeadless`
- `npm --prefix webapp/frontend run lint`
- `npm --prefix webapp/frontend run build`
- parse `docs/openapi.yaml` with Ruby YAML loader

## Notes

Legacy callers that omit `device_id` still receive unfiltered temperature history. Existing stored temperature points are retained when storage is disabled.
