### PR TITLE
Add bulk SMART host lifecycle management

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Full credit for the original vision and architecture goes to [AnalogJ](https://g
 - **HTML Email Notifications** - Rich HTML emails with plain-text fallback for reports, test notifications, collector errors, missed ping digests, and other alert emails over SMTP
 - **Enhanced Seagate Drive Support** - Better timeout handling and FARM log collection for Seagate drives
 - **Workload Insights** - Visualize daily read/write rates, I/O intensity, SSD endurance, and activity spike detection
+- **SMART Host Management** - Search collector hosts and bulk archive, unarchive, or safely purge their devices
 - **Home Assistant MQTT Discovery** - Native MQTT integration for automatic device discovery in Home Assistant
 - **UI-Configurable Notification URLs** - Add, edit, test, and delete notification endpoints directly in the web UI
 - **Uptime Kuma Push Monitor** - Dedicated push-based integration for Uptime Kuma status monitoring
@@ -150,6 +151,7 @@ These S.M.A.R.T hard drive self-tests can help you detect and replace failing ha
 - **Missed Ping Digest** - Batch notification when multiple collectors go unreachable
 - **HTML Email Notifications** - Rich HTML formatting with plain-text fallback for SMTP notifications, including reports, test notifications, collector errors, missed ping digests, heartbeat, performance degradation, replacement risk, and MDADM degradation alerts
 - **Workload Insights** - Daily read/write rates, R/W ratio, I/O intensity classification, SSD endurance tracking, and activity spike detection
+- **SMART Host Management** - Bulk archive, unarchive, and confirmed permanent purge with shared-WWN protection ([operator guide](docs/HOST_MANAGEMENT.md))
 - **Consumer Drive Profiles** - Apply vetted ATA HDD and SSD profiles based on Backblaze-informed thresholds, with opt-out controls and replacement-risk transparency
 - **Filesystem Capacity Monitoring** - Track logical filesystem free space independently from SMART device health
 - **MDADM Monitoring** - Monitor Linux software RAID arrays with a dedicated collector

--- a/docs/HOST_MANAGEMENT.md
+++ b/docs/HOST_MANAGEMENT.md
@@ -1,0 +1,46 @@
+# SMART Host Management
+
+Scrutiny groups SMART devices by non-empty collector `host_id` values. Open **Hosts** from desktop navigation or **Settings > SMART Host Management** on mobile.
+
+The host page does not include ZFS pools, MDADM arrays, Btrfs filesystems, filesystem-capacity records, or devices whose collector did not send a host ID.
+
+## Archive and unarchive
+
+Archiving a host marks every SMART device currently assigned to that host as archived. Device metadata and time-series history remain stored. Unarchiving restores every device assigned to that host.
+
+Use archive when retiring a collector temporarily or when historical data must remain available.
+
+## Permanent purge
+
+Purge deletes selected SMART device rows and their matching InfluxDB history. It cannot be undone.
+
+Before purging:
+
+1. Stop collectors on every selected host.
+2. Confirm selected host IDs and device counts.
+3. Type `PURGE` in the confirmation dialog.
+
+An active collector can re-register devices immediately after purge. Purge does not alter data on physical drives.
+
+### Shared WWN protection
+
+InfluxDB history is keyed by WWN, while device metadata is keyed by `device_id`. If any WWN belonging to a selected host is also used by a device outside the full selected host set, Scrutiny blocks purge for the affected host rather than deleting shared history.
+
+Select every intended host sharing that WWN, or resolve incorrect device identity before retrying.
+
+### Partial failures and retries
+
+The API returns a result for every requested host. Successfully purged hosts are removed from selection; failed hosts remain selected and can be retried.
+
+For each host, Scrutiny deletes InfluxDB history before deleting SQLite device rows. If history deletion fails, the device rows remain, so repeating the purge is safe. If SQLite deletion fails after history deletion, repeating the operation safely retries idempotent history deletion before the SQLite delete.
+
+Review the per-host error before retrying. Storage or connectivity failures should be corrected first; shared-WWN blocks require an identity or selection change.
+
+## API
+
+- `GET /api/hosts`
+- `POST /api/hosts/archive`
+- `POST /api/hosts/unarchive`
+- `POST /api/hosts/purge`
+
+See [openapi.yaml](openapi.yaml) for request and response schemas.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -12,6 +12,7 @@ tags:
   - name: Auth
   - name: Health
   - name: Devices
+  - name: Hosts
   - name: Settings
   - name: Reports
   - name: Filesystems
@@ -305,6 +306,84 @@ paths:
                         additionalProperties:
                           $ref: "#/components/schemas/WorkloadInsight"
                 required: [success, data]
+        "500":
+          $ref: "#/components/responses/ErrorResponse"
+  /api/hosts:
+    get:
+      tags: [Hosts]
+      summary: List SMART collector hosts
+      description: Returns non-empty SMART device host IDs with active, archived, and total device counts. Non-SMART resources are excluded.
+      responses:
+        "200":
+          description: SMART host inventory
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HostSummaryResponse"
+        "500":
+          $ref: "#/components/responses/ErrorResponse"
+  /api/hosts/archive:
+    post:
+      tags: [Hosts]
+      summary: Archive all SMART devices for selected hosts
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/HostActionRequest"
+      responses:
+        "200":
+          description: Per-host archive results
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HostActionResponse"
+        "400":
+          $ref: "#/components/responses/ErrorResponse"
+        "500":
+          $ref: "#/components/responses/ErrorResponse"
+  /api/hosts/unarchive:
+    post:
+      tags: [Hosts]
+      summary: Unarchive all SMART devices for selected hosts
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/HostActionRequest"
+      responses:
+        "200":
+          description: Per-host unarchive results
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HostActionResponse"
+        "400":
+          $ref: "#/components/responses/ErrorResponse"
+        "500":
+          $ref: "#/components/responses/ErrorResponse"
+  /api/hosts/purge:
+    post:
+      tags: [Hosts]
+      summary: Permanently purge selected SMART hosts
+      description: Deletes selected SMART devices and matching InfluxDB history. A WWN shared with a device outside the selected host set blocks that host. Successful hosts can be omitted when retrying partial failures.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/HostPurgeRequest"
+      responses:
+        "200":
+          description: Per-host purge results
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HostActionResponse"
+        "400":
+          $ref: "#/components/responses/ErrorResponse"
         "500":
           $ref: "#/components/responses/ErrorResponse"
   /api/filesystems/summary:
@@ -1470,6 +1549,79 @@ components:
           schema:
             $ref: "#/components/schemas/ErrorResponse"
   schemas:
+    HostSummary:
+      type: object
+      properties:
+        host_id:
+          type: string
+          minLength: 1
+        active_devices:
+          type: integer
+          format: int64
+          minimum: 0
+        archived_devices:
+          type: integer
+          format: int64
+          minimum: 0
+        total_devices:
+          type: integer
+          format: int64
+          minimum: 1
+      required: [host_id, active_devices, archived_devices, total_devices]
+    HostSummaryResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/HostSummary"
+      required: [success, data]
+    HostActionRequest:
+      type: object
+      properties:
+        host_ids:
+          type: array
+          minItems: 1
+          items:
+            type: string
+            minLength: 1
+      required: [host_ids]
+    HostPurgeRequest:
+      allOf:
+        - $ref: "#/components/schemas/HostActionRequest"
+        - type: object
+          properties:
+            confirmation:
+              type: string
+              enum: [PURGE]
+          required: [confirmation]
+    HostActionResult:
+      type: object
+      properties:
+        host_id:
+          type: string
+        success:
+          type: boolean
+        device_count:
+          type: integer
+          format: int64
+          minimum: 0
+        error:
+          type: string
+      required: [host_id, success, device_count]
+    HostActionResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+          description: True only when every requested host succeeds.
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/HostActionResult"
+      required: [success, data]
     SuccessResponse:
       type: object
       properties:

--- a/webapp/backend/pkg/database/interface.go
+++ b/webapp/backend/pkg/database/interface.go
@@ -49,6 +49,9 @@ type DeviceRepo interface {
 	UpdateDeviceMissedPingTimeout(ctx context.Context, deviceID string, timeoutMinutes int) error
 	MergeDevices(ctx context.Context, sourceDeviceID string, destinationDeviceID string) error
 	DeleteDevice(ctx context.Context, deviceID string) error
+	GetHosts(ctx context.Context) ([]models.HostSummary, error)
+	UpdateHostArchived(ctx context.Context, hostID string, archived bool) (int64, error)
+	PurgeHosts(ctx context.Context, hostIDs []string) ([]models.HostActionResult, error)
 	// RecalculateDeviceStatusFromHistory re-evaluates device status from stored SMART data
 	// with current overrides applied. Used when overrides are added/modified/deleted.
 	RecalculateDeviceStatusFromHistory(ctx context.Context, deviceID string) error

--- a/webapp/backend/pkg/database/mock/mock_database.go
+++ b/webapp/backend/pkg/database/mock/mock_database.go
@@ -365,6 +365,21 @@ func (mr *MockDeviceRepoMockRecorder) GetFilesystemSummary(ctx interface{}) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFilesystemSummary", reflect.TypeOf((*MockDeviceRepo)(nil).GetFilesystemSummary), ctx)
 }
 
+// GetHosts mocks base method.
+func (m *MockDeviceRepo) GetHosts(ctx context.Context) ([]models.HostSummary, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetHosts", ctx)
+	ret0, _ := ret[0].([]models.HostSummary)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetHosts indicates an expected call of GetHosts.
+func (mr *MockDeviceRepoMockRecorder) GetHosts(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHosts", reflect.TypeOf((*MockDeviceRepo)(nil).GetHosts), ctx)
+}
+
 // GetLatestMdadmMetrics mocks base method.
 func (m *MockDeviceRepo) GetLatestMdadmMetrics(ctx context.Context, uuid string) (*measurements.MDADMMetrics, error) {
 	m.ctrl.T.Helper()
@@ -736,6 +751,21 @@ func (m *MockDeviceRepo) MergeDevices(ctx context.Context, sourceDeviceID, desti
 func (mr *MockDeviceRepoMockRecorder) MergeDevices(ctx, sourceDeviceID, destinationDeviceID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MergeDevices", reflect.TypeOf((*MockDeviceRepo)(nil).MergeDevices), ctx, sourceDeviceID, destinationDeviceID)
+}
+
+// PurgeHosts mocks base method.
+func (m *MockDeviceRepo) PurgeHosts(ctx context.Context, hostIDs []string) ([]models.HostActionResult, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PurgeHosts", ctx, hostIDs)
+	ret0, _ := ret[0].([]models.HostActionResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PurgeHosts indicates an expected call of PurgeHosts.
+func (mr *MockDeviceRepoMockRecorder) PurgeHosts(ctx, hostIDs interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PurgeHosts", reflect.TypeOf((*MockDeviceRepo)(nil).PurgeHosts), ctx, hostIDs)
 }
 
 // RecalculateDeviceStatusFromHistory mocks base method.
@@ -1146,6 +1176,21 @@ func (m *MockDeviceRepo) UpdateDeviceStatus(ctx context.Context, deviceID string
 func (mr *MockDeviceRepoMockRecorder) UpdateDeviceStatus(ctx, deviceID, status interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDeviceStatus", reflect.TypeOf((*MockDeviceRepo)(nil).UpdateDeviceStatus), ctx, deviceID, status)
+}
+
+// UpdateHostArchived mocks base method.
+func (m *MockDeviceRepo) UpdateHostArchived(ctx context.Context, hostID string, archived bool) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateHostArchived", ctx, hostID, archived)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateHostArchived indicates an expected call of UpdateHostArchived.
+func (mr *MockDeviceRepoMockRecorder) UpdateHostArchived(ctx, hostID, archived interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateHostArchived", reflect.TypeOf((*MockDeviceRepo)(nil).UpdateHostArchived), ctx, hostID, archived)
 }
 
 // UpdateMdadmArrayArchived mocks base method.

--- a/webapp/backend/pkg/database/scrutiny_repository_hosts.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_hosts.go
@@ -1,0 +1,175 @@
+package database
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/analogj/scrutiny/webapp/backend/pkg/models"
+	"gorm.io/gorm"
+)
+
+func (sr *scrutinyRepository) GetHosts(ctx context.Context) ([]models.HostSummary, error) {
+	hosts := []models.HostSummary{}
+	err := sr.gormClient.WithContext(ctx).
+		Model(&models.Device{}).
+		Select(`
+			host_id,
+			SUM(CASE WHEN archived = false THEN 1 ELSE 0 END) AS active_devices,
+			SUM(CASE WHEN archived = true THEN 1 ELSE 0 END) AS archived_devices,
+			COUNT(*) AS total_devices
+		`).
+		Where("TRIM(host_id) <> ''").
+		Group("host_id").
+		Order("LOWER(host_id) ASC, host_id ASC").
+		Scan(&hosts).Error
+	if err != nil {
+		return nil, fmt.Errorf("could not list SMART hosts: %w", err)
+	}
+	return hosts, nil
+}
+
+func (sr *scrutinyRepository) UpdateHostArchived(ctx context.Context, hostID string, archived bool) (int64, error) {
+	result := sr.gormClient.WithContext(ctx).
+		Model(&models.Device{}).
+		Where("host_id = ?", hostID).
+		Update("archived", archived)
+	if result.Error != nil {
+		return 0, fmt.Errorf("could not update host %q: %w", hostID, result.Error)
+	}
+	return result.RowsAffected, nil
+}
+
+func (sr *scrutinyRepository) PurgeHosts(ctx context.Context, hostIDs []string) ([]models.HostActionResult, error) {
+	var devices []models.Device
+	if err := sr.gormClient.WithContext(ctx).
+		Where("TRIM(host_id) <> ''").
+		Find(&devices).Error; err != nil {
+		return nil, fmt.Errorf("could not load SMART hosts for purge: %w", err)
+	}
+
+	selectedHosts := make(map[string]struct{}, len(hostIDs))
+	devicesByHost := make(map[string][]models.Device, len(hostIDs))
+	for _, hostID := range hostIDs {
+		selectedHosts[hostID] = struct{}{}
+	}
+	for i := range devices {
+		if _, selected := selectedHosts[devices[i].HostId]; selected {
+			devicesByHost[devices[i].HostId] = append(devicesByHost[devices[i].HostId], devices[i])
+		}
+	}
+
+	blockedHosts := findHostsWithExternallySharedWWNs(devices, selectedHosts)
+	results := make([]models.HostActionResult, 0, len(hostIDs))
+	for _, hostID := range hostIDs {
+		hostDevices := devicesByHost[hostID]
+		result := models.HostActionResult{
+			HostID:      hostID,
+			DeviceCount: int64(len(hostDevices)),
+		}
+		if len(hostDevices) == 0 {
+			result.Error = "host not found"
+			results = append(results, result)
+			continue
+		}
+		if sharedWWNs := blockedHosts[hostID]; len(sharedWWNs) > 0 {
+			result.Error = fmt.Sprintf(
+				"history deletion blocked because WWN %q is also used outside selected hosts",
+				sharedWWNs[0],
+			)
+			results = append(results, result)
+			continue
+		}
+
+		if err := sr.deleteHostInfluxHistory(ctx, hostID, hostDevices); err != nil {
+			result.Error = err.Error()
+			results = append(results, result)
+			continue
+		}
+		if err := sr.gormClient.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+			return tx.Where("host_id = ?", hostID).Delete(&models.Device{}).Error
+		}); err != nil {
+			result.Error = fmt.Sprintf("could not delete host devices: %v", err)
+			results = append(results, result)
+			continue
+		}
+
+		result.Success = true
+		results = append(results, result)
+	}
+	return results, nil
+}
+
+func findHostsWithExternallySharedWWNs(devices []models.Device, selectedHosts map[string]struct{}) map[string][]string {
+	hostsByWWN := make(map[string]map[string]struct{})
+	for i := range devices {
+		wwn := devices[i].WWN
+		if strings.TrimSpace(wwn) == "" {
+			continue
+		}
+		if hostsByWWN[wwn] == nil {
+			hostsByWWN[wwn] = make(map[string]struct{})
+		}
+		hostsByWWN[wwn][devices[i].HostId] = struct{}{}
+	}
+
+	blocked := make(map[string][]string)
+	for wwn, hosts := range hostsByWWN {
+		hasOutsideHost := false
+		for hostID := range hosts {
+			if _, selected := selectedHosts[hostID]; !selected {
+				hasOutsideHost = true
+				break
+			}
+		}
+		if !hasOutsideHost {
+			continue
+		}
+		for hostID := range hosts {
+			if _, selected := selectedHosts[hostID]; selected {
+				blocked[hostID] = append(blocked[hostID], wwn)
+			}
+		}
+	}
+	for hostID := range blocked {
+		sort.Strings(blocked[hostID])
+	}
+	return blocked
+}
+
+func (sr *scrutinyRepository) deleteHostInfluxHistory(ctx context.Context, hostID string, devices []models.Device) error {
+	wwns := make(map[string]struct{}, len(devices))
+	for i := range devices {
+		if wwn := devices[i].WWN; strings.TrimSpace(wwn) != "" {
+			wwns[wwn] = struct{}{}
+		}
+	}
+	if len(wwns) == 0 {
+		return nil
+	}
+
+	buckets := []string{
+		sr.appConfig.GetString(cfgInfluxDBBucket),
+		fmt.Sprintf("%s_weekly", sr.appConfig.GetString(cfgInfluxDBBucket)),
+		fmt.Sprintf("%s_monthly", sr.appConfig.GetString(cfgInfluxDBBucket)),
+		fmt.Sprintf("%s_yearly", sr.appConfig.GetString(cfgInfluxDBBucket)),
+	}
+	for wwn := range wwns {
+		for _, bucket := range buckets {
+			sr.logger.Infof("Purging SMART host %s history for WWN %s in bucket %s", hostID, wwn, bucket)
+			if err := sr.influxClient.DeleteAPI().DeleteWithName(
+				ctx,
+				sr.appConfig.GetString(cfgInfluxDBOrg),
+				bucket,
+				time.Now().AddDate(-10, 0, 0),
+				time.Now(),
+				fmt.Sprintf("device_wwn=%q", wwn),
+			); err != nil {
+				return fmt.Errorf("could not delete history for WWN %q from bucket %q: %w", wwn, bucket, err)
+			}
+		}
+	}
+	return nil
+}

--- a/webapp/backend/pkg/database/scrutiny_repository_hosts_test.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_hosts_test.go
@@ -1,0 +1,157 @@
+package database
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	mock_config "github.com/analogj/scrutiny/webapp/backend/pkg/config/mock"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/models"
+	"github.com/glebarez/sqlite"
+	"github.com/golang/mock/gomock"
+	influxdb2 "github.com/influxdata/influxdb-client-go/v2"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func newHostManagementTestRepository(t *testing.T) *scrutinyRepository {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(fmt.Sprintf("file:%s?mode=memory&cache=shared", t.Name())), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.Device{}))
+	return &scrutinyRepository{gormClient: db}
+}
+
+func TestGetHostsCountsSMARTDevicesAndExcludesEmptyHostIDs(t *testing.T) {
+	repo := newHostManagementTestRepository(t)
+	ctx := context.Background()
+	require.NoError(t, repo.gormClient.Create(&[]models.Device{
+		{DeviceID: "a-active", HostId: "alpha"},
+		{DeviceID: "a-archived", HostId: "alpha", Archived: true},
+		{DeviceID: "b-active", HostId: "beta"},
+		{DeviceID: "empty", HostId: ""},
+		{DeviceID: "spaces", HostId: "   "},
+	}).Error)
+
+	hosts, err := repo.GetHosts(ctx)
+
+	require.NoError(t, err)
+	require.Equal(t, []models.HostSummary{
+		{HostID: "alpha", ActiveDevices: 1, ArchivedDevices: 1, TotalDevices: 2},
+		{HostID: "beta", ActiveDevices: 1, ArchivedDevices: 0, TotalDevices: 1},
+	}, hosts)
+}
+
+func TestUpdateHostArchivedUpdatesEveryDeviceInHost(t *testing.T) {
+	repo := newHostManagementTestRepository(t)
+	ctx := context.Background()
+	require.NoError(t, repo.gormClient.Create(&[]models.Device{
+		{DeviceID: "a-1", HostId: "alpha"},
+		{DeviceID: "a-2", HostId: "alpha"},
+		{DeviceID: "b-1", HostId: "beta"},
+	}).Error)
+
+	count, err := repo.UpdateHostArchived(ctx, "alpha", true)
+
+	require.NoError(t, err)
+	require.Equal(t, int64(2), count)
+	var activeAlpha int64
+	require.NoError(t, repo.gormClient.Model(&models.Device{}).Where("host_id = ? AND archived = false", "alpha").Count(&activeAlpha).Error)
+	require.Zero(t, activeAlpha)
+}
+
+func TestFindHostsWithExternallySharedWWNsUsesWholeSelection(t *testing.T) {
+	devices := []models.Device{
+		{DeviceID: "a", HostId: "alpha", WWN: "shared-selected"},
+		{DeviceID: "b", HostId: "beta", WWN: "shared-selected"},
+		{DeviceID: "a-unsafe", HostId: "alpha", WWN: "shared-outside"},
+		{DeviceID: "c", HostId: "gamma", WWN: "shared-outside"},
+	}
+	selected := map[string]struct{}{"alpha": {}, "beta": {}}
+
+	blocked := findHostsWithExternallySharedWWNs(devices, selected)
+
+	require.Equal(t, []string{"shared-outside"}, blocked["alpha"])
+	require.NotContains(t, blocked, "beta")
+}
+
+func TestPurgeHostsBlocksWWNSharedOutsideSelectedHosts(t *testing.T) {
+	repo := newHostManagementTestRepository(t)
+	ctx := context.Background()
+	require.NoError(t, repo.gormClient.Create(&[]models.Device{
+		{DeviceID: "a", HostId: "alpha", WWN: "shared"},
+		{DeviceID: "b", HostId: "beta", WWN: "shared"},
+	}).Error)
+
+	results, err := repo.PurgeHosts(ctx, []string{"alpha"})
+
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	require.False(t, results[0].Success)
+	require.Contains(t, results[0].Error, "outside selected hosts")
+	var count int64
+	require.NoError(t, repo.gormClient.Model(&models.Device{}).Count(&count).Error)
+	require.Equal(t, int64(2), count)
+}
+
+func TestPurgeHostsWithoutWWNIsRetrySafe(t *testing.T) {
+	repo := newHostManagementTestRepository(t)
+	ctx := context.Background()
+	require.NoError(t, repo.gormClient.Create(&models.Device{DeviceID: "a", HostId: "alpha"}).Error)
+
+	first, err := repo.PurgeHosts(ctx, []string{"alpha"})
+	require.NoError(t, err)
+	require.True(t, first[0].Success)
+	require.Equal(t, int64(1), first[0].DeviceCount)
+
+	second, err := repo.PurgeHosts(ctx, []string{"alpha"})
+	require.NoError(t, err)
+	require.False(t, second[0].Success)
+	require.Equal(t, "host not found", second[0].Error)
+}
+
+func TestPurgeHostsKeepsSQLiteRowsAfterInfluxFailureAndCanRetry(t *testing.T) {
+	var failDeletes atomic.Bool
+	failDeletes.Store(true)
+	deleteServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		require.Equal(t, "/api/v2/delete", request.URL.Path)
+		if failDeletes.Load() {
+			http.Error(writer, "temporary failure", http.StatusServiceUnavailable)
+			return
+		}
+		writer.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(deleteServer.Close)
+
+	ctrl := gomock.NewController(t)
+	appConfig := mock_config.NewMockInterface(ctrl)
+	appConfig.EXPECT().GetString(cfgInfluxDBBucket).Return("metrics").AnyTimes()
+	appConfig.EXPECT().GetString(cfgInfluxDBOrg).Return("scrutiny").AnyTimes()
+
+	repo := newHostManagementTestRepository(t)
+	repo.appConfig = appConfig
+	repo.logger = logrus.WithField("test", t.Name())
+	repo.influxClient = influxdb2.NewClient(deleteServer.URL, "token")
+	t.Cleanup(repo.influxClient.Close)
+	ctx := context.Background()
+	require.NoError(t, repo.gormClient.Create(&models.Device{DeviceID: "a", HostId: "alpha", WWN: "wwn-a"}).Error)
+
+	first, err := repo.PurgeHosts(ctx, []string{"alpha"})
+	require.NoError(t, err)
+	require.False(t, first[0].Success)
+	require.Contains(t, first[0].Error, "could not delete history")
+	var count int64
+	require.NoError(t, repo.gormClient.Model(&models.Device{}).Where("host_id = ?", "alpha").Count(&count).Error)
+	require.Equal(t, int64(1), count)
+
+	failDeletes.Store(false)
+	second, err := repo.PurgeHosts(ctx, []string{"alpha"})
+	require.NoError(t, err)
+	require.True(t, second[0].Success)
+	require.NoError(t, repo.gormClient.Model(&models.Device{}).Where("host_id = ?", "alpha").Count(&count).Error)
+	require.Zero(t, count)
+}

--- a/webapp/backend/pkg/models/host_management.go
+++ b/webapp/backend/pkg/models/host_management.go
@@ -1,0 +1,15 @@
+package models
+
+type HostSummary struct {
+	HostID          string `json:"host_id"`
+	ActiveDevices   int64  `json:"active_devices"`
+	ArchivedDevices int64  `json:"archived_devices"`
+	TotalDevices    int64  `json:"total_devices"`
+}
+
+type HostActionResult struct {
+	HostID      string `json:"host_id"`
+	Success     bool   `json:"success"`
+	DeviceCount int64  `json:"device_count"`
+	Error       string `json:"error,omitempty"`
+}

--- a/webapp/backend/pkg/models/host_management.go
+++ b/webapp/backend/pkg/models/host_management.go
@@ -9,7 +9,7 @@ type HostSummary struct {
 
 type HostActionResult struct {
 	HostID      string `json:"host_id"`
-	Success     bool   `json:"success"`
-	DeviceCount int64  `json:"device_count"`
 	Error       string `json:"error,omitempty"`
+	DeviceCount int64  `json:"device_count"`
+	Success     bool   `json:"success"`
 }

--- a/webapp/backend/pkg/web/handler/hosts.go
+++ b/webapp/backend/pkg/web/handler/hosts.go
@@ -1,0 +1,178 @@
+package handler
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/analogj/scrutiny/webapp/backend/pkg/database"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/models"
+	"github.com/gin-gonic/gin"
+	"github.com/sirupsen/logrus"
+)
+
+type hostActionRequest struct {
+	HostIDs      []string `json:"host_ids"`
+	Confirmation string   `json:"confirmation,omitempty"`
+}
+
+func GetHosts(c *gin.Context) {
+	logger := c.MustGet("LOGGER").(*logrus.Entry)
+	deviceRepo := c.MustGet("DEVICE_REPOSITORY").(database.DeviceRepo)
+
+	hosts, err := deviceRepo.GetHosts(c)
+	if err != nil {
+		logger.Errorln("An error occurred while listing SMART hosts", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"success": true, "data": hosts})
+}
+
+func ArchiveHosts(c *gin.Context) {
+	updateHostsArchived(c, true)
+}
+
+func UnarchiveHosts(c *gin.Context) {
+	updateHostsArchived(c, false)
+}
+
+func updateHostsArchived(c *gin.Context, archived bool) {
+	logger := c.MustGet("LOGGER").(*logrus.Entry)
+	deviceRepo := c.MustGet("DEVICE_REPOSITORY").(database.DeviceRepo)
+
+	hostIDs, ok := bindHostIDs(c)
+	if !ok {
+		return
+	}
+	devices, err := deviceRepo.GetDevices(c)
+	if err != nil {
+		logger.Errorln("An error occurred while loading host devices", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
+		return
+	}
+
+	results := make([]models.HostActionResult, 0, len(hostIDs))
+	for _, hostID := range hostIDs {
+		count, updateErr := deviceRepo.UpdateHostArchived(c, hostID, archived)
+		result := models.HostActionResult{HostID: hostID, DeviceCount: count}
+		switch {
+		case updateErr != nil:
+			result.Error = updateErr.Error()
+		case count == 0:
+			result.Error = "host not found"
+		default:
+			result.Success = true
+			for i := range devices {
+				if devices[i].HostId != hostID {
+					continue
+				}
+				if archived {
+					removeMqttDevice(c, &devices[i])
+				} else {
+					devices[i].Archived = false
+					publishMqttDeviceDiscovery(c, &devices[i])
+				}
+			}
+		}
+		results = append(results, result)
+	}
+	c.JSON(http.StatusOK, gin.H{"success": allHostActionsSucceeded(results), "data": results})
+}
+
+func PurgeHosts(c *gin.Context) {
+	logger := c.MustGet("LOGGER").(*logrus.Entry)
+	deviceRepo := c.MustGet("DEVICE_REPOSITORY").(database.DeviceRepo)
+
+	var request hostActionRequest
+	if err := c.ShouldBindJSON(&request); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": "invalid request body"})
+		return
+	}
+	hostIDs, err := normalizeHostIDs(request.HostIDs)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": err.Error()})
+		return
+	}
+	if request.Confirmation != "PURGE" {
+		c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": "confirmation must equal PURGE"})
+		return
+	}
+
+	devices, err := deviceRepo.GetDevices(c)
+	if err != nil {
+		logger.Errorln("An error occurred while loading host devices for purge", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
+		return
+	}
+	results, err := deviceRepo.PurgeHosts(c, hostIDs)
+	if err != nil {
+		logger.Errorln("An error occurred while purging SMART hosts", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
+		return
+	}
+	for _, result := range results {
+		if !result.Success {
+			continue
+		}
+		for i := range devices {
+			if devices[i].HostId == result.HostID {
+				removeMqttDevice(c, &devices[i])
+			}
+		}
+	}
+	c.JSON(http.StatusOK, gin.H{"success": allHostActionsSucceeded(results), "data": results})
+}
+
+func bindHostIDs(c *gin.Context) ([]string, bool) {
+	var request hostActionRequest
+	if err := c.ShouldBindJSON(&request); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": "invalid request body"})
+		return nil, false
+	}
+	hostIDs, err := normalizeHostIDs(request.HostIDs)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": err.Error()})
+		return nil, false
+	}
+	return hostIDs, true
+}
+
+func normalizeHostIDs(input []string) ([]string, error) {
+	hostIDs := make([]string, 0, len(input))
+	seen := make(map[string]struct{}, len(input))
+	for _, rawHostID := range input {
+		if strings.TrimSpace(rawHostID) == "" {
+			return nil, &hostRequestError{message: "host_ids cannot contain empty values"}
+		}
+		hostID := rawHostID
+		if _, exists := seen[hostID]; exists {
+			continue
+		}
+		seen[hostID] = struct{}{}
+		hostIDs = append(hostIDs, hostID)
+	}
+	if len(hostIDs) == 0 {
+		return nil, &hostRequestError{message: "host_ids must contain at least one host"}
+	}
+	return hostIDs, nil
+}
+
+type hostRequestError struct {
+	message string
+}
+
+func (e *hostRequestError) Error() string {
+	return e.message
+}
+
+func allHostActionsSucceeded(results []models.HostActionResult) bool {
+	if len(results) == 0 {
+		return false
+	}
+	for _, result := range results {
+		if !result.Success {
+			return false
+		}
+	}
+	return true
+}

--- a/webapp/backend/pkg/web/handler/hosts.go
+++ b/webapp/backend/pkg/web/handler/hosts.go
@@ -11,8 +11,8 @@ import (
 )
 
 type hostActionRequest struct {
-	HostIDs      []string `json:"host_ids"`
 	Confirmation string   `json:"confirmation,omitempty"`
+	HostIDs      []string `json:"host_ids"`
 }
 
 func GetHosts(c *gin.Context) {

--- a/webapp/backend/pkg/web/handler/hosts_test.go
+++ b/webapp/backend/pkg/web/handler/hosts_test.go
@@ -1,0 +1,121 @@
+package handler
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/analogj/scrutiny/webapp/backend/pkg/database/mock"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/models"
+	"github.com/gin-gonic/gin"
+	"github.com/golang/mock/gomock"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func setupHostsRouter(t *testing.T, repo *mock_database.MockDeviceRepo) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.Use(func(c *gin.Context) {
+		c.Set("LOGGER", logrus.WithField("test", t.Name()))
+		c.Set("DEVICE_REPOSITORY", repo)
+		c.Next()
+	})
+	router.GET("/hosts", GetHosts)
+	router.POST("/hosts/archive", ArchiveHosts)
+	router.POST("/hosts/unarchive", UnarchiveHosts)
+	router.POST("/hosts/purge", PurgeHosts)
+	return router
+}
+
+func TestGetHostsReturnsHostInventory(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	repo := mock_database.NewMockDeviceRepo(ctrl)
+	repo.EXPECT().GetHosts(gomock.Any()).Return([]models.HostSummary{
+		{HostID: "alpha", ActiveDevices: 2, ArchivedDevices: 1, TotalDevices: 3},
+	}, nil)
+	router := setupHostsRouter(t, repo)
+
+	response := httptest.NewRecorder()
+	router.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/hosts", nil))
+
+	require.Equal(t, http.StatusOK, response.Code)
+	require.JSONEq(t, `{"success":true,"data":[{"host_id":"alpha","active_devices":2,"archived_devices":1,"total_devices":3}]}`, response.Body.String())
+}
+
+func TestArchiveHostsDeduplicatesHostIDsAndReturnsPerHostResults(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	repo := mock_database.NewMockDeviceRepo(ctrl)
+	repo.EXPECT().GetDevices(gomock.Any()).Return([]models.Device{
+		{DeviceID: "a", HostId: "alpha"},
+	}, nil)
+	repo.EXPECT().UpdateHostArchived(gomock.Any(), "alpha", true).Return(int64(1), nil)
+	repo.EXPECT().UpdateHostArchived(gomock.Any(), "missing", true).Return(int64(0), nil)
+	router := setupHostsRouter(t, repo)
+
+	response := httptest.NewRecorder()
+	body := bytes.NewBufferString(`{"host_ids":["alpha","alpha","missing"]}`)
+	router.ServeHTTP(response, httptest.NewRequest(http.MethodPost, "/hosts/archive", body))
+
+	require.Equal(t, http.StatusOK, response.Code)
+	require.JSONEq(t, `{
+		"success":false,
+		"data":[
+			{"host_id":"alpha","success":true,"device_count":1},
+			{"host_id":"missing","success":false,"device_count":0,"error":"host not found"}
+		]
+	}`, response.Body.String())
+}
+
+func TestPurgeHostsRequiresTypedConfirmation(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	repo := mock_database.NewMockDeviceRepo(ctrl)
+	router := setupHostsRouter(t, repo)
+
+	response := httptest.NewRecorder()
+	body := bytes.NewBufferString(`{"host_ids":["alpha"],"confirmation":"purge"}`)
+	router.ServeHTTP(response, httptest.NewRequest(http.MethodPost, "/hosts/purge", body))
+
+	require.Equal(t, http.StatusBadRequest, response.Code)
+	require.JSONEq(t, `{"success":false,"error":"confirmation must equal PURGE"}`, response.Body.String())
+}
+
+func TestPurgeHostsReturnsRetryablePartialResults(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	repo := mock_database.NewMockDeviceRepo(ctrl)
+	repo.EXPECT().GetDevices(gomock.Any()).Return([]models.Device{
+		{DeviceID: "a", HostId: "alpha"},
+		{DeviceID: "b", HostId: "beta"},
+	}, nil)
+	repo.EXPECT().PurgeHosts(gomock.Any(), []string{"alpha", "beta"}).Return([]models.HostActionResult{
+		{HostID: "alpha", Success: true, DeviceCount: 1},
+		{HostID: "beta", DeviceCount: 1, Error: "storage unavailable"},
+	}, nil)
+	router := setupHostsRouter(t, repo)
+
+	response := httptest.NewRecorder()
+	body := bytes.NewBufferString(`{"host_ids":["alpha","beta"],"confirmation":"PURGE"}`)
+	router.ServeHTTP(response, httptest.NewRequest(http.MethodPost, "/hosts/purge", body))
+
+	require.Equal(t, http.StatusOK, response.Code)
+	require.JSONEq(t, `{
+		"success":false,
+		"data":[
+			{"host_id":"alpha","success":true,"device_count":1},
+			{"host_id":"beta","success":false,"device_count":1,"error":"storage unavailable"}
+		]
+	}`, response.Body.String())
+}
+
+func TestNormalizeHostIDsRejectsEmptyValues(t *testing.T) {
+	_, err := normalizeHostIDs([]string{"alpha", " "})
+	require.EqualError(t, err, "host_ids cannot contain empty values")
+}
+
+func TestNormalizeHostIDsPreservesExactStoredIdentity(t *testing.T) {
+	hostIDs, err := normalizeHostIDs([]string{" alpha "})
+	require.NoError(t, err)
+	require.Equal(t, []string{" alpha "}, hostIDs)
+}

--- a/webapp/backend/pkg/web/server.go
+++ b/webapp/backend/pkg/web/server.go
@@ -126,7 +126,11 @@ func (ae *AppEngine) Setup(logger *logrus.Entry) *gin.Engine {
 			api.GET(apiSummaryPath, handler.GetDevicesSummary)             // used by Dashboard
 			api.GET("/summary/temp", handler.GetDevicesSummaryTempHistory) // used by Dashboard (Temperature history dropdown)
 			api.GET("/summary/temp/devices", handler.GetTemperatureDeviceOptions)
-			api.GET("/summary/workload", handler.GetWorkloadInsights)         // used by Workload Insights page
+			api.GET("/summary/workload", handler.GetWorkloadInsights) // used by Workload Insights page
+			api.GET("/hosts", handler.GetHosts)                       // used by SMART host management
+			api.POST("/hosts/archive", handler.ArchiveHosts)
+			api.POST("/hosts/unarchive", handler.UnarchiveHosts)
+			api.POST("/hosts/purge", handler.PurgeHosts)
 			api.GET("/filesystems/summary", handler.GetFilesystemSummary)     // used by Dashboard filesystem capacity panel
 			api.POST("/filesystems/summary", handler.UploadFilesystemSummary) // used by Filesystem Collector to upload data
 			api.POST("/collectors/run", handler.TriggerCollectors)            // used by Dashboard to trigger local collectors in omnibus mode

--- a/webapp/frontend/src/app/app.routing.spec.ts
+++ b/webapp/frontend/src/app/app.routing.spec.ts
@@ -6,4 +6,10 @@ describe('appRoutes', () => {
 
         expect(protectedRoute?.children?.some((child) => child.path === 'mobile-drives')).toBeTrue();
     });
+
+    it('should expose SMART host management without adding a mobile tab route', () => {
+        const protectedRoute = appRoutes.find((route) => route.children?.some((child) => child.path === 'dashboard'));
+
+        expect(protectedRoute?.children?.some((child) => child.path === 'hosts')).toBeTrue();
+    });
 });

--- a/webapp/frontend/src/app/app.routing.ts
+++ b/webapp/frontend/src/app/app.routing.ts
@@ -55,6 +55,9 @@ export const appRoutes: Route[] = [
             // Workload Insights
             { path: 'workload', loadChildren: () => import('app/modules/workload/workload.module').then((m) => m.WorkloadModule) },
 
+            // SMART host management
+            { path: 'hosts', loadChildren: () => import('app/modules/hosts/hosts.module').then((m) => m.HostsModule) },
+
             // Mobile-only routes
             { path: 'mobile-home', loadChildren: () => import('app/modules/mobile-home/mobile-home.module').then((m) => m.MobileHomeModule) },
             { path: 'mobile-drives', loadChildren: () => import('app/modules/dashboard/dashboard.module').then((m) => m.DashboardModule) },

--- a/webapp/frontend/src/app/core/models/host-management-model.ts
+++ b/webapp/frontend/src/app/core/models/host-management-model.ts
@@ -1,0 +1,24 @@
+export interface HostSummaryModel {
+    host_id: string;
+    active_devices: number;
+    archived_devices: number;
+    total_devices: number;
+}
+
+export interface HostActionResultModel {
+    host_id: string;
+    success: boolean;
+    device_count: number;
+    error?: string;
+}
+
+export interface HostSummaryResponse {
+    success: boolean;
+    data: HostSummaryModel[];
+}
+
+export interface HostActionResponse {
+    success: boolean;
+    data: HostActionResultModel[];
+    error?: string;
+}

--- a/webapp/frontend/src/app/layout/layouts/horizontal/material/material.component.html
+++ b/webapp/frontend/src/app/layout/layouts/horizontal/material/material.component.html
@@ -45,6 +45,7 @@
                     } @if (config.navigation?.show_workload !== false) {
                     <a routerLink="/workload" routerLinkActive="active" class="nav-link">Workload</a>
                     }
