### PR TITLE
SCR-17 v1.0.0 — Correct develop GHCR namespace

### DIFF
--- a/deploy/testing/docker-compose.yml
+++ b/deploy/testing/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   scrutiny:
     container_name: scrutiny-testing
-    image: ${SCRUTINY_IMAGE:-ghcr.io/starosdev/scrutiny:develop-omnibus}
+    image: ${SCRUTINY_IMAGE:-ghcr.io/staros-labs/scrutiny:develop-omnibus}
     restart: unless-stopped
     cap_add:
       - SYS_RAWIO

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -1,7 +1,7 @@
 services:
   scrutiny:
     container_name: scrutiny-dev
-    image: ghcr.io/starosdev/scrutiny:develop-omnibus
+    image: ghcr.io/staros-labs/scrutiny:develop-omnibus
     cap_add:
       - SYS_RAWIO
       - SYS_ADMIN  # Required for NVMe devices and MDADM

--- a/docs/DEPLOYMENTS.md
+++ b/docs/DEPLOYMENTS.md
@@ -8,7 +8,7 @@ For release-version verification details, see [RELEASE_VERSION_VERIFICATION.md](
 
 | Environment | Branch | Workflow | Published Image | Notes |
 | --- | --- | --- | --- | --- |
-| Testing | `develop` | `.github/workflows/deploy-testing.yml` | `ghcr.io/starosdev/scrutiny:develop` and `develop-omnibus` | External hosts pull these tags when they want the latest testing build |
+| Testing | `develop` | `.github/workflows/deploy-testing.yml` | `ghcr.io/staros-labs/scrutiny:develop` and `develop-omnibus` | External hosts pull these tags when they want the latest testing build |
 | Beta | `beta` | `.github/workflows/deploy-beta.yml` | `ghcr.io/starosdev/scrutiny:beta` and `beta-omnibus` | External hosts pull these tags when they want a pre-release candidate ahead of stable |
 | Production | `master` | `.github/workflows/release-and-deploy.yml` | `ghcr.io/starosdev/scrutiny:latest` and `latest-omnibus` | External hosts pull these tags when they want the latest production build |
 
@@ -69,7 +69,7 @@ Environment rollout is outside GitHub Actions.
 
 If Zeus should move to a new image, do that from the host by pulling the published tags and restarting the compose project there. The current Zeus mapping is:
 
-- develop image path: `ghcr.io/starosdev/scrutiny:develop-omnibus`
+- develop image path: `ghcr.io/staros-labs/scrutiny:develop-omnibus`
 - beta image path: `ghcr.io/starosdev/scrutiny:beta-omnibus`
 - production image path: `ghcr.io/starosdev/scrutiny:latest`
 - develop compose project: `scrutiny-develop`
@@ -84,6 +84,13 @@ If Zeus should move to a new image, do that from the host by pulling the publish
 - develop compose file: `/mnt/user/appdata/scrutiny-develop/docker-compose.yml`
 - beta compose file: `/mnt/user/appdata/scrutiny-beta/docker-compose.yml`
 - production compose file: `/mnt/user/appdata/scrutiny/docker-compose.yml`
+
+### GHCR Namespace Verification
+
+- **Problem:** A repository transfer changes `github.repository`, so publishing workflows write to the new owner's GHCR namespace. Existing compose files can keep pulling a stale package under the previous owner.
+- **Approach:** Compare the exact image repository shown in the successful build log with the image repository in the host compose file before rollout.
+- **Dead end:** A successful workflow and successful `docker compose pull` do not prove the host pulled that workflow's image when the namespaces differ.
+- **Rule:** After a repository transfer, verify the full GHCR repository path on both publisher and host before trusting tags or digests.
 
 ## Current Zeus Host Layout
 


### PR DESCRIPTION
## Course

SCR-17

## Version

1.0.0

## Track

develop

## Branch

scrutiny/SCR-17-ghcr-namespace

## Summary

- Point maintained develop compose files at `ghcr.io/staros-labs/scrutiny:develop-omnibus`.
- Document why repository transfers require publisher and host namespace verification.
- Keep beta and production references unchanged until their tags exist under the organization package.

## Root cause

GitHub Actions publishes current develop images under `ghcr.io/staros-labs/scrutiny`, while Zeus and maintained develop compose files still pulled `ghcr.io/starosdev/scrutiny`. Pulling the legacy package succeeded but returned stale frontend code.

## Linked Issues

- Linear: SCR-17
- Follow-up to #694 and #705

## Test plan

- Validated both changed compose files with `docker compose config --quiet` on Zeus.
- Pulled and recreated Zeus `scrutiny-develop` from the organization package.
- Confirmed `GET /api/health` reports healthy frontend, InfluxDB, and SQLite checks.
- Confirmed rendered temperature selector shows `Drives (0/18)` for 18 available devices.
- Ran `git diff --check`.
