### PR TITLE
SCR-15 v1.0.0 — Restore CI lint startup

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,11 +76,14 @@ jobs:
           go-version-file: go.mod
       - name: Sync vendor
         run: go mod vendor
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9
-        with:
-          version: v2.4.0
-          args: --timeout=5m --new-from-rev=origin/${{ github.base_ref }}
+      - name: Install golangci-lint
+        run: |
+          go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.4.0
+      - name: Lint Backend
+        run: |
+          "$(go env GOPATH)/bin/golangci-lint" run \
+            --timeout=5m \
+            --new-from-rev="origin/${{ github.base_ref }}"
 
   build:
     name: Build ${{ matrix.cfg.goos }}/${{ matrix.cfg.goarch }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,7 @@ This repo also has read-only and draft-only loop pilot workflows on `master`.
 - No emojis in code, commits, comments, or documentation
 - Follow existing code patterns and formatting
 - Run linting before submitting: `npm run lint` (frontend)
+- Backend CI installs `golangci-lint` v2.4.0 directly through the Go toolchain because the organization Actions policy restricts third-party wrappers. Keep the pinned version in `.github/workflows/ci.yaml` unless that policy changes.
 
 ## Project Structure
 


### PR DESCRIPTION
Course: SCR-15
Version: 1.0.0
Track: Weekly CI remediation
Branch: scrutiny/SCR-15-ci-golangci-policy

## Summary

Restore Scrutiny CI startup by replacing the disallowed third-party golangci-lint action wrapper with a pinned direct Go toolchain install.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD or infrastructure change

## Related Issues

SCR-15 (Linear)

## Changes Made

- Install golangci-lint v2.4.0 directly with `go install`.
- Run the pinned binary with the existing timeout and changed-files scope.
- Document the organization Actions-policy constraint and version pin.

## Testing

- [x] I have tested this locally
- [ ] I have added/updated tests that prove my fix/feature works
- [ ] All existing tests pass

Commands:
- `actionlint .github/workflows/ci.yaml`
- `go mod vendor`
- `GOBIN=<temporary-directory> go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.4.0`
- `golangci-lint run --timeout=5m --new-from-rev=origin/develop` returned `0 issues.`
- `git diff --check`

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary (particularly complex areas)
- [x] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [x] No console.log, debug statements, or commented-out code

## Screenshots (if applicable)

Not applicable.

## Additional Notes

This PR addresses only the `CI` workflow startup failure. The obsolete Auto PR Description workflow remains a separate remediation item.
