### PR TITLE
security(workflow): add OSV, SBOM, and IaC scans

### DIFF
--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -15,13 +15,13 @@ on:
 jobs:
   trivy-scan:
     name: Trivy Vulnerability Scan
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
       - name: Run Trivy vulnerability scanner (JSON)
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.36.0
@@ -33,11 +33,47 @@ jobs:
           severity: 'UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL'
           exit-code: '0'
 
+      - name: Generate CycloneDX SBOM
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.36.0
+        with:
+          scan-type: 'fs'
+          path: '.'
+          format: 'cyclonedx'
+          output: 'trivy-sbom.cdx.json'
+          exit-code: '0'
+
+      - name: Redact Trivy reports
+        if: always()
+        run: |
+          set -euo pipefail
+          artifact_dir="$RUNNER_TEMP/trivy-artifact"
+          mkdir -p "$artifact_dir"
+          redact='walk(
+            if type == "object" then
+              with_entries(
+                if (.key | ascii_downcase | test("secret|match|password|token|authorization|private[_-]?key"))
+                then .value = "[REDACTED]"
+                else .
+                end
+              )
+            else .
+            end
+          )'
+          if [[ -s trivy-summary.json ]]; then
+            jq "$redact" trivy-summary.json > "$artifact_dir/trivy.redacted.json"
+          else
+            printf '%s\n' '{"scanner":"trivy","status":"not-run"}' > "$artifact_dir/trivy.redacted.json"
+          fi
+          if [[ -s trivy-sbom.cdx.json ]]; then
+            jq "$redact" trivy-sbom.cdx.json > "$artifact_dir/trivy.sbom.cdx.redacted.json"
+          fi
+
       - name: Upload Trivy scan results
-        uses: actions/upload-artifact@v7
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: trivy-scan-results
-          path: trivy-summary.json
+          path: ${{ runner.temp }}/trivy-artifact
           retention-days: 7
           if-no-files-found: error
 
@@ -95,8 +131,127 @@ jobs:
               echo "  No critical vulnerabilities found"
             fi
           else
-            echo "  WARNING: No trivy-summary.json found - scan may have failed"
+            echo "  ERROR: No trivy-summary.json found - scanner failed"
+            exit 1
           fi
 
           echo ""
           echo "Security scan completed"
