### PR TITLE
fix(database): use case-insensitive serial comparison

### DIFF
--- a/webapp/backend/pkg/database/scrutiny_repository_analogj_migration.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_analogj_migration.go
@@ -110,7 +110,7 @@ func prepareAnalogJDeviceRepair(ctx context.Context, tx *gorm.DB) (map[string]st
 
 		targetWWN := strings.ToLower(originalWWN)
 		legacyWWN := originalWWN
-		if serial != "" && originalWWN == strings.ToLower(serial) {
+		if serial != "" && strings.EqualFold(originalWWN, serial) {
 			legacyWWN = ""
 		}
 		if err := addAnalogJLegacyMapping(mapping, legacyScrutinyUUID(device.ModelName, device.SerialNumber, legacyWWN), targetWWN); err != nil {


### PR DESCRIPTION
## Summary

- Replace manual lowercase comparison with `strings.EqualFold`.
- Preserve case-insensitive serial-fallback identity handling.
- Unblock the backend lint check on PR #725.

## Validation

- `go test ./webapp/backend/pkg/database/...`
- `go mod vendor`
- `golangci-lint run --timeout=5m --new-from-rev=origin/master` (`0 issues.`)

Linear: SCR-23