### PR TITLE
SCR-16 v1.0.0 — Restore automatic PR descriptions

### DIFF
--- a/.github/workflows/auto-pr-description.yaml
+++ b/.github/workflows/auto-pr-description.yaml
@@ -19,15 +19,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-
       - name: Generate PR Description
-        uses: timrogers/autofill-pr-description-with-openai@main
+        uses: platisd/openai-pr-description@5ba2cf03f9f6c0ba68356a9bda44a380f55cccdb # v1.5.0
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
-          model: gpt-4o-mini
-          overwrite: false
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          openai_api_key: ${{ secrets.OPENAI_API_KEY }}
+          openai_model: gpt-4o-mini
+          overwrite_description: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,10 @@ We use a Gitflow-style workflow:
 4. Update `README.md` when your change affects the top-level product surface, feature set, supported deployment paths, or published image matrix
 5. Submit a PR to `develop` (or `master` for hotfixes)
 
+### PR Description Automation
+
+`.github/workflows/auto-pr-description.yaml` fills an empty PR body when the PR is opened. It preserves author-written descriptions. Keep `platisd/openai-pr-description` pinned to an approved release commit covered by the organization Actions allowlist. After changing the action or allowlist, test an empty-body PR; a PR with a body skips the job before action resolution and cannot prove the reference works.
+
 ### Loop Pilot Workflows
 
 This repo also has read-only and draft-only loop pilot workflows on `master`.


### PR DESCRIPTION
Course: SCR-16
Version: 1.0.0
Track: Weekly CI remediation
Branch: scrutiny/SCR-16-auto-pr-description-action

## Summary

Restore automatic descriptions for PRs opened without a body by replacing an unavailable action with the organization-approved implementation pinned to its v1.5.0 commit.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD or infrastructure change

## Related Issues

SCR-16 (Linear)

## Changes Made

- Replace the unavailable action with `platisd/openai-pr-description` pinned to commit `5ba2cf03f9f6c0ba68356a9bda44a380f55cccdb` from v1.5.0.
- Map existing credentials and behavior to the replacement action's supported inputs.
- Remove checkout because the action reads PR metadata and patches through GitHub APIs.
- Document pinning, allowlist, and empty-body validation requirements.

## Testing

- [x] I have tested this locally
- [ ] I have added/updated tests that prove my fix/feature works
- [ ] All existing tests pass

Commands and checks:
- `actionlint .github/workflows/auto-pr-description.yaml`
- `git diff --check`
- Confirmed pinned SHA equals upstream v1.5.0 tag.
- Confirmed pinned action declares all four configured inputs.
- Confirmed repository `OPENAI_API_KEY` secret exists and organization allowlist permits `platisd/openai-pr-description@*`.

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary (particularly complex areas)
- [x] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [x] No console.log, debug statements, or commented-out code

## Screenshots (if applicable)

Not applicable.

## Additional Notes

This PR has a non-empty body, so the auto-description job should skip. After merge, an empty-body PR smoke test must confirm action resolution, OpenAI generation, and GitHub write permission.