+                    <a routerLink="/hosts" routerLinkActive="active" class="nav-link">Hosts</a>
                 </nav>
                 }
 

--- a/webapp/frontend/src/app/modules/hosts/host-purge-dialog.component.html
+++ b/webapp/frontend/src/app/modules/hosts/host-purge-dialog.component.html
@@ -1,0 +1,14 @@
+<h2 mat-dialog-title>Permanently purge {{ data.hostIds.length }} host{{ data.hostIds.length === 1 ? '' : 's' }}?</h2>
+<mat-dialog-content>
+    <p>This deletes selected hosts, devices, and all matching SMART and temperature history. This cannot be undone.</p>
+    <p><strong>Stop active collectors first.</strong> Any collector still reporting these devices can re-register them after purge.</p>
+    <p>Type <strong>PURGE</strong> to continue.</p>
+    <mat-form-field appearance="outline" class="w-full">
+        <mat-label>Confirmation</mat-label>
+        <input matInput [(ngModel)]="confirmation" autocomplete="off" />
+    </mat-form-field>
+</mat-dialog-content>
+<mat-dialog-actions align="end">
+    <button mat-button mat-dialog-close>Cancel</button>
+    <button mat-flat-button color="warn" [disabled]="confirmation !== 'PURGE'" (click)="confirm()">Permanently purge</button>
+</mat-dialog-actions>

--- a/webapp/frontend/src/app/modules/hosts/host-purge-dialog.component.ts
+++ b/webapp/frontend/src/app/modules/hosts/host-purge-dialog.component.ts
@@ -1,0 +1,24 @@
+import { Component, inject } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { MAT_DIALOG_DATA, MatDialogActions, MatDialogClose, MatDialogContent, MatDialogRef, MatDialogTitle } from '@angular/material/dialog';
+import { MatButton } from '@angular/material/button';
+import { MatFormField, MatLabel } from '@angular/material/form-field';
+import { MatInput } from '@angular/material/input';
+
+@Component({
+    selector: 'host-purge-dialog',
+    templateUrl: './host-purge-dialog.component.html',
+    imports: [FormsModule, MatDialogTitle, MatDialogContent, MatDialogActions, MatDialogClose, MatButton, MatFormField, MatLabel, MatInput],
+})
+export class HostPurgeDialogComponent {
+    readonly data = inject<{ hostIds: string[] }>(MAT_DIALOG_DATA);
+    private readonly dialogRef = inject<MatDialogRef<HostPurgeDialogComponent>>(MatDialogRef);
+
+    confirmation = '';
+
+    confirm(): void {
+        if (this.confirmation === 'PURGE') {
+            this.dialogRef.close(true);
+        }
+    }
+}

--- a/webapp/frontend/src/app/modules/hosts/hosts.component.html
+++ b/webapp/frontend/src/app/modules/hosts/hosts.component.html
@@ -1,0 +1,78 @@
+<div class="hosts-page flex flex-col flex-auto w-full p-8 xs:p-4">
+    <div class="flex flex-wrap items-start justify-between gap-4 mb-6">
+        <div>
+            <h2 class="m-0">SMART Hosts</h2>
+            <div class="text-secondary">Archive or permanently purge devices grouped by collector host ID.</div>
+        </div>
+        <button mat-stroked-button (click)="loadHosts()" [disabled]="loading || actionInProgress">
+            <mat-icon class="icon-size-20 mr-2">refresh</mat-icon>
+            Refresh
+        </button>
+    </div>
+
+    <div class="host-warning rounded-lg p-4 mb-6">
+        <strong>Before purge:</strong> stop collectors for selected hosts. Active collectors can immediately re-register purged devices.
+    </div>
+
+    <div class="flex flex-wrap items-center gap-3 mb-4">
+        <mat-form-field appearance="outline" class="host-search">
+            <mat-label>Search hosts</mat-label>
+            <mat-icon matPrefix>search</mat-icon>
+            <input matInput [value]="search" (input)="setSearch($any($event.target).value)" />
+        </mat-form-field>
+
+        <span class="text-secondary">{{ selectedCount }} selected</span>
+        <span class="flex-auto"></span>
+        <button mat-stroked-button (click)="archiveSelected()" [disabled]="selectedCount === 0 || actionInProgress">Archive devices</button>
+        <button mat-stroked-button (click)="unarchiveSelected()" [disabled]="selectedCount === 0 || actionInProgress">Unarchive devices</button>
+        <button mat-flat-button color="warn" (click)="purgeSelected()" [disabled]="selectedCount === 0 || actionInProgress">Permanently purge</button>
+    </div>
+
+    @if (actionResults.length > 0) {
+    <div class="action-results rounded-lg p-4 mb-4">
+        <div class="font-semibold mb-2">Latest results</div>
+        @for (result of actionResults; track result.host_id) {
+        <div class="flex items-start gap-2 text-sm py-1">
+            <mat-icon class="icon-size-18" [class.text-green-500]="result.success" [class.text-red-500]="!result.success">
+                {{ result.success ? 'check_circle' : 'error' }}
+            </mat-icon>
+            <div>
+                <strong>{{ result.host_id }}</strong>
+                — {{ result.success ? result.device_count + ' device(s) updated' : result.error }}
+            </div>
+        </div>
+        } @if (lastAction === 'purge' && selectedCount > 0) {
+        <button mat-button class="mt-2" (click)="retryFailed()" [disabled]="actionInProgress || !selectedCount">Retry failed purges</button>
+        }
+    </div>
+    } @if (loading) {
+    <div class="flex justify-center p-12"><mat-spinner diameter="40"></mat-spinner></div>
+    } @else if (loadError) {
+    <div class="text-red-500 p-6 text-center">{{ loadError }}</div>
+    } @else if (filteredHosts.length === 0) {
+    <div class="text-secondary p-12 text-center">{{ hosts.length === 0 ? 'No SMART hosts with a host ID were found.' : 'No hosts match this search.' }}</div>
+    } @else {
+    <div class="host-table rounded-lg overflow-hidden">
+        <div class="host-row host-header">
+            <mat-checkbox [checked]="allFilteredSelected" (change)="toggleFilteredHosts($event.checked)" aria-label="Select all filtered hosts"></mat-checkbox>
+            <div>Host</div>
+            <div>Active</div>
+            <div>Archived</div>
+            <div>Total</div>
+        </div>
+        @for (host of filteredHosts; track host.host_id) {
+        <div class="host-row">
+            <mat-checkbox
+                [checked]="selectedHostIds.has(host.host_id)"
+                (change)="toggleHost(host.host_id, $event.checked)"
+                [attr.aria-label]="'Select ' + host.host_id"
+            ></mat-checkbox>
+            <div class="font-semibold break-all">{{ host.host_id }}</div>
+            <div><span class="mobile-label">Active</span>{{ host.active_devices }}</div>
+            <div><span class="mobile-label">Archived</span>{{ host.archived_devices }}</div>
+            <div><span class="mobile-label">Total</span>{{ host.total_devices }}</div>
+        </div>
+        }
+    </div>
+    }
+</div>

--- a/webapp/frontend/src/app/modules/hosts/hosts.component.scss
+++ b/webapp/frontend/src/app/modules/hosts/hosts.component.scss
@@ -1,0 +1,71 @@
+hosts {
+    display: block;
+
+    .host-warning {
+        background: rgba(245, 158, 11, 0.12);
+        border: 1px solid rgba(245, 158, 11, 0.35);
+    }
+
+    .host-search {
+        width: min(100%, 360px);
+
+        .mat-mdc-form-field-subscript-wrapper {
+            display: none;
+        }
+    }
+
+    .action-results,
+    .host-table {
+        background: var(--mat-sys-surface-container, rgba(148, 163, 184, 0.08));
+        border: 1px solid rgba(148, 163, 184, 0.25);
+    }
+
+    .host-row {
+        display: grid;
+        grid-template-columns: 48px minmax(180px, 1fr) repeat(3, minmax(80px, 120px));
+        align-items: center;
+        min-height: 56px;
+        padding: 0 16px;
+        border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+
+        &:last-child {
+            border-bottom: 0;
+        }
+    }
+
+    .host-header {
+        min-height: 48px;
+        font-size: 0.75rem;
+        font-weight: 600;
+        text-transform: uppercase;
+        color: var(--mat-sys-on-surface-variant, inherit);
+    }
+
+    .mobile-label {
+        display: none;
+    }
+
+    @media (max-width: 959px) {
+        .host-row {
+            grid-template-columns: 40px 1fr;
+            gap: 8px;
+            padding: 12px;
+
+            > div:nth-child(n + 3) {
+                grid-column: 2;
+            }
+        }
+
+        .host-header {
+            > div:nth-child(n + 3) {
+                display: none;
+            }
+        }
+
+        .mobile-label {
+            display: inline-block;
+            min-width: 72px;
+            color: var(--mat-sys-on-surface-variant, inherit);
+        }
+    }
+}