+
+  osv:
+    name: OSV Dependency Scan
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    env:
+      OSV_VERSION: 2.3.8
+      OSV_SHA256: bc98e15319ed0d515e3f9235287ba53cdc5535d576d24fd573978ecfe9ab92dc
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+
+      - name: Install OSV-Scanner
+        run: |
+          set -euo pipefail
+          binary="$RUNNER_TEMP/osv-scanner"
+          curl --fail --silent --show-error --location \
+            "https://github.com/google/osv-scanner/releases/download/v${OSV_VERSION}/osv-scanner_linux_amd64" \
+            --output "$binary"
+          printf '%s  %s\n' "$OSV_SHA256" "$binary" | sha256sum --check --status
+          chmod 0755 "$binary"
+
+      - name: Scan dependencies
+        id: scan
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          "$RUNNER_TEMP/osv-scanner" scan source -r "${{ github.workspace }}" \
+            --format json \
+            --output-file "$RUNNER_TEMP/osv.json"
+
+      - name: Redact report
+        if: always()
+        run: |
+          set -euo pipefail
+          if [[ -s "$RUNNER_TEMP/osv.json" ]]; then
+            jq '
+              walk(
+                if type == "object" then
+                  with_entries(
+                    if (.key | ascii_downcase | test("secret|match|password|token|authorization|private[_-]?key"))
+                    then .value = "[REDACTED]"
+                    else .
+                    end
+                  )
+                else .
+                end
+              )
+            ' "$RUNNER_TEMP/osv.json" > "$RUNNER_TEMP/osv.redacted.json"
+          else
+            printf '%s\n' '{"scanner":"osv","status":"not-run"}' > "$RUNNER_TEMP/osv.redacted.json"
+          fi
+
+      - name: Upload private report
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: osv-scan-results
+          path: ${{ runner.temp }}/osv.redacted.json
+          retention-days: 7
+          if-no-files-found: error
+
+      - name: Enforce scanner execution
+        if: always()
+        run: test -s "$RUNNER_TEMP/osv.json"
+
+  iac:
+    name: Trivy IaC Scan
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+
+      - name: Run Trivy IaC scanner (JSON)
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.36.0
+        with:
+          scan-type: 'config'
+          hide-progress: true
+          format: 'json'
+          output: 'trivy-iac-summary.json'
+          severity: 'CRITICAL,HIGH'
+          scanners: 'misconfig'
+          exit-code: '0'
+
+      - name: Redact Trivy IaC report
+        if: always()
+        run: |
+          set -euo pipefail
+          if [[ -s trivy-iac-summary.json ]]; then
+            jq '
+              walk(
+                if type == "object" then
+                  with_entries(
+                    if (.key | ascii_downcase | test("secret|match|password|token|authorization|private[_-]?key"))
+                    then .value = "[REDACTED]"
+                    else .
+                    end
+                  )
+                else .
+                end
+              )
+            ' trivy-iac-summary.json > "$RUNNER_TEMP/trivy-iac.redacted.json"
+          else
+            printf '%s\n' '{"scanner":"trivy","scan_type":"config","status":"not-run"}' > "$RUNNER_TEMP/trivy-iac.redacted.json"
+          fi
+
+      - name: Upload Trivy IaC results
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: trivy-iac-scan-results
+          path: ${{ runner.temp }}/trivy-iac.redacted.json
+          retention-days: 7
+          if-no-files-found: error

--- a/scripts/tests/test_security_scan_workflow.py
+++ b/scripts/tests/test_security_scan_workflow.py
@@ -14,9 +14,35 @@ def test_security_scan_is_ghas_free_and_preserves_outage_gate() -> None:
         assert forbidden not in lowered
 
     assert "format: 'json'" in text
-    assert "path: trivy-summary.json" in text
+    assert "trivy-summary.json" in text
+    assert "trivy-sbom.cdx.json" in text
     assert "retention-days: 7" in text
-    assert "continue-on-error: true" not in lowered
+    assert "continue-on-error: true" not in text.split("\n  osv:", 1)[0].lower()
+
+
+def test_security_scan_covers_dependencies_iac_and_sbom() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    workflow = yaml.safe_load(text)
+    triggers = workflow.get("on", workflow.get(True, {}))
+
+    assert "pull_request" in triggers
+    assert "schedule" in triggers
+    assert "paths" not in triggers
+    assert "osv:" in text
+    assert 'scan source -r "${{ github.workspace }}"' in text
+    assert "scan-type: 'config'" in text
+    assert "format: 'cyclonedx'" in text
+    assert "OSV_SHA256" in text
+    assert "trivy.redacted.json" in text
+    assert "trivy-iac.redacted.json" in text
+    assert "with_entries(" in text
+    assert "path: ${{ runner.temp }}/trivy-artifact" in text
+    assert "path: ${{ runner.temp }}/trivy-iac.redacted.json" in text
+    assert "path: trivy-summary.json" not in text
+    assert "path: trivy-iac-summary.json" not in text
+    assert "runs-on: ubuntu-24.04" in text
+    assert "actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09" in text
+    assert "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02" in text
 
 
 def test_gitleaks_workflow_covers_current_tree_and_history_without_ghas() -> None:


### PR DESCRIPTION
## Summary
- add pinned OSV dependency scan and Trivy IaC scan
- generate CycloneDX SBOM and keep scanner outage failures visible
- redact scanner reports before seven-day private artifact upload

## Validation
- python3 -m pytest -q scripts/tests/test_security_scan_workflow.py
- actionlint .github/workflows/security-scan.yaml .github/workflows/security-gitleaks.yml
- git diff --check