### PR TITLE
Fix temperature selector drive count

### DIFF
--- a/webapp/frontend/src/app/modules/dashboard/dashboard.component.html
+++ b/webapp/frontend/src/app/modules/dashboard/dashboard.component.html
@@ -275,7 +275,7 @@
 
                                 <button class="h-8 min-h-8 px-3 ml-2" mat-stroked-button [matMenuTriggerFor]="driveFilterMenu">
                                     <mat-icon class="icon-size-4" [svgIcon]="'filter_list'"></mat-icon>
-                                    <span class="font-medium text-sm ml-1">Drives ({{ temperatureSelection.ids.length }}/{{ temperatureSelection.maxSelected }})</span>
+                                    <span class="font-medium text-sm ml-1">Drives ({{ temperatureSelection.ids.length }}/{{ temperatureDevices.length }})</span>
                                     <mat-icon class="icon-size-4 ml-1" [svgIcon]="'expand_more'"></mat-icon>
                                 </button>
 

--- a/webapp/frontend/src/app/modules/dashboard/dashboard.component.spec.ts
+++ b/webapp/frontend/src/app/modules/dashboard/dashboard.component.spec.ts
@@ -39,16 +39,16 @@ describe('DashboardComponent temperature chart', () => {
             temperatureSelection,
         });
         dashboardService.getTemperatureDeviceOptions.and.returnValue(
-            of([
-                {
-                    device_id: 'drive-1',
+            of(
+                Array.from({ length: 19 }, (_, index) => ({
+                    device_id: `drive-${index + 1}`,
                     host_id: 'host-1',
                     label: '',
-                    device_name: 'sda',
+                    device_name: `sd${String.fromCharCode(97 + index)}`,
                     model_name: 'Test Drive',
-                    serial_number: 'serial-1',
-                },
-            ])
+                    serial_number: `serial-${index + 1}`,
+                }))
+            )
         );
         dashboardService.getSummaryTempData.and.returnValue(
             of({
@@ -78,12 +78,18 @@ describe('DashboardComponent temperature chart', () => {
 
         fixture = TestBed.createComponent(DashboardComponent);
         component = fixture.componentInstance;
-        component.ngOnInit();
+        fixture.detectChanges();
     });
 
     afterEach(() => {
-        component.ngOnDestroy();
         fixture.destroy();
+    });
+
+    it('shows selected drives out of available drives', () => {
+        const driveFilterButton = Array.from<HTMLElement>(fixture.nativeElement.querySelectorAll('button')).find((button) => button.textContent?.includes('Drives ('));
+
+        expect(driveFilterButton?.textContent).toContain('Drives (0/19)');
+        expect(driveFilterButton?.textContent).not.toContain(`/${component.temperatureSelection.maxSelected})`);
     });
 
     it('binds loaded temperature data before the lazy chart instance exists', () => {


### PR DESCRIPTION
## Summary

- Show selected temperature drives out of available drives instead of the 20-drive selection cap.
- Add a rendered regression test for a dashboard with 19 drives.

## Root cause

The selector label used `temperatureSelection.maxSelected` as its denominator. That value limits selection to 20 drives; it does not represent available drive count. The label now uses `temperatureDevices.length`.

## Linked Issues

- Linear: SCR-6
- Follow-up reported in #694

## Test plan

- `npm test -- --watch=false --browsers=ChromeHeadless --include='src/app/modules/dashboard/dashboard.component.spec.ts'`
- `npm test -- --watch=false --browsers=ChromeHeadless`
- `npm run lint`
- `npm run build:prod`
- `git diff --check`