--- a/webapp/frontend/src/app/modules/hosts/hosts.component.spec.ts
+++ b/webapp/frontend/src/app/modules/hosts/hosts.component.spec.ts
@@ -1,0 +1,79 @@
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatDialog } from '@angular/material/dialog';
+import { of } from 'rxjs';
+import { HostsComponent } from './hosts.component';
+import { HostsService } from './hosts.service';
+
+describe('HostsComponent', () => {
+    let component: HostsComponent;
+    let fixture: ComponentFixture<HostsComponent>;
+    let hostsService: jasmine.SpyObj<HostsService>;
+    let dialog: jasmine.SpyObj<MatDialog>;
+
+    beforeEach(async () => {
+        hostsService = jasmine.createSpyObj('HostsService', ['getHosts', 'archiveHosts', 'unarchiveHosts', 'purgeHosts']);
+        dialog = jasmine.createSpyObj('MatDialog', ['open']);
+        hostsService.getHosts.and.returnValue(
+            of({
+                success: true,
+                data: [
+                    { host_id: 'alpha', active_devices: 2, archived_devices: 1, total_devices: 3 },
+                    { host_id: 'beta', active_devices: 1, archived_devices: 0, total_devices: 1 },
+                ],
+            })
+        );
+
+        await TestBed.configureTestingModule({
+            imports: [NoopAnimationsModule, HostsComponent],
+            providers: [
+                { provide: HostsService, useValue: hostsService },
+                { provide: MatDialog, useValue: dialog },
+            ],
+        }).compileComponents();
+
+        fixture = TestBed.createComponent(HostsComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
+
+    it('filters hosts and keeps selection independent from search', () => {
+        component.toggleHost('alpha', true);
+        component.setSearch('beta');
+
+        expect(component.filteredHosts.map((host) => host.host_id)).toEqual(['beta']);
+        expect(component.selectedHostIds.has('alpha')).toBeTrue();
+    });
+
+    it('archives all selected host devices and refreshes counts', () => {
+        hostsService.archiveHosts.and.returnValue(
+            of({
+                success: true,
+                data: [{ host_id: 'alpha', success: true, device_count: 3 }],
+            })
+        );
+        component.toggleHost('alpha', true);
+
+        component.archiveSelected();
+
+        expect(hostsService.archiveHosts).toHaveBeenCalledWith(['alpha']);
+        expect(hostsService.getHosts).toHaveBeenCalledTimes(2);
+    });
+
+    it('purges only after typed confirmation dialog succeeds', () => {
+        hostsService.purgeHosts.and.returnValue(
+            of({
+                success: false,
+                data: [{ host_id: 'alpha', success: false, device_count: 3, error: 'storage unavailable' }],
+            })
+        );
+        dialog.open.and.returnValue({ afterClosed: () => of(true) } as any);
+        component.toggleHost('alpha', true);
+
+        component.purgeSelected();
+
+        expect(hostsService.purgeHosts).toHaveBeenCalledWith(['alpha']);
+        expect(component.selectedHostIds.has('alpha')).toBeTrue();
+        expect(component.lastAction).toBe('purge');
+    });
+});

--- a/webapp/frontend/src/app/modules/hosts/hosts.component.ts
+++ b/webapp/frontend/src/app/modules/hosts/hosts.component.ts
@@ -1,0 +1,166 @@
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, ViewEncapsulation, inject } from '@angular/core';
+import { MatButton } from '@angular/material/button';
+import { MatCheckbox } from '@angular/material/checkbox';
+import { MatDialog } from '@angular/material/dialog';
+import { MatFormField, MatLabel, MatPrefix } from '@angular/material/form-field';
+import { MatIcon } from '@angular/material/icon';
+import { MatInput } from '@angular/material/input';
+import { MatProgressSpinner } from '@angular/material/progress-spinner';
+import { HostActionResponse, HostActionResultModel, HostSummaryModel } from 'app/core/models/host-management-model';
+import { Observable } from 'rxjs';
+import { finalize } from 'rxjs/operators';
+import { HostPurgeDialogComponent } from './host-purge-dialog.component';
+import { HostsService } from './hosts.service';
+
+@Component({
+    selector: 'hosts',
+    templateUrl: './hosts.component.html',
+    styleUrls: ['./hosts.component.scss'],
+    encapsulation: ViewEncapsulation.None,
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    imports: [MatButton, MatCheckbox, MatFormField, MatLabel, MatPrefix, MatIcon, MatInput, MatProgressSpinner],
+})
+export class HostsComponent implements OnInit {
+    private readonly hostsService = inject(HostsService);
+    private readonly dialog = inject(MatDialog);
+    private readonly changeDetectorRef = inject(ChangeDetectorRef);
+
+    hosts: HostSummaryModel[] = [];
+    selectedHostIds = new Set<string>();
+    search = '';
+    loading = true;
+    actionInProgress = false;
+    actionResults: HostActionResultModel[] = [];
+    lastAction: 'archive' | 'unarchive' | 'purge' | null = null;
+    loadError = '';
+
+    get filteredHosts(): HostSummaryModel[] {
+        const search = this.search.trim().toLowerCase();
+        if (!search) {
+            return this.hosts;
+        }
+        return this.hosts.filter((host) => host.host_id.toLowerCase().includes(search));
+    }
+
+    get selectedCount(): number {
+        return this.selectedHostIds.size;
+    }
+
+    get allFilteredSelected(): boolean {
+        return this.filteredHosts.length > 0 && this.filteredHosts.every((host) => this.selectedHostIds.has(host.host_id));
+    }
+
+    ngOnInit(): void {
+        this.loadHosts();
+    }
+
+    loadHosts(): void {
+        this.loading = true;
+        this.loadError = '';
+        this.hostsService
+            .getHosts()
+            .pipe(
+                finalize(() => {
+                    this.loading = false;
+                    this.changeDetectorRef.markForCheck();
+                })
+            )
+            .subscribe({
+                next: (response) => {
+                    this.hosts = response.data;
+                    const availableHostIds = new Set(this.hosts.map((host) => host.host_id));
+                    this.selectedHostIds = new Set([...this.selectedHostIds].filter((hostId) => availableHostIds.has(hostId)));
+                },
+                error: () => {
+                    this.loadError = 'Could not load SMART hosts.';
+                },
+            });
+    }
+
+    setSearch(value: string): void {
+        this.search = value;
+    }
+
+    toggleHost(hostId: string, checked: boolean): void {
+        if (checked) {
+            this.selectedHostIds.add(hostId);
+        } else {
+            this.selectedHostIds.delete(hostId);
+        }
+    }
+
+    toggleFilteredHosts(checked: boolean): void {
+        for (const host of this.filteredHosts) {
+            if (checked) {
+                this.selectedHostIds.add(host.host_id);
+            } else {
+                this.selectedHostIds.delete(host.host_id);
+            }
+        }
+    }
+
+    archiveSelected(): void {
+        this.runAction('archive', (hostIds) => this.hostsService.archiveHosts(hostIds));
+    }
+
+    unarchiveSelected(): void {
+        this.runAction('unarchive', (hostIds) => this.hostsService.unarchiveHosts(hostIds));
+    }
+
+    purgeSelected(): void {
+        const hostIds = [...this.selectedHostIds];
+        if (hostIds.length === 0) {
+            return;
+        }
+        this.dialog
+            .open(HostPurgeDialogComponent, {
+                width: '520px',
+                maxWidth: '95vw',
+                data: { hostIds },
+            })
+            .afterClosed()
+            .subscribe((confirmed) => {
+                if (confirmed) {
+                    this.runAction('purge', (selectedHostIds) => this.hostsService.purgeHosts(selectedHostIds));
+                }
+            });
+    }
+
+    retryFailed(): void {
+        const failedHostIds = this.actionResults.filter((result) => !result.success).map((result) => result.host_id);
+        this.selectedHostIds = new Set(failedHostIds);
+        this.purgeSelected();
+    }
+
+    private runAction(actionName: 'archive' | 'unarchive' | 'purge', action: (hostIds: string[]) => Observable<HostActionResponse>): void {
+        const hostIds = [...this.selectedHostIds];
+        if (hostIds.length === 0 || this.actionInProgress) {
+            return;
+        }
+        this.actionInProgress = true;
+        this.lastAction = actionName;
+        this.actionResults = [];
+        action(hostIds)
+            .pipe(
+                finalize(() => {
+                    this.actionInProgress = false;
+                    this.changeDetectorRef.markForCheck();
+                })
+            )
+            .subscribe({
+                next: (response) => {
+                    this.actionResults = response.data;
+                    this.selectedHostIds = new Set(response.data.filter((result) => !result.success).map((result) => result.host_id));
+                    this.loadHosts();
+                },
+                error: () => {
+                    this.actionResults = hostIds.map((hostId) => ({
+                        host_id: hostId,
+                        success: false,
+                        device_count: 0,
+                        error: 'Request failed before host result was returned.',
+                    }));
+                },
+            });
+    }
+}

--- a/webapp/frontend/src/app/modules/hosts/hosts.module.ts
+++ b/webapp/frontend/src/app/modules/hosts/hosts.module.ts
@@ -1,0 +1,9 @@
+import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { HostsComponent } from './hosts.component';
+import { hostsRoutes } from './hosts.routing';
+
+@NgModule({
+    imports: [RouterModule.forChild(hostsRoutes), HostsComponent],
+})
+export class HostsModule {}

--- a/webapp/frontend/src/app/modules/hosts/hosts.routing.ts
+++ b/webapp/frontend/src/app/modules/hosts/hosts.routing.ts
@@ -1,0 +1,9 @@
+import { Route } from '@angular/router';
+import { HostsComponent } from './hosts.component';
+
+export const hostsRoutes: Route[] = [
+    {
+        path: '',
+        component: HostsComponent,
+    },
+];

--- a/webapp/frontend/src/app/modules/hosts/hosts.service.spec.ts
+++ b/webapp/frontend/src/app/modules/hosts/hosts.service.spec.ts
@@ -1,0 +1,41 @@
+import { HttpClient } from '@angular/common/http';
+import { TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+import { HostsService } from './hosts.service';
+
+describe('HostsService', () => {
+    let service: HostsService;
+    let httpClient: jasmine.SpyObj<HttpClient>;
+
+    beforeEach(() => {
+        httpClient = jasmine.createSpyObj('HttpClient', ['get', 'post']);
+        TestBed.configureTestingModule({
+            providers: [HostsService, { provide: HttpClient, useValue: httpClient }],
+        });
+        service = TestBed.inject(HostsService);
+    });
+
+    it('loads SMART host inventory', () => {
+        const response = {
+            success: true,
+            data: [{ host_id: 'alpha', active_devices: 2, archived_devices: 1, total_devices: 3 }],
+        };
+        httpClient.get.and.returnValue(of(response));
+
+        service.getHosts().subscribe((value) => expect(value).toEqual(response));
+
+        expect(httpClient.get).toHaveBeenCalledWith(jasmine.stringMatching(/\/api\/hosts$/));
+    });
+
+    it('requires server-side PURGE confirmation for selected hosts', () => {
+        const response = { success: true, data: [] };
+        httpClient.post.and.returnValue(of(response));
+
+        service.purgeHosts(['alpha', 'beta']).subscribe((value) => expect(value).toEqual(response));
+
+        expect(httpClient.post).toHaveBeenCalledWith(jasmine.stringMatching(/\/api\/hosts\/purge$/), {
+            host_ids: ['alpha', 'beta'],
+            confirmation: 'PURGE',
+        });
+    });
+});

--- a/webapp/frontend/src/app/modules/hosts/hosts.service.ts
+++ b/webapp/frontend/src/app/modules/hosts/hosts.service.ts
@@ -1,0 +1,32 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable, inject } from '@angular/core';
+import { getBasePath } from 'app/app.routing';
+import { HostActionResponse, HostSummaryResponse } from 'app/core/models/host-management-model';
+import { Observable } from 'rxjs';
+
+@Injectable({
+    providedIn: 'root',
+})
+export class HostsService {
+    private readonly http = inject(HttpClient);
+    private readonly baseUrl = getBasePath() + '/api/hosts';
+
+    getHosts(): Observable<HostSummaryResponse> {
+        return this.http.get<HostSummaryResponse>(this.baseUrl);
+    }
+
+    archiveHosts(hostIds: string[]): Observable<HostActionResponse> {
+        return this.http.post<HostActionResponse>(this.baseUrl + '/archive', { host_ids: hostIds });
+    }
+
+    unarchiveHosts(hostIds: string[]): Observable<HostActionResponse> {
+        return this.http.post<HostActionResponse>(this.baseUrl + '/unarchive', { host_ids: hostIds });
+    }
+
+    purgeHosts(hostIds: string[]): Observable<HostActionResponse> {
+        return this.http.post<HostActionResponse>(this.baseUrl + '/purge', {
+            host_ids: hostIds,
+            confirmation: 'PURGE',
+        });
+    }
+}

--- a/webapp/frontend/src/app/modules/mobile-settings/mobile-settings.component.html
+++ b/webapp/frontend/src/app/modules/mobile-settings/mobile-settings.component.html
@@ -7,6 +7,11 @@
         <span class="ml-2">Display & Notifications</span>
     </button>
 
+    <a mat-stroked-button class="settings-button mt-3" routerLink="/hosts">
+        <mat-icon class="icon-size-20">dns</mat-icon>
+        <span class="ml-2">SMART Host Management</span>
+    </a>
+
     <div class="mt-6">
         <a class="version-link text-secondary" href="https://github.com/Starosdev/scrutiny" target="_blank" rel="noopener noreferrer">
             <code>{{ appVersion }}</code>

--- a/webapp/frontend/src/app/modules/mobile-settings/mobile-settings.component.ts
+++ b/webapp/frontend/src/app/modules/mobile-settings/mobile-settings.component.ts
@@ -4,13 +4,14 @@ import { DashboardSettingsComponent } from 'app/layout/common/dashboard-settings
 import { versionInfo } from 'environments/versions';
 import { MatButton } from '@angular/material/button';
 import { MatIcon } from '@angular/material/icon';
+import { RouterLink } from '@angular/router';
 
 @Component({
     selector: 'mobile-settings',
     templateUrl: './mobile-settings.component.html',
     styleUrls: ['./mobile-settings.component.scss'],
     encapsulation: ViewEncapsulation.None,
-    imports: [MatButton, MatIcon],
+    imports: [MatButton, MatIcon, RouterLink],
 })
 export class MobileSettingsComponent {
     private readonly dialog = inject(MatDialog);


### PR DESCRIPTION
## Summary

- add searchable SMART host inventory with active, archived, and total device counts
- add bulk archive and unarchive actions plus typed-confirmation permanent purge
- guard InfluxDB deletion when a WWN is shared outside selected hosts
- return retryable per-host results and retain SQLite rows after InfluxDB failures
- expose Hosts in desktop navigation and mobile Settings
- document API and operator workflow

## Linked Issues

Closes #684
Part of #674

## Test plan

- go test ./...
- npm --prefix webapp/frontend test -- --watch=false --browsers=ChromeHeadless (170 tests)
- npm --prefix webapp/frontend run lint
- npm --prefix webapp/frontend run build
- parse docs/openapi.yaml with Ruby YAML
- git diff --check