### PR TITLE
[SCR-8] v1.0.0 — Complete GitHub issue 674 feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,8 +36,13 @@ All notable changes to Scrutiny will be documented in this file.
 
 ## Unreleased
 
+### Features
+
+* **dashboard:** add global host search and host-count pagination that keeps each host's SMART devices together ([#674](https://github.com/Starosdev/scrutiny/issues/674))
+
 ### Bug Fixes
 
+* **dashboard:** retain the current page after device archive actions and remove MDADM cards from the SMART dashboard ([#674](https://github.com/Starosdev/scrutiny/issues/674))
 * **smart:** skip generic HDD observed-threshold scoring for vendor-specific ATA SSD attributes and add a Crucial RealSSD compatibility profile ([#587](https://github.com/Starosdev/scrutiny/issues/587))
 
 ## [1.65.0](https://github.com/Starosdev/scrutiny/compare/v1.64.0...v1.65.0) (2026-06-29)

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Full credit for the original vision and architecture goes to [AnalogJ](https://g
 - **HTML Email Notifications** - Rich HTML emails with plain-text fallback for reports, test notifications, collector errors, missed ping digests, and other alert emails over SMTP
 - **Enhanced Seagate Drive Support** - Better timeout handling and FARM log collection for Seagate drives
 - **Workload Insights** - Visualize daily read/write rates, I/O intensity, SSD endurance, and activity spike detection
-- **SMART Host Management** - Search collector hosts and bulk archive, unarchive, or safely purge their devices
+- **SMART Host Management** - Search hosts across the SMART dashboard, keep each host's devices together during pagination, and bulk archive, unarchive, or safely purge devices
 - **Home Assistant MQTT Discovery** - Native MQTT integration for automatic device discovery in Home Assistant
 - **UI-Configurable Notification URLs** - Add, edit, test, and delete notification endpoints directly in the web UI
 - **Uptime Kuma Push Monitor** - Dedicated push-based integration for Uptime Kuma status monitoring
@@ -151,7 +151,7 @@ These S.M.A.R.T hard drive self-tests can help you detect and replace failing ha
 - **Missed Ping Digest** - Batch notification when multiple collectors go unreachable
 - **HTML Email Notifications** - Rich HTML formatting with plain-text fallback for SMTP notifications, including reports, test notifications, collector errors, missed ping digests, heartbeat, performance degradation, replacement risk, and MDADM degradation alerts
 - **Workload Insights** - Daily read/write rates, R/W ratio, I/O intensity classification, SSD endurance tracking, and activity spike detection
-- **SMART Host Management** - Bulk archive, unarchive, and confirmed permanent purge with shared-WWN protection ([operator guide](docs/HOST_MANAGEMENT.md))
+- **SMART Host Management** - Global dashboard host search, host-count pagination, and bulk archive, unarchive, or confirmed permanent purge with shared-WWN protection ([operator guide](docs/HOST_MANAGEMENT.md))
 - **Consumer Drive Profiles** - Apply vetted ATA HDD and SSD profiles based on Backblaze-informed thresholds, with opt-out controls and replacement-risk transparency
 - **Filesystem Capacity Monitoring** - Track logical filesystem free space independently from SMART device health
 - **MDADM Monitoring** - Monitor Linux software RAID arrays with a dedicated collector
@@ -326,6 +326,14 @@ drive that Scrutiny detected. The collector is configured to run once a day, but
 
 For users of the docker Hub/Spoke deployment or manual install: initially the dashboard will be empty.
 After the first collector run, you'll be greeted with a list of all your hard drives and their current smart status.
+
+### SMART Dashboard Navigation
+
+The SMART dashboard paginates by host so every device reported by one host stays on the same page. Open Dashboard Settings to select 5, 10, 25, or 50 hosts per page; the default is 10. Use **Search hosts** to filter host IDs across all pages before pagination.
+
+Archiving, unarchiving, or deleting a device reloads the current page. Scrutiny moves to the last valid page only when the current page no longer exists. MDADM arrays remain available from the dedicated MDADM page and do not appear among SMART device cards.
+
+See [SMART Host Management](docs/HOST_MANAGEMENT.md) for host archive and purge behavior.
 
 ```bash
 docker exec scrutiny /opt/scrutiny/bin/scrutiny-collector-metrics run

--- a/docs/HOST_MANAGEMENT.md
+++ b/docs/HOST_MANAGEMENT.md
@@ -4,6 +4,14 @@ Scrutiny groups SMART devices by non-empty collector `host_id` values. Open **Ho
 
 The host page does not include ZFS pools, MDADM arrays, Btrfs filesystems, filesystem-capacity records, or devices whose collector did not send a host ID.
 
+## SMART dashboard navigation
+
+The SMART dashboard pages by host instead of by device. All SMART devices assigned to one host remain together on the same page. Dashboard Settings provides 5, 10, 25, and 50 hosts-per-page options; the default is 10.
+
+Use **Search hosts** on the SMART dashboard to filter host IDs across the full active or archived result set. Search is case-insensitive and runs before pagination.
+
+Archiving, unarchiving, or deleting a device reloads the current page. If that page no longer exists, Scrutiny loads the last valid page. MDADM arrays remain on the dedicated MDADM page.
+
 ## Archive and unarchive
 
 Archiving a host marks every SMART device currently assigned to that host as archived. Device metadata and time-series history remain stored. Unarchiving restores every device assigned to that host.

--- a/docs/MDADM_MONITORING.md
+++ b/docs/MDADM_MONITORING.md
@@ -2,6 +2,8 @@
 
 Scrutiny supports Linux software RAID arrays managed by `mdadm`.
 
+MDADM arrays appear on the dedicated MDADM page. The SMART dashboard contains SMART device cards only, so MDADM arrays do not affect SMART host search or host-count pagination.
+
 This guide covers:
 
 - omnibus deployments where the collector runs inside the main Scrutiny container
@@ -105,7 +107,7 @@ docker exec -it scrutiny /opt/scrutiny/bin/scrutiny-collector-mdadm run --debug
 curl -s http://localhost:8080/api/mdadm/summary | jq .
 ```
 
-4. Open the MDADM page in the UI and verify the arrays show a state and size, not just static metadata.
+4. Open the dedicated MDADM page in the UI and verify the arrays show a state and size, not just static metadata.
 
 Upgrade note:
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -174,7 +174,7 @@ paths:
     get:
       tags: [Devices]
       summary: Get dashboard device summary
-      description: Without `page`, returns the legacy unpaginated summary. Supplying `page` enables global device pagination while retaining host-first ordering.
+      description: Without `page`, returns the legacy unpaginated summary. Supplying `page` enables pagination. Set `group_by=host` to paginate hosts while keeping all devices for each selected host together.
       parameters:
         - name: page
           in: query
@@ -186,8 +186,14 @@ paths:
           in: query
           schema:
             type: integer
-            enum: [25, 50, 100, 250]
-          description: Devices per page. Defaults to the saved dashboard setting.
+            enum: [5, 10, 25, 50, 100, 250]
+          description: Hosts per page when `group_by=host` (5, 10, 25, or 50); otherwise devices per page (25, 50, 100, or 250). Defaults to the matching saved dashboard setting.
+        - name: group_by
+          in: query
+          schema:
+            type: string
+            enum: [host]
+          description: Set to `host` to paginate by host count and keep every device for a selected host on the same page.
         - name: archived
           in: query
           schema:
@@ -206,6 +212,11 @@ paths:
             type: string
             enum: [name, serial_id, uuid, label]
           description: Title source used by title sorting. Defaults to the saved dashboard setting.
+        - name: host
+          in: query
+          schema:
+            type: string
+          description: Case-insensitive host ID substring applied before pagination.
       responses:
         "200":
           description: Device summary payload
@@ -2067,6 +2078,10 @@ components:
           type: integer
           enum: [25, 50, 100, 250]
           default: 25
+        dashboard_host_page_size:
+          type: integer
+          enum: [5, 10, 25, 50]
+          default: 10
         temperature_unit:
           type: string
         line_stroke:
@@ -3039,7 +3054,7 @@ components:
           minimum: 1
         page_size:
           type: integer
-          enum: [25, 50, 100, 250]
+          enum: [5, 10, 25, 50, 100, 250]
         total_items:
           type: integer
           minimum: 0

--- a/webapp/backend/pkg/database/scrutiny_repository_migrations.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_migrations.go
@@ -641,6 +641,17 @@ func (sr *scrutinyRepository) Migrate(ctx context.Context) error {
 				return sr.migrateM20260803000000(ctx, tx)
 			},
 		},
+		{
+			ID: "m20260809000000", // add host-count dashboard page size setting (#674)
+			Migrate: func(tx *gorm.DB) error {
+				return tx.Create(&m20220716214900.Setting{
+					SettingKeyName:        "dashboard_host_page_size",
+					SettingKeyDescription: "Number of SMART dashboard hosts per page (5 | 10 | 25 | 50)",
+					SettingDataType:       "numeric",
+					SettingValueNumeric:   10,
+				}).Error
+			},
+		},
 	})
 
 	if err := m.Migrate(); err != nil {

--- a/webapp/backend/pkg/database/scrutiny_repository_migrations_test.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_migrations_test.go
@@ -529,6 +529,17 @@ func TestMigrateAddsDashboardPageSizeSetting(t *testing.T) {
 	require.Equal(t, 25, setting.SettingValueNumeric)
 }
 
+func TestMigrateAddsDashboardHostPageSizeSetting(t *testing.T) {
+	repo := createMigrationTestRepository(t)
+
+	require.NoError(t, repo.Migrate(context.Background()))
+
+	var setting models.SettingEntry
+	require.NoError(t, repo.gormClient.Where("setting_key_name = ?", "dashboard_host_page_size").First(&setting).Error)
+	require.Equal(t, "numeric", setting.SettingDataType)
+	require.Equal(t, 10, setting.SettingValueNumeric)
+}
+
 func TestMigrateEnablesTemperatureHistoryStorage(t *testing.T) {
 	repo := createMigrationTestRepository(t)
 

--- a/webapp/backend/pkg/database/scrutiny_repository_summary_page.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_summary_page.go
@@ -9,12 +9,20 @@ import (
 )
 
 const defaultDashboardPageSize = 25
+const defaultDashboardHostPageSize = 10
 
 var validDashboardPageSizes = map[int]struct{}{
 	25:  {},
 	50:  {},
 	100: {},
 	250: {},
+}
+
+var validDashboardHostPageSizes = map[int]struct{}{
+	5:  {},
+	10: {},
+	25: {},
+	50: {},
 }
 
 func (sr *scrutinyRepository) GetSummaryPage(ctx context.Context, options models.DeviceSummaryPageOptions) (*models.DeviceSummaryPage, error) {
@@ -30,11 +38,12 @@ func (sr *scrutinyRepository) GetSummaryPage(ctx context.Context, options models
 func buildSummaryPage(summaries map[string]*models.DeviceSummary, options models.DeviceSummaryPageOptions) *models.DeviceSummaryPage {
 	ordered := make([]*models.DeviceSummary, 0, len(summaries))
 	attentionCount := 0
+	hostSearch := strings.ToLower(strings.TrimSpace(options.HostSearch))
 	for _, summary := range summaries {
 		if !summary.Device.Archived && summary.Device.DeviceStatus > 0 {
 			attentionCount++
 		}
-		if summary.Device.Archived == options.Archived {
+		if summary.Device.Archived == options.Archived && (hostSearch == "" || strings.Contains(strings.ToLower(summary.Device.HostId), hostSearch)) {
 			ordered = append(ordered, summary)
 		}
 	}
@@ -44,18 +53,34 @@ func buildSummaryPage(summaries map[string]*models.DeviceSummary, options models
 	})
 
 	totalItems := len(ordered)
+	if options.GroupByHost {
+		hosts := make([]string, 0)
+		seenHosts := make(map[string]struct{})
+		for _, summary := range ordered {
+			if _, seen := seenHosts[summary.Device.HostId]; seen {
+				continue
+			}
+			seenHosts[summary.Device.HostId] = struct{}{}
+			hosts = append(hosts, summary.Device.HostId)
+		}
+
+		totalItems = len(hosts)
+		start, end := summaryPageBounds(totalItems, options.Page, options.PageSize)
+		selectedHosts := make(map[string]struct{}, end-start)
+		for _, host := range hosts[start:end] {
+			selectedHosts[host] = struct{}{}
+		}
+		ordered = summariesForHosts(ordered, selectedHosts)
+	}
+
 	totalPages := 0
 	if totalItems > 0 {
 		totalPages = (totalItems + options.PageSize - 1) / options.PageSize
 	}
 
-	start := (options.Page - 1) * options.PageSize
-	if start > totalItems {
-		start = totalItems
-	}
-	end := start + options.PageSize
-	if end > totalItems {
-		end = totalItems
+	start, end := 0, len(ordered)
+	if !options.GroupByHost {
+		start, end = summaryPageBounds(totalItems, options.Page, options.PageSize)
 	}
 
 	pageSummaries := make(map[string]*models.DeviceSummary, end-start)
@@ -75,15 +100,45 @@ func buildSummaryPage(summaries map[string]*models.DeviceSummary, options models
 	}
 }
 
+func summaryPageBounds(totalItems, page, pageSize int) (int, int) {
+	start := (page - 1) * pageSize
+	if start > totalItems {
+		start = totalItems
+	}
+	end := start + pageSize
+	if end > totalItems {
+		end = totalItems
+	}
+	return start, end
+}
+
+func summariesForHosts(summaries []*models.DeviceSummary, hosts map[string]struct{}) []*models.DeviceSummary {
+	selected := make([]*models.DeviceSummary, 0)
+	for _, summary := range summaries {
+		if _, ok := hosts[summary.Device.HostId]; ok {
+			selected = append(selected, summary)
+		}
+	}
+	return selected
+}
+
 func normalizeSummaryPageOptions(sr *scrutinyRepository, options *models.DeviceSummaryPageOptions) {
 	if options.Page < 1 {
 		options.Page = 1
 	}
-	if _, ok := validDashboardPageSizes[options.PageSize]; !ok {
-		options.PageSize = sr.appConfig.GetInt("user.dashboard_page_size")
+	validPageSizes := validDashboardPageSizes
+	settingKey := "user.dashboard_page_size"
+	defaultPageSize := defaultDashboardPageSize
+	if options.GroupByHost {
+		validPageSizes = validDashboardHostPageSizes
+		settingKey = "user.dashboard_host_page_size"
+		defaultPageSize = defaultDashboardHostPageSize
 	}
-	if _, ok := validDashboardPageSizes[options.PageSize]; !ok {
-		options.PageSize = defaultDashboardPageSize
+	if _, ok := validPageSizes[options.PageSize]; !ok {
+		options.PageSize = sr.appConfig.GetInt(settingKey)
+	}
+	if _, ok := validPageSizes[options.PageSize]; !ok {
+		options.PageSize = defaultPageSize
 	}
 	if options.Sort == "" {
 		options.Sort = sr.appConfig.GetString("user.dashboard_sort")

--- a/webapp/backend/pkg/database/scrutiny_repository_summary_page_test.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_summary_page_test.go
@@ -80,3 +80,54 @@ func TestBuildSummaryPageFiltersSlicesAndCountsAttention(t *testing.T) {
 	require.Contains(t, page.Summary, "device-026")
 	require.Contains(t, page.Summary, "device-050")
 }
+
+func TestBuildSummaryPageFiltersHostsBeforePagination(t *testing.T) {
+	summaries := map[string]*models.DeviceSummary{
+		"alpha-1": {Device: models.Device{DeviceID: "alpha-1", HostId: "Alpha"}},
+		"alpha-2": {Device: models.Device{DeviceID: "alpha-2", HostId: "Alpha"}},
+		"beta-1":  {Device: models.Device{DeviceID: "beta-1", HostId: "Beta"}},
+	}
+
+	page := buildSummaryPage(summaries, models.DeviceSummaryPageOptions{
+		Page:       1,
+		PageSize:   25,
+		HostSearch: " alp ",
+	})
+
+	require.Equal(t, 2, page.Pagination.TotalItems)
+	require.Contains(t, page.Summary, "alpha-1")
+	require.Contains(t, page.Summary, "alpha-2")
+	require.NotContains(t, page.Summary, "beta-1")
+}
+
+func TestBuildSummaryPagePaginatesHostsWithoutSplittingDevices(t *testing.T) {
+	summaries := map[string]*models.DeviceSummary{
+		"host-1-a": {Device: models.Device{DeviceID: "host-1-a", HostId: "host-1"}},
+		"host-1-b": {Device: models.Device{DeviceID: "host-1-b", HostId: "host-1"}},
+		"host-2":   {Device: models.Device{DeviceID: "host-2", HostId: "host-2"}},
+		"host-3":   {Device: models.Device{DeviceID: "host-3", HostId: "host-3"}},
+		"host-4":   {Device: models.Device{DeviceID: "host-4", HostId: "host-4"}},
+		"host-5":   {Device: models.Device{DeviceID: "host-5", HostId: "host-5"}},
+		"host-6":   {Device: models.Device{DeviceID: "host-6", HostId: "host-6"}},
+	}
+
+	firstPage := buildSummaryPage(summaries, models.DeviceSummaryPageOptions{
+		Page:        1,
+		PageSize:    5,
+		GroupByHost: true,
+	})
+
+	require.Len(t, firstPage.Summary, 6)
+	require.Equal(t, 6, firstPage.Pagination.TotalItems)
+	require.Equal(t, 2, firstPage.Pagination.TotalPages)
+	require.Contains(t, firstPage.Summary, "host-1-a")
+	require.Contains(t, firstPage.Summary, "host-1-b")
+	require.NotContains(t, firstPage.Summary, "host-6")
+
+	secondPage := buildSummaryPage(summaries, models.DeviceSummaryPageOptions{
+		Page:        2,
+		PageSize:    5,
+		GroupByHost: true,
+	})
+	require.Equal(t, map[string]*models.DeviceSummary{"host-6": summaries["host-6"]}, secondPage.Summary)
+}

--- a/webapp/backend/pkg/models/device_summary.go
+++ b/webapp/backend/pkg/models/device_summary.go
@@ -23,11 +23,13 @@ type PaginationMetadata struct {
 }
 
 type DeviceSummaryPageOptions struct {
-	Sort     string
-	Display  string
-	Page     int
-	PageSize int
-	Archived bool
+	Sort        string
+	Display     string
+	HostSearch  string
+	Page        int
+	PageSize    int
+	Archived    bool
+	GroupByHost bool
 }
 
 type DeviceSummaryPage struct {

--- a/webapp/backend/pkg/models/settings.go
+++ b/webapp/backend/pkg/models/settings.go
@@ -42,19 +42,20 @@ type Settings struct {
 		ReportPDFEnabled              bool   `json:"report_pdf_enabled" mapstructure:"report_pdf_enabled"`
 		NotifyOnCollectorError        bool   `json:"notify_on_collector_error" mapstructure:"notify_on_collector_error"`
 	} `json:"metrics" mapstructure:"metrics"`
-	Theme              string `json:"theme" mapstructure:"theme"`
-	Layout             string `json:"layout" mapstructure:"layout"`
-	DashboardDisplay   string `json:"dashboard_display" mapstructure:"dashboard_display"`
-	DashboardSort      string `json:"dashboard_sort" mapstructure:"dashboard_sort"`
-	DashboardDensity   string `json:"dashboard_density" mapstructure:"dashboard_density"`
-	TemperatureUnit    string `json:"temperature_unit" mapstructure:"temperature_unit"`
-	LineStroke         string `json:"line_stroke" mapstructure:"line_stroke"`
-	PoweredOnHoursUnit string `json:"powered_on_hours_unit" mapstructure:"powered_on_hours_unit"`
-	TimeFormat         string `json:"time_format" mapstructure:"time_format"`
-	DashboardColumns   int    `json:"dashboard_columns" mapstructure:"dashboard_columns"`
-	DashboardPageSize  int    `json:"dashboard_page_size" mapstructure:"dashboard_page_size"`
-	FileSizeSIUnits    bool   `json:"file_size_si_units" mapstructure:"file_size_si_units"`
-	Collector          struct {
+	Theme                 string `json:"theme" mapstructure:"theme"`
+	Layout                string `json:"layout" mapstructure:"layout"`
+	DashboardDisplay      string `json:"dashboard_display" mapstructure:"dashboard_display"`
+	DashboardSort         string `json:"dashboard_sort" mapstructure:"dashboard_sort"`
+	DashboardDensity      string `json:"dashboard_density" mapstructure:"dashboard_density"`
+	TemperatureUnit       string `json:"temperature_unit" mapstructure:"temperature_unit"`
+	LineStroke            string `json:"line_stroke" mapstructure:"line_stroke"`
+	PoweredOnHoursUnit    string `json:"powered_on_hours_unit" mapstructure:"powered_on_hours_unit"`
+	TimeFormat            string `json:"time_format" mapstructure:"time_format"`
+	DashboardColumns      int    `json:"dashboard_columns" mapstructure:"dashboard_columns"`
+	DashboardPageSize     int    `json:"dashboard_page_size" mapstructure:"dashboard_page_size"`
+	DashboardHostPageSize int    `json:"dashboard_host_page_size" mapstructure:"dashboard_host_page_size"`
+	FileSizeSIUnits       bool   `json:"file_size_si_units" mapstructure:"file_size_si_units"`
+	Collector             struct {
 		RetrieveSCTHistory bool `json:"retrieve_sct_temperature_history" mapstructure:"retrieve_sct_temperature_history"`
 		StoreTempHistory   bool `json:"store_temperature_history" mapstructure:"store_temperature_history"`
 	} `json:"collector" mapstructure:"collector"` // Missed collector ping notification settings
@@ -106,6 +107,7 @@ func (s *Settings) ApplyDefaults() {
 	defaultStr(&s.TimeFormat, "24")
 	defaultInt(&s.DashboardColumns, 2)
 	defaultInt(&s.DashboardPageSize, 25)
+	defaultInt(&s.DashboardHostPageSize, 10)
 
 	// Metrics: numeric fields where 0 is not a valid value.
 	// Note: StatusFilterAttributes defaults to 0 (All), which is the zero value, so no check needed.

--- a/webapp/backend/pkg/web/handler/get_devices_summary.go
+++ b/webapp/backend/pkg/web/handler/get_devices_summary.go
@@ -62,9 +62,16 @@ func getPaginatedDevicesSummary(c *gin.Context, logger *logrus.Entry, deviceRepo
 
 func parseSummaryPageOptions(c *gin.Context) (models.DeviceSummaryPageOptions, error) {
 	options := models.DeviceSummaryPageOptions{
-		Archived: false,
-		Sort:     c.Query("sort"),
-		Display:  c.Query("display"),
+		Archived:   false,
+		Sort:       c.Query("sort"),
+		Display:    c.Query("display"),
+		HostSearch: c.Query("host"),
+	}
+	if groupBy := c.Query("group_by"); groupBy != "" {
+		if groupBy != "host" {
+			return options, fmt.Errorf("group_by must be host")
+		}
+		options.GroupByHost = true
 	}
 
 	page, err := strconv.Atoi(c.Query("page"))
@@ -75,8 +82,11 @@ func parseSummaryPageOptions(c *gin.Context) (models.DeviceSummaryPageOptions, e
 
 	if pageSizeValue, exists := c.GetQuery("page_size"); exists {
 		pageSize, parseErr := strconv.Atoi(pageSizeValue)
-		if parseErr != nil || !validSummaryPageSize(pageSize) {
+		if parseErr != nil || (!options.GroupByHost && !validSummaryPageSize(pageSize)) {
 			return options, fmt.Errorf("page_size must be one of 25, 50, 100, or 250")
+		}
+		if options.GroupByHost && !validSummaryHostPageSize(pageSize) {
+			return options, fmt.Errorf("page_size must be one of 5, 10, 25, or 50 when group_by=host")
 		}
 		options.PageSize = pageSize
 	}
@@ -101,6 +111,10 @@ func parseSummaryPageOptions(c *gin.Context) (models.DeviceSummaryPageOptions, e
 
 func validSummaryPageSize(pageSize int) bool {
 	return pageSize == 25 || pageSize == 50 || pageSize == 100 || pageSize == 250
+}
+
+func validSummaryHostPageSize(pageSize int) bool {
+	return pageSize == 5 || pageSize == 10 || pageSize == 25 || pageSize == 50
 }
 
 func validSummarySort(sort string) bool {

--- a/webapp/backend/pkg/web/handler/get_devices_summary_test.go
+++ b/webapp/backend/pkg/web/handler/get_devices_summary_test.go
@@ -51,11 +51,13 @@ func TestGetDevicesSummaryReturnsPaginatedResponse(t *testing.T) {
 	t.Cleanup(mockCtrl.Finish)
 	repo := mock_database.NewMockDeviceRepo(mockCtrl)
 	options := models.DeviceSummaryPageOptions{
-		Page:     2,
-		PageSize: 50,
-		Archived: true,
-		Sort:     "title_asc",
-		Display:  "label",
+		Page:        2,
+		PageSize:    10,
+		Archived:    true,
+		Sort:        "title_asc",
+		Display:     "label",
+		HostSearch:  "alpha",
+		GroupByHost: true,
 	}
 	page := &models.DeviceSummaryPage{
 		Summary: map[string]*models.DeviceSummary{
@@ -63,7 +65,7 @@ func TestGetDevicesSummaryReturnsPaginatedResponse(t *testing.T) {
 		},
 		Pagination: models.PaginationMetadata{
 			Page:           2,
-			PageSize:       50,
+			PageSize:       10,
 			TotalItems:     75,
 			TotalPages:     2,
 			AttentionCount: 3,
@@ -72,7 +74,7 @@ func TestGetDevicesSummaryReturnsPaginatedResponse(t *testing.T) {
 	repo.EXPECT().GetSummaryPage(gomock.Any(), options).Return(page, nil)
 
 	response := httptest.NewRecorder()
-	request, _ := http.NewRequest(http.MethodGet, "/api/summary?page=2&page_size=50&archived=true&sort=title_asc&display=label", nil)
+	request, _ := http.NewRequest(http.MethodGet, "/api/summary?page=2&page_size=10&group_by=host&archived=true&sort=title_asc&display=label&host=alpha", nil)
 	setupSummaryRouter(t, repo).ServeHTTP(response, request)
 
 	require.Equal(t, http.StatusOK, response.Code)
@@ -89,6 +91,8 @@ func TestGetDevicesSummaryRejectsInvalidPagination(t *testing.T) {
 		"/api/summary?page=0",
 		"/api/summary?page=one",
 		"/api/summary?page=1&page_size=10",
+		"/api/summary?page=1&page_size=100&group_by=host",
+		"/api/summary?page=1&group_by=unknown",
 		"/api/summary?page=1&archived=maybe",
 		"/api/summary?page=1&sort=unknown",
 		"/api/summary?page=1&display=unknown",

--- a/webapp/backend/pkg/web/handler/save_settings.go
+++ b/webapp/backend/pkg/web/handler/save_settings.go
@@ -25,6 +25,10 @@ func SaveSettings(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": "dashboard_page_size must be one of 25, 50, 100, or 250"})
 		return
 	}
+	if !validSummaryHostPageSize(settings.DashboardHostPageSize) {
+		c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": "dashboard_host_page_size must be one of 5, 10, 25, or 50"})
+		return
+	}
 
 	err = deviceRepo.SaveSettings(c, settings)
 	if err != nil {

--- a/webapp/backend/pkg/web/handler/settings_test.go
+++ b/webapp/backend/pkg/web/handler/settings_test.go
@@ -109,3 +109,19 @@ func TestSaveSettingsRejectsUnsupportedDashboardPageSize(t *testing.T) {
 	require.Equal(t, http.StatusBadRequest, response.Code)
 	require.Contains(t, response.Body.String(), "dashboard_page_size")
 }
+
+func TestSaveSettingsRejectsUnsupportedDashboardHostPageSize(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	t.Cleanup(mockCtrl.Finish)
+	mockRepo := mock_database.NewMockDeviceRepo(mockCtrl)
+	router := setupSettingsRouter(t, mockRepo, true)
+
+	body := strings.NewReader(`{"dashboard_host_page_size": 100}`)
+	response := httptest.NewRecorder()
+	request, _ := http.NewRequest(http.MethodPost, "/api/settings", body)
+	request.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(response, request)
+
+	require.Equal(t, http.StatusBadRequest, response.Code)
+	require.Contains(t, response.Body.String(), "dashboard_host_page_size")
+}

--- a/webapp/frontend/src/app/core/config/app.config.ts
+++ b/webapp/frontend/src/app/core/config/app.config.ts
@@ -11,6 +11,7 @@ export type DashboardColumns = 2 | 3 | 4 | 5;
 export type DashboardDensity = 'comfortable' | 'compact';
 
 export type DashboardPageSize = 25 | 50 | 100 | 250;
+export type DashboardHostPageSize = 5 | 10 | 25 | 50;
 
 export type DashboardSort =
     | 'status'
@@ -105,6 +106,7 @@ export interface AppConfig {
     dashboard_columns?: DashboardColumns;
     dashboard_density?: DashboardDensity;
     dashboard_page_size?: DashboardPageSize;
+    dashboard_host_page_size?: DashboardHostPageSize;
 
     temperature_unit?: TemperatureUnit;
 
@@ -193,6 +195,7 @@ export const appConfig: AppConfig = {
     dashboard_columns: 2,
     dashboard_density: 'comfortable',
     dashboard_page_size: 25,
+    dashboard_host_page_size: 10,
 
     temperature_unit: 'celsius',
     file_size_si_units: false,

--- a/webapp/frontend/src/app/layout/common/dashboard-settings/dashboard-settings.component.html
+++ b/webapp/frontend/src/app/layout/common/dashboard-settings/dashboard-settings.component.html
@@ -80,14 +80,14 @@
             </mat-form-field>
 
             <mat-form-field class="flex-auto gt-xs:pr-3 gt-md:pl-3">
-                <mat-label>Devices Per Page</mat-label>
-                <mat-select [(ngModel)]="dashboardPageSize">
-                    <mat-option [value]="25">25 Devices</mat-option>
-                    <mat-option [value]="50">50 Devices</mat-option>
-                    <mat-option [value]="100">100 Devices</mat-option>
-                    <mat-option [value]="250">250 Devices</mat-option>
+                <mat-label>Hosts Per Page</mat-label>
+                <mat-select [(ngModel)]="dashboardHostPageSize">
+                    <mat-option [value]="5">5 Hosts</mat-option>
+                    <mat-option [value]="10">10 Hosts</mat-option>
+                    <mat-option [value]="25">25 Hosts</mat-option>
+                    <mat-option [value]="50">50 Hosts</mat-option>
                 </mat-select>
-                <mat-hint>Maximum SMART device cards rendered on one dashboard page.</mat-hint>
+                <mat-hint>All SMART devices for each host stay together.</mat-hint>
             </mat-form-field>
         </div>
 

--- a/webapp/frontend/src/app/layout/common/dashboard-settings/dashboard-settings.component.ts
+++ b/webapp/frontend/src/app/layout/common/dashboard-settings/dashboard-settings.component.ts
@@ -4,7 +4,7 @@ import {
     AppConfig,
     DashboardColumns,
     DashboardDensity,
-    DashboardPageSize,
+    DashboardHostPageSize,
     AttributeOverride,
     DashboardDisplay,
     DashboardSort,
@@ -92,7 +92,7 @@ export class DashboardSettingsComponent implements OnInit {
     dashboardSort: DashboardSort;
     dashboardColumns: DashboardColumns;
     dashboardDensity: DashboardDensity;
-    dashboardPageSize: DashboardPageSize;
+    dashboardHostPageSize: DashboardHostPageSize;
     temperatureUnit: string;
     fileSizeSIUnits: boolean;
     poweredOnHoursUnit: string;
@@ -216,7 +216,7 @@ export class DashboardSettingsComponent implements OnInit {
             this.dashboardSort = config.dashboard_sort;
             this.dashboardColumns = config.dashboard_columns;
             this.dashboardDensity = config.dashboard_density;
-            this.dashboardPageSize = config.dashboard_page_size;
+            this.dashboardHostPageSize = config.dashboard_host_page_size ?? 10;
             this.temperatureUnit = config.temperature_unit;
             this.fileSizeSIUnits = config.file_size_si_units;
             this.poweredOnHoursUnit = config.powered_on_hours_unit;
@@ -542,7 +542,7 @@ export class DashboardSettingsComponent implements OnInit {
             dashboard_sort: this.dashboardSort as DashboardSort,
             dashboard_columns: this.dashboardColumns as DashboardColumns,
             dashboard_density: this.dashboardDensity as DashboardDensity,
-            dashboard_page_size: this.dashboardPageSize as DashboardPageSize,
+            dashboard_host_page_size: this.dashboardHostPageSize as DashboardHostPageSize,
             temperature_unit: this.temperatureUnit as TemperatureUnit,
             time_format: this.timeFormat as TimeFormat,
             file_size_si_units: this.fileSizeSIUnits,

--- a/webapp/frontend/src/app/modules/dashboard/dashboard.component.html
+++ b/webapp/frontend/src/app/modules/dashboard/dashboard.component.html
@@ -68,6 +68,18 @@
                 </div>
             </div>
 
+            <form class="flex flex-wrap items-center gap-3 w-full px-4 mb-4" (ngSubmit)="applyHostSearch()">
+                <mat-form-field appearance="outline" subscriptSizing="dynamic" class="w-full max-w-80">
+                    <mat-label>Search hosts</mat-label>
+                    <mat-icon matPrefix aria-hidden="true">search</mat-icon>
+                    <input matInput type="search" name="hostSearch" [(ngModel)]="hostSearch" autocomplete="off" />
+                </mat-form-field>
+                <button mat-flat-button color="primary" type="submit">Search</button>
+                @if (hostSearch || appliedHostSearch) {
+                <button mat-button type="button" (click)="clearHostSearch()">Clear</button>
+                }
+            </form>
+
             <!-- Device Groups -->
             @for (hostId of hostGroups | keyvalue; track hostId) {
             <div class="flex flex-wrap w-full mb-6">
@@ -112,71 +124,13 @@
                     [pageSize]="pagination.page_size"
                     [pageSizeOptions]="pageSizeOptions"
                     [showFirstLastButtons]="true"
-                    aria-label="Select SMART device page"
+                    aria-label="Select SMART host page"
                     (page)="onPageChange($event)"
                 >
                 </mat-paginator>
             </div>
 
-            <!-- MDADM RAID Arrays -->
-            @if (mdadmArrays.length > 0) {
-            <div class="flex flex-wrap w-full mb-6">
-                <div class="flex items-center ml-4 gap-3">
-                    <h3 class="m-0 uppercase tracking-wider text-secondary">MDADM RAID Arrays</h3>
-                </div>
-                <div class="flex flex-wrap w-full">
-                    @for (array of mdadmArrays; track array.uuid) {
-                    <div class="flex gt-sm:w-1/3 min-w-80 p-4">
-                        <a
-                            class="flex flex-col flex-auto bg-card shadow-md rounded p-6 hover:bg-hover transition-colors duration-150 ease-in-out cursor-pointer"
-                            [routerLink]="['/mdadm', array.uuid]"
-                        >
-                            <div class="flex items-center justify-between">
-                                <div class="flex items-center">
-                                    <div class="flex items-center justify-center w-10 h-10 rounded-full bg-blue-100 dark:bg-blue-900">
-                                        <mat-icon class="text-blue-600 dark:text-blue-400" [svgIcon]="'heroicons_outline:collection'"></mat-icon>
-                                    </div>
-                                    <div class="ml-4">
-                                        <div class="text-lg font-bold leading-none truncate">{{ array.label || array.name }}</div>
-                                        <div class="text-md text-secondary mt-1">{{ array.level }}</div>
-                                    </div>
-                                </div>
-                                <div class="px-2 py-1 rounded text-xs font-semibold uppercase" [ngClass]="getMdadmArrayStatusColorClass(array)">
-                                    {{ array.state || 'UNKNOWN' }}
-                                </div>
-                            </div>
-
-                            <!-- Sync Progress -->
-                            @if (array.sync_progress > 0 && array.sync_progress < 100) {
-                            <div class="flex flex-col mt-4">
-                                <div class="flex items-center justify-between text-secondary mb-1">
-                                    <div class="text-xs">Sync Progress</div>
-                                    <div class="text-xs font-medium text-blue-500">{{ array.sync_progress }}%</div>
-                                </div>
-                                <div class="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-1.5">
-                                    <div class="bg-blue-500 h-1.5 rounded-full transition-all duration-300" [style.width.%]="array.sync_progress"></div>
-                                </div>
-                            </div>
-                            }
-
-                            <!-- Array Size / Used -->
-                            @if (array.array_size) {
-                            <div class="flex items-center justify-between mt-4 text-secondary">
-                                <div class="text-xs">Array Size</div>
-                                <div class="text-xs font-medium">{{ array.array_size | fileSize : config?.file_size_si_units }}</div>
-                            </div>
-                            } @if (array.used_bytes !== undefined && array.used_bytes !== null) {
-                            <div class="flex items-center justify-between mt-1 text-secondary">
-                                <div class="text-xs">Used</div>
-                                <div class="text-xs font-medium">{{ array.used_bytes | fileSize : config?.file_size_si_units }}</div>
-                            </div>
-                            }
-                        </a>
-                    </div>
-                    }
-                </div>
-            </div>
-            } @if (hasFilesystemData()) {
+            @if (hasFilesystemData()) {
             <div class="flex flex-col w-full mb-6 px-4">
                 <div class="mb-4">
                     <div class="font-bold text-md text-secondary uppercase tracking-wider">Filesystem Capacity</div>

--- a/webapp/frontend/src/app/modules/dashboard/dashboard.component.spec.ts
+++ b/webapp/frontend/src/app/modules/dashboard/dashboard.component.spec.ts
@@ -4,7 +4,6 @@ import { Router } from '@angular/router';
 import { of } from 'rxjs';
 import { AppConfig } from 'app/core/config/app.config';
 import { ScrutinyConfigService } from 'app/core/config/scrutiny-config.service';
-import { MDADMService } from 'app/modules/mdadm/mdadm.service';
 import { DashboardComponent } from './dashboard.component';
 import { DashboardService } from './dashboard.service';
 import { TemperatureSelection } from './temperature-selection';
@@ -25,12 +24,12 @@ describe('DashboardComponent temperature chart', () => {
         };
         const temperatureSelection = new TemperatureSelection();
 
-        dashboardService = jasmine.createSpyObj('DashboardService', ['getTemperatureDeviceOptions', 'getSummaryTempData', 'getFilesystemSummaryData'], {
+        dashboardService = jasmine.createSpyObj('DashboardService', ['getSummaryPage', 'getTemperatureDeviceOptions', 'getSummaryTempData', 'getFilesystemSummaryData'], {
             pageData$: of({
                 summary: {},
                 pagination: {
                     page: 1,
-                    page_size: 25,
+                    page_size: 10,
                     total_items: 0,
                     total_pages: 0,
                     attention_count: 0,
@@ -56,12 +55,23 @@ describe('DashboardComponent temperature chart', () => {
             })
         );
         dashboardService.getFilesystemSummaryData.and.returnValue(of({ filesystems: {}, hosts: {} }));
+        dashboardService.getSummaryPage.and.returnValue(
+            of({
+                summary: {},
+                pagination: {
+                    page: 1,
+                    page_size: 10,
+                    total_items: 0,
+                    total_pages: 0,
+                    attention_count: 0,
+                },
+            })
+        );
 
         TestBed.configureTestingModule({
             imports: [DashboardComponent],
             providers: [
                 { provide: DashboardService, useValue: dashboardService },
-                { provide: MDADMService, useValue: { getSummaryData: () => of([]) } },
                 { provide: ScrutinyConfigService, useValue: { config$: of(config) } },
                 { provide: MatDialog, useValue: { open: jasmine.createSpy('open') } },
                 {
@@ -95,5 +105,54 @@ describe('DashboardComponent temperature chart', () => {
                 data: [{ x: new Date('2026-08-03T12:00:00Z'), y: 64 }],
             },
         ]);
+    });
+
+    it('keeps current page after archiving when that page still exists', () => {
+        component.pagination = {
+            page: 2,
+            page_size: 25,
+            total_items: 75,
+            total_pages: 3,
+            attention_count: 0,
+        };
+
+        component.onDeviceArchived('drive-1');
+
+        expect(dashboardService.getSummaryPage).toHaveBeenCalledWith(jasmine.objectContaining({ page: 2, groupBy: 'host', pageSize: 10 }));
+    });
+
+    it('loads the new last page after archiving empties the current page', () => {
+        const page = (currentPage: number, totalPages: number) =>
+            of({
+                summary: {},
+                pagination: {
+                    page: currentPage,
+                    page_size: 10,
+                    total_items: 20,
+                    total_pages: totalPages,
+                    attention_count: 0,
+                },
+            });
+        dashboardService.getSummaryPage.and.returnValues(page(3, 2), page(2, 2));
+        component.pagination = {
+            page: 3,
+            page_size: 10,
+            total_items: 21,
+            total_pages: 3,
+            attention_count: 0,
+        };
+
+        component.onDeviceArchived('drive-1');
+
+        expect(dashboardService.getSummaryPage.calls.argsFor(0)[0]).toEqual(jasmine.objectContaining({ page: 3 }));
+        expect(dashboardService.getSummaryPage.calls.argsFor(1)[0]).toEqual(jasmine.objectContaining({ page: 2 }));
+    });
+
+    it('applies trimmed host search across paginated dashboard results', () => {
+        component.hostSearch = ' host-42 ';
+
+        component.applyHostSearch();
+
+        expect(dashboardService.getSummaryPage).toHaveBeenCalledWith(jasmine.objectContaining({ page: 1, hostSearch: 'host-42' }));
     });
 });

--- a/webapp/frontend/src/app/modules/dashboard/dashboard.component.ts
+++ b/webapp/frontend/src/app/modules/dashboard/dashboard.component.ts
@@ -5,14 +5,12 @@ import { ApexOptions, ChartComponent } from 'ng-apexcharts';
 import { DashboardService } from 'app/modules/dashboard/dashboard.service';
 import { MatDialog as MatDialog } from '@angular/material/dialog';
 import { DashboardSettingsComponent } from 'app/layout/common/dashboard-settings/dashboard-settings.component';
-import { AppConfig, DashboardColumns, DashboardDensity, DashboardPageSize } from 'app/core/config/app.config';
+import { AppConfig, DashboardColumns, DashboardDensity, DashboardHostPageSize } from 'app/core/config/app.config';
 import { ScrutinyConfigService } from 'app/core/config/scrutiny-config.service';
-import { Router, RouterLink } from '@angular/router';
+import { Router } from '@angular/router';
 import { TemperaturePipe } from 'app/shared/temperature.pipe';
 import { DeviceTitlePipe } from 'app/shared/device-title.pipe';
 import { DeviceSummaryModel } from 'app/core/models/device-summary-model';
-import { MDADMService } from 'app/modules/mdadm/mdadm.service';
-import { MDADMArrayModel } from 'app/core/models/mdadm-array-model';
 import { FilesystemCapacityModel, FilesystemHostStatusModel } from 'app/core/models/filesystem-summary-model';
 import { MatButton, MatIconButton } from '@angular/material/button';
 import { MatIcon } from '@angular/material/icon';
@@ -31,6 +29,7 @@ import { DeviceSummaryPagination } from 'app/core/models/device-summary-response
 import { TemperatureDeviceOption } from 'app/core/models/device-summary-temp-response-wrapper';
 import { SmartTemperatureModel } from 'app/core/models/measurements/smart-temperature-model';
 import { MatInput } from '@angular/material/input';
+import { MatFormField, MatLabel, MatPrefix } from '@angular/material/form-field';
 import { FormsModule } from '@angular/forms';
 import { alignTemperatureChartSeries, TemperatureChartSeries } from './temperature-chart-series';
 import { createTemperatureChartTooltip } from './temperature-chart-tooltip';
@@ -59,7 +58,6 @@ const DASHBOARD_SHELL_WIDTHS: Record<DashboardColumns, string> = {
         MatMenu,
         MatMenuItem,
         DashboardDeviceComponent,
-        RouterLink,
         NgClass,
         MatCheckbox,
         MatDivider,
@@ -72,12 +70,14 @@ const DASHBOARD_SHELL_WIDTHS: Record<DashboardColumns, string> = {
         DeviceSortPipe,
         MatPaginator,
         MatInput,
+        MatFormField,
+        MatLabel,
+        MatPrefix,
         FormsModule,
     ],
 })
 export class DashboardComponent implements OnInit, OnDestroy {
     private readonly _dashboardService = inject(DashboardService);
-    private readonly _mdadmService = inject(MDADMService);
     private readonly _configService = inject(ScrutinyConfigService);
     private readonly _changeDetectorRef = inject(ChangeDetectorRef);
     private readonly _document = inject(DOCUMENT);
@@ -95,17 +95,18 @@ export class DashboardComponent implements OnInit, OnDestroy {
     temperatureDeviceSearch = '';
     temperatureHistory: { [deviceID: string]: SmartTemperatureModel[] } = {};
     readonly temperatureSelection = this._dashboardService.temperatureSelection;
-    mdadmArrays: MDADMArrayModel[] = [];
+    hostSearch = '';
+    appliedHostSearch = '';
     isTriggering: boolean = false;
     countdown: number = 0;
     pagination: DeviceSummaryPagination = {
         page: 1,
-        page_size: 25,
+        page_size: 10,
         total_items: 0,
         total_pages: 0,
         attention_count: 0,
     };
-    readonly pageSizeOptions: DashboardPageSize[] = [25, 50, 100, 250];
+    readonly pageSizeOptions: DashboardHostPageSize[] = [5, 10, 25, 50];
 
     // Private
     private readonly _unsubscribeAll: Subject<void>;
@@ -183,13 +184,6 @@ export class DashboardComponent implements OnInit, OnDestroy {
                 this._changeDetectorRef.markForCheck();
             });
 
-        // Get MDADM data
-        this._mdadmService
-            .getSummaryData()
-            .pipe(takeUntil(this._unsubscribeAll))
-            .subscribe((arrays) => {
-                this.mdadmArrays = arrays;
-            });
         this._dashboardService
             .getFilesystemSummaryData()
             .pipe(takeUntil(this._unsubscribeAll))
@@ -488,17 +482,19 @@ export class DashboardComponent implements OnInit, OnDestroy {
     }
 
     onDeviceDeleted(_deviceId: string): void {
-        const remainingItems = Math.max(0, this.pagination.total_items - 1);
-        const lastPage = Math.max(1, Math.ceil(remainingItems / this.pagination.page_size));
-        this.loadSummaryPage(Math.min(this.pagination.page, lastPage));
+        this.reloadAfterPageItemRemoval();
     }
 
     onDeviceArchived(_deviceId: string): void {
-        this.loadSummaryPage(1);
+        this.reloadAfterPageItemRemoval();
     }
 
     onDeviceUnarchived(_deviceId: string): void {
-        this.loadSummaryPage(1);
+        this.reloadAfterPageItemRemoval();
+    }
+
+    private reloadAfterPageItemRemoval(): void {
+        this.loadSummaryPage(this.pagination.page);
     }
 
     toggleArchived(): void {
@@ -507,25 +503,43 @@ export class DashboardComponent implements OnInit, OnDestroy {
     }
 
     onPageChange(event: PageEvent): void {
-        const pageSize = event.pageSize as DashboardPageSize;
+        const pageSize = event.pageSize as DashboardHostPageSize;
         if (pageSize !== this.pagination.page_size) {
-            this.config = { ...this.config, dashboard_page_size: pageSize };
-            this._configService.config = { dashboard_page_size: pageSize };
+            this.config = { ...this.config, dashboard_host_page_size: pageSize };
+            this._configService.config = { dashboard_host_page_size: pageSize };
         }
         this.loadSummaryPage(event.pageIndex + 1, pageSize);
     }
 
-    private loadSummaryPage(page: number, pageSize?: DashboardPageSize): void {
+    applyHostSearch(): void {
+        this.appliedHostSearch = this.hostSearch.trim();
+        this.loadSummaryPage(1);
+    }
+
+    clearHostSearch(): void {
+        this.hostSearch = '';
+        this.appliedHostSearch = '';
+        this.loadSummaryPage(1);
+    }
+
+    private loadSummaryPage(page: number, pageSize?: DashboardHostPageSize): void {
+        const effectivePageSize = pageSize ?? this.config?.dashboard_host_page_size ?? 10;
         this._dashboardService
             .getSummaryPage({
                 page,
-                pageSize: pageSize ?? (this.pagination.page_size as DashboardPageSize),
+                pageSize: effectivePageSize,
+                groupBy: 'host',
                 archived: this.showArchived,
                 sort: this.config?.dashboard_sort,
                 display: this.config?.dashboard_display,
+                hostSearch: this.appliedHostSearch,
             })
             .pipe(takeUntil(this._unsubscribeAll))
-            .subscribe();
+            .subscribe((response) => {
+                if (response.pagination.total_pages > 0 && page > response.pagination.total_pages) {
+                    this.loadSummaryPage(response.pagination.total_pages, effectivePageSize);
+                }
+            });
     }
 
     dashboardColumns(): DashboardColumns {
@@ -619,20 +633,6 @@ export class DashboardComponent implements OnInit, OnDestroy {
             return;
         }
         this.temperatureOptions = { ...this.temperatureOptions, series };
-    }
-
-    getMdadmArrayStatusColorClass(array: MDADMArrayModel): string {
-        const state = (array.state || '').toLowerCase();
-        if (state.includes('degraded') || state.includes('inactive')) {
-            return 'text-red-600 dark:text-red-400 bg-red-100 dark:bg-red-900';
-        }
-        if (state.includes('checking') || state.includes('resync') || state.includes('recover') || state.includes('rebuild')) {
-            return 'text-blue-600 dark:text-blue-400 bg-blue-100 dark:bg-blue-900';
-        }
-        if (state.includes('clean') || state.includes('active')) {
-            return 'text-green-600 dark:text-green-400 bg-green-100 dark:bg-green-900';
-        }
-        return 'text-gray-600 dark:text-gray-400 bg-gray-100 dark:bg-gray-800';
     }
 
     /**

--- a/webapp/frontend/src/app/modules/dashboard/dashboard.resolvers.ts
+++ b/webapp/frontend/src/app/modules/dashboard/dashboard.resolvers.ts
@@ -21,6 +21,6 @@ export class DashboardResolver {
      * @param state
      */
     resolve(_route: ActivatedRouteSnapshot, _state: RouterStateSnapshot): Observable<DeviceSummaryPage> {
-        return this._dashboardService.getSummaryPage({ page: 1 });
+        return this._dashboardService.getSummaryPage({ page: 1, groupBy: 'host' });
     }
 }

--- a/webapp/frontend/src/app/modules/dashboard/dashboard.service.spec.ts
+++ b/webapp/frontend/src/app/modules/dashboard/dashboard.service.spec.ts
@@ -38,7 +38,7 @@ describe('DashboardService', () => {
                 summary: summary.data.summary,
                 pagination: {
                     page: 2,
-                    page_size: 50,
+                    page_size: 10,
                     total_items: 75,
                     total_pages: 2,
                     attention_count: 4,
@@ -47,15 +47,17 @@ describe('DashboardService', () => {
         };
         httpClientSpy.get.and.returnValue(of(page));
 
-        service.getSummaryPage({ page: 2, pageSize: 50, archived: true, sort: 'title_asc', display: 'label' }).subscribe((value) => {
+        service.getSummaryPage({ page: 2, pageSize: 10, groupBy: 'host', archived: true, sort: 'title_asc', display: 'label', hostSearch: 'alpha' }).subscribe((value) => {
             expect(value).toEqual(page.data);
             expect(httpClientSpy.get).toHaveBeenCalledWith(jasmine.stringMatching(/\/api\/summary$/), {
                 params: {
                     page: '2',
                     archived: 'true',
-                    page_size: '50',
+                    page_size: '10',
+                    group_by: 'host',
                     sort: 'title_asc',
                     display: 'label',
+                    host: 'alpha',
                 },
             });
             done();

--- a/webapp/frontend/src/app/modules/dashboard/dashboard.service.ts
+++ b/webapp/frontend/src/app/modules/dashboard/dashboard.service.ts
@@ -8,15 +8,17 @@ import { DeviceSummaryModel } from 'app/core/models/device-summary-model';
 import { SmartTemperatureModel } from 'app/core/models/measurements/smart-temperature-model';
 import { DeviceSummaryTempResponseWrapper, TemperatureDeviceOption, TemperatureDeviceOptionsResponseWrapper } from 'app/core/models/device-summary-temp-response-wrapper';
 import { FilesystemSummaryResponseWrapper, FilesystemCapacityModel, FilesystemHostStatusModel } from 'app/core/models/filesystem-summary-model';
-import { DashboardDisplay, DashboardPageSize, DashboardSort } from 'app/core/config/app.config';
+import { DashboardDisplay, DashboardHostPageSize, DashboardPageSize, DashboardSort } from 'app/core/config/app.config';
 import { TemperatureSelection } from 'app/modules/dashboard/temperature-selection';
 
 export interface SummaryPageRequest {
     page: number;
-    pageSize?: DashboardPageSize;
+    pageSize?: DashboardPageSize | DashboardHostPageSize;
+    groupBy?: 'host';
     archived?: boolean;
     sort?: DashboardSort;
     display?: DashboardDisplay;
+    hostSearch?: string;
 }
 
 @Injectable({
@@ -82,11 +84,17 @@ export class DashboardService {
         if (request.pageSize) {
             params['page_size'] = request.pageSize.toString();
         }
+        if (request.groupBy) {
+            params['group_by'] = request.groupBy;
+        }
         if (request.sort) {
             params['sort'] = request.sort;
         }
         if (request.display) {
             params['display'] = request.display;
+        }
+        if (request.hostSearch) {
+            params['host'] = request.hostSearch;
         }
 
         return this._httpClient.get<DeviceSummaryResponseWrapper>(getBasePath() + '/api/summary', { params }).pipe(


### PR DESCRIPTION
## Summary

Implements final beta-tester feedback from issue #674 for large SMART deployments. Dashboard now searches across host IDs, paginates by host count, keeps every device for a host together, excludes MDADM arrays, and retains page position after archive actions.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

Closes #674

## Changes Made

- Add `group_by=host` summary pagination with persisted 5, 10, 25, or 50 hosts-per-page settings while preserving legacy device pagination.
- Add case-insensitive global host search before pagination and keep all SMART devices for each selected host together.
- Remove MDADM cards from SMART dashboard while retaining dedicated MDADM page.
- Preserve current page after archive, unarchive, or delete actions and fall back only when page no longer exists.
- Update README, host-management guide, MDADM guide, changelog, OpenAPI schema, and regression tests.

## Testing

- [x] I have tested this locally
- [x] I have added/updated tests that prove my fix/feature works
- [x] All existing tests pass

Validation:

- `go test ./...`
- `npm --prefix webapp/frontend test -- --watch=false --browsers=ChromeHeadless` (186 specs)
- `npm --prefix webapp/frontend run lint`
- OpenAPI YAML parse
- `git diff --check`

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary (particularly complex areas)
- [x] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [x] No console.log, debug statements, or commented-out code

## Screenshots (if applicable)

Not captured. Automated component tests cover pagination, host search, temperature selection, and archive-page behavior.

## Additional Notes

Legacy device-count pagination remains available through the existing API values 25, 50, 100, and 250. Dashboard UI uses additive host-count mode and defaults to 10 hosts per page.
