### PR TITLE
[SCR-5] v1.0.0 — Remove residual GHAS references from security scan

### DIFF
--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -18,22 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      security-events: write
 
     steps:
       - name: Checkout
         uses: actions/checkout@v7
-
-      - name: Run Trivy vulnerability scanner (SARIF)
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.36.0
-        with:
-          scan-type: 'fs'
-          path: '.'
-          format: 'sarif'
-          output: 'trivy-repo-results.sarif'
-          severity: 'CRITICAL,HIGH'
-          exit-code: '0'
-        continue-on-error: true
 
       - name: Run Trivy vulnerability scanner (JSON)
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.36.0
@@ -44,17 +32,14 @@ jobs:
           output: 'trivy-summary.json'
           severity: 'UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL'
           exit-code: '0'
-        continue-on-error: true
 
       - name: Upload Trivy scan results
         uses: actions/upload-artifact@v7
         with:
           name: trivy-scan-results
-          path: |
-            trivy-*.sarif
-            trivy-*.json
-          retention-days: 30
-          if-no-files-found: warn
+          path: trivy-summary.json
+          retention-days: 7
+          if-no-files-found: error
 
       - name: Display vulnerability summary
         if: always()

--- a/scripts/tests/test_security_scan_workflow.py
+++ b/scripts/tests/test_security_scan_workflow.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+
+WORKFLOW = Path(__file__).parents[2] / ".github/workflows/security-scan.yaml"
+
+
+def test_security_scan_is_ghas_free_and_preserves_outage_gate() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    lowered = text.lower()
+
+    for forbidden in ("github/codeql-action", "security-events", "upload-sarif", "sarif"):
+        assert forbidden not in lowered
+
+    assert "format: 'json'" in text
+    assert "path: trivy-summary.json" in text
+    assert "retention-days: 7" in text
+    assert "continue-on-error: true" not in lowered


### PR DESCRIPTION
## Summary\n\n- Removes security-events permission and SARIF output from the Trivy workflow.\n- Keeps private JSON artifact output with seven-day retention.\n- Makes scanner execution failure fail the workflow instead of continuing.\n- Adds a workflow contract test for GHAS-free output and outage gating.\n\n## Validation\n\n- Focused workflow test passed.\n- actionlint passed.\n- Diff check passed.\n\nLinear: SCR-5 under INF-810.