### PR TITLE
fix: support device-scoped SMART attribute overrides

### DIFF
--- a/docs/DEPLOYMENTS.md
+++ b/docs/DEPLOYMENTS.md
@@ -8,7 +8,7 @@ For release-version verification details, see [RELEASE_VERSION_VERIFICATION.md](
 
 | Environment | Branch | Workflow | Published Image | Notes |
 | --- | --- | --- | --- | --- |
-| Testing | `develop` | `.github/workflows/deploy-testing.yml` | `ghcr.io/staros-labs/scrutiny:develop` and `develop-omnibus` | External hosts pull these tags when they want the latest testing build |
+| Testing | `develop` | `.github/workflows/deploy-testing.yml` | `ghcr.io/starosdev/scrutiny:develop` and `develop-omnibus` | External hosts pull these tags when they want the latest testing build |
 | Beta | `beta` | `.github/workflows/deploy-beta.yml` | `ghcr.io/starosdev/scrutiny:beta` and `beta-omnibus` | External hosts pull these tags when they want a pre-release candidate ahead of stable |
 | Production | `master` | `.github/workflows/release-and-deploy.yml` | `ghcr.io/starosdev/scrutiny:latest` and `latest-omnibus` | External hosts pull these tags when they want the latest production build |
 
@@ -81,7 +81,7 @@ Environment rollout is outside GitHub Actions.
 
 If Zeus should move to a new image, do that from the host by pulling the published tags and restarting the compose project there. The current Zeus mapping is:
 
-- develop image path: `ghcr.io/staros-labs/scrutiny:develop-omnibus`
+- develop image path: `ghcr.io/starosdev/scrutiny:develop-omnibus`
 - beta image path: `ghcr.io/starosdev/scrutiny:beta-omnibus`
 - production image path: `ghcr.io/starosdev/scrutiny:latest`
 - develop compose project: `scrutiny-develop`

--- a/webapp/backend/pkg/database/scrutiny_repository_device.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_device.go
@@ -271,18 +271,12 @@ func recalculateStatusFromSmart(device *models.Device, latestSmart *measurements
 
 func recalculatedAttributeStatus(device *models.Device, attrID string, attr measurements.SmartAttribute, mergedOverrides []overrides.AttributeOverride) (pkg.AttributeStatus, bool, bool) {
 	attrStatus := attr.GetStatus()
-	result := overrides.ApplyWithOverrides(mergedOverrides, device.DeviceProtocol, attrID, device.WWN)
+	result := overrides.ApplyWithOverrides(mergedOverrides, device.DeviceProtocol, attrID, device.DeviceID, device.WWN)
 	if result == nil {
 		return attrStatus, false, false
 	}
-	if result.ShouldIgnore {
-		return attrStatus, true, false
-	}
-	if result.Status == nil {
-		return attrStatus, false, false
-	}
-	attrStatus = *result.Status
-	return attrStatus, false, pkg.AttributeStatusHas(*result.Status, pkg.AttributeStatusFailedScrutiny)
+	ignored, forcedFailure := measurements.ApplyOverrideToAttribute(attr, result)
+	return attr.GetStatus(), ignored, forcedFailure
 }
 
 func (sr *scrutinyRepository) persistRecalculatedDeviceStatus(ctx context.Context, deviceID string, device *models.Device, newStatus pkg.DeviceStatus) error {

--- a/webapp/backend/pkg/database/scrutiny_repository_device_smart_attributes.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_device_smart_attributes.go
@@ -18,6 +18,13 @@ import (
 func (sr *scrutinyRepository) SaveSmartAttributes(ctx context.Context, wwn string, collectorSmartData collector.SmartInfo) (measurements.Smart, error) {
 	deviceSmartData := measurements.Smart{}
 
+	// Look up the device before processing so device-scoped overrides apply to
+	// the incoming SMART result as well as read-time projections.
+	device, devErr := sr.GetDeviceByWWN(ctx, wwn)
+	if devErr == nil {
+		deviceSmartData.DeviceID = device.DeviceID
+	}
+
 	// Get merged overrides (config + database) for SMART attribute processing
 	mergedOverrides := sr.GetMergedOverrides(ctx)
 
@@ -25,13 +32,6 @@ func (sr *scrutinyRepository) SaveSmartAttributes(ctx context.Context, wwn strin
 	if err != nil {
 		sr.logger.Errorln("Could not process SMART metrics", err)
 		return measurements.Smart{}, err
-	}
-
-	// Look up the device via WWN so the current upload can carry a stable device_id tag
-	// and self-test history can be attached to the correct SQLite row set.
-	device, devErr := sr.GetDeviceByWWN(ctx, wwn)
-	if devErr == nil {
-		deviceSmartData.DeviceID = device.DeviceID
 	}
 
 	// Apply delta-based evaluation for cumulative counter attributes (e.g., UltraDMA CRC Error Count).

--- a/webapp/backend/pkg/database/scrutiny_repository_migrations.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_migrations.go
@@ -652,6 +652,18 @@ func (sr *scrutinyRepository) Migrate(ctx context.Context) error {
 				}).Error
 			},
 		},
+		{
+			ID: "m20260823000000", // add stable device selector to attribute overrides (#755)
+			Migrate: func(tx *gorm.DB) error {
+				if err := tx.Exec("ALTER TABLE attribute_overrides ADD COLUMN device_id TEXT NOT NULL DEFAULT ''").Error; err != nil {
+					return fmt.Errorf("failed to add attribute override device_id: %w", err)
+				}
+				if err := tx.Exec("DROP INDEX IF EXISTS idx_override_lookup").Error; err != nil {
+					return fmt.Errorf("failed to replace attribute override index: %w", err)
+				}
+				return tx.Exec("CREATE UNIQUE INDEX idx_override_lookup ON attribute_overrides (protocol, attribute_id, device_id, wwn)").Error
+			},
+		},
 	})
 
 	if err := m.Migrate(); err != nil {

--- a/webapp/backend/pkg/database/scrutiny_repository_migrations_test.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_migrations_test.go
@@ -97,6 +97,19 @@ func TestMigrateBackfillsDistinctDeviceIDsForLegacyDevicesWithMissingWWN(t *test
 	require.Equal(t, int64(2), nullWWNCount)
 }
 
+func TestMigrateAttributeOverridesSupportsDistinctDeviceSelectors(t *testing.T) {
+	repo := createMigrationTestRepository(t)
+	require.NoError(t, repo.Migrate(context.Background()))
+
+	first := models.AttributeOverride{Protocol: "NVMe", AttributeId: "media_errors", DeviceID: "b62e6d86-6ce0-50da-8bff-b2ee54c4af4e", Action: "ignore"}
+	second := models.AttributeOverride{Protocol: "NVMe", AttributeId: "media_errors", DeviceID: "c4ac4ff4-1a4d-52aa-9724-40fbc47dd306", Action: "ignore"}
+	require.NoError(t, repo.gormClient.Create(&first).Error)
+	require.NoError(t, repo.gormClient.Create(&second).Error)
+
+	duplicate := models.AttributeOverride{Protocol: "NVMe", AttributeId: "media_errors", DeviceID: first.DeviceID, Action: "force_status", Status: "passed"}
+	require.Error(t, repo.gormClient.Create(&duplicate).Error)
+}
+
 func TestMigratePreservesDeviceColumnsAcrossSQLiteTableRebuilds(t *testing.T) {
 	repo := createMigrationTestRepositoryWithAppliedMigrations(t, []string{
 		"20201107210306",

--- a/webapp/backend/pkg/models/attribute_override.go
+++ b/webapp/backend/pkg/models/attribute_override.go
@@ -16,6 +16,7 @@ type AttributeOverride struct {
 	FailAbove   *int64    `json:"fail_above,omitempty"`
 	Protocol    string    `json:"protocol" gorm:"not null;uniqueIndex:idx_override_lookup"`
 	AttributeId string    `json:"attribute_id" gorm:"not null;uniqueIndex:idx_override_lookup"`
+	DeviceID    string    `json:"device_id,omitempty" gorm:"uniqueIndex:idx_override_lookup"`
 	WWN         string    `json:"wwn,omitempty" gorm:"uniqueIndex:idx_override_lookup"`
 	Action      string    `json:"action,omitempty"`
 	Status      string    `json:"status,omitempty"`
@@ -33,6 +34,7 @@ func (ao *AttributeOverride) ToOverride() overrides.AttributeOverride {
 	return overrides.AttributeOverride{
 		Protocol:    ao.Protocol,
 		AttributeId: ao.AttributeId,
+		DeviceID:    ao.DeviceID,
 		WWN:         ao.WWN,
 		Action:      overrides.AttributeOverrideAction(ao.Action),
 		Status:      ao.Status,

--- a/webapp/backend/pkg/models/measurements/smart.go
+++ b/webapp/backend/pkg/models/measurements/smart.go
@@ -48,6 +48,34 @@ func applyOverrideResult(result *overrides.Result, thresholdValue int64, status 
 	return false, false
 }
 
+// ApplyOverrideToAttribute applies an override to one in-memory attribute.
+// It is used for ingestion and read-time projection without rewriting history.
+func ApplyOverrideToAttribute(attribute SmartAttribute, result *overrides.Result) (ignored bool, forcedFailure bool) {
+	switch attr := attribute.(type) {
+	case *SmartAtaAttribute:
+		return applyOverrideResult(result, attr.RawValue, &attr.Status, &attr.StatusReason)
+	case *SmartAtaDeviceStatAttribute:
+		return applyOverrideResult(result, attr.Value, &attr.Status, &attr.StatusReason)
+	case *SmartFarmAttribute:
+		return applyOverrideResult(result, attr.Value, &attr.Status, &attr.StatusReason)
+	case *SmartNvmeAttribute:
+		return applyOverrideResult(result, attr.Value, &attr.Status, &attr.StatusReason)
+	case *SmartScsiAttribute:
+		return applyOverrideResult(result, attr.Value, &attr.Status, &attr.StatusReason)
+	default:
+		return false, false
+	}
+}
+
+// ApplyOverrides projects current override rules over a stored SMART result.
+// It changes only response data; raw InfluxDB history is retained.
+func (sm *Smart) ApplyOverrides(overrideList []overrides.AttributeOverride, deviceID string) {
+	for attributeID, attribute := range sm.Attributes {
+		result := overrides.ApplyWithOverrides(overrideList, sm.DeviceProtocol, attributeID, deviceID, sm.DeviceWWN)
+		ApplyOverrideToAttribute(attribute, result)
+	}
+}
+
 type Smart struct {
 	Date           time.Time `json:"date"`
 	DeviceWWN      string    `json:"device_wwn"` //(tag)
@@ -500,7 +528,7 @@ func (sm *Smart) processAtaSmartInfoWithOverrides(cfg config.Interface, modelFam
 		attrIdStr := strconv.Itoa(collectorAttr.ID)
 
 		// Apply merged overrides (config + database)
-		result := overrides.ApplyWithOverrides(mergedOverrides, pkg.DeviceProtocolAta, attrIdStr, sm.DeviceWWN)
+		result := overrides.ApplyWithOverrides(mergedOverrides, pkg.DeviceProtocolAta, attrIdStr, sm.DeviceID, sm.DeviceWWN)
 		ignored, forcedFailure := applyOverrideResult(result, attrModel.RawValue, &attrModel.Status, &attrModel.StatusReason)
 		if forcedFailure {
 			sm.HasForcedFailure = true
@@ -564,7 +592,7 @@ func (sm *Smart) processAtaDeviceStatisticsWithOverrides(cfg config.Interface, d
 			attrModel.PopulateAttributeStatus()
 
 			// Apply merged overrides (config + database)
-			result := overrides.ApplyWithOverrides(mergedOverrides, pkg.DeviceProtocolAta, attrId, sm.DeviceWWN)
+			result := overrides.ApplyWithOverrides(mergedOverrides, pkg.DeviceProtocolAta, attrId, sm.DeviceID, sm.DeviceWWN)
 			ignored, forcedFailure := applyOverrideResult(result, attrModel.Value, &attrModel.Status, &attrModel.StatusReason)
 			if forcedFailure {
 				sm.HasForcedFailure = true
@@ -630,7 +658,7 @@ func (sm *Smart) processFarmDataWithOverrides(cfg config.Interface, farmLog *col
 		attrModel.PopulateAttributeStatus()
 
 		// Apply merged overrides (config + database)
-		result := overrides.ApplyWithOverrides(mergedOverrides, pkg.DeviceProtocolAta, attrId, sm.DeviceWWN)
+		result := overrides.ApplyWithOverrides(mergedOverrides, pkg.DeviceProtocolAta, attrId, sm.DeviceID, sm.DeviceWWN)
 		ignored, forcedFailure := applyOverrideResult(result, attrModel.Value, &attrModel.Status, &attrModel.StatusReason)
 		if forcedFailure {
 			sm.HasForcedFailure = true
@@ -670,7 +698,7 @@ func (sm *Smart) processNvmeSmartInfoWithOverrides(cfg config.Interface, nvmeSma
 		nvmeAttr := val.(*SmartNvmeAttribute)
 
 		// Apply merged overrides (config + database)
-		result := overrides.ApplyWithOverrides(mergedOverrides, pkg.DeviceProtocolNvme, attrId, sm.DeviceWWN)
+		result := overrides.ApplyWithOverrides(mergedOverrides, pkg.DeviceProtocolNvme, attrId, sm.DeviceID, sm.DeviceWWN)
 		ignored, forcedFailure := applyOverrideResult(result, nvmeAttr.Value, &nvmeAttr.Status, &nvmeAttr.StatusReason)
 		if forcedFailure {
 			sm.HasForcedFailure = true
@@ -934,7 +962,7 @@ func (sm *Smart) processScsiSmartInfoWithOverrides(cfg config.Interface, defectG
 
 		if scsiAttr, ok := val.(*SmartScsiAttribute); ok {
 			// Apply merged overrides (config + database)
-			result := overrides.ApplyWithOverrides(mergedOverrides, pkg.DeviceProtocolScsi, attrId, sm.DeviceWWN)
+			result := overrides.ApplyWithOverrides(mergedOverrides, pkg.DeviceProtocolScsi, attrId, sm.DeviceID, sm.DeviceWWN)
 			var forcedFailure bool
 			ignored, forcedFailure = applyOverrideResult(result, scsiAttr.Value, &scsiAttr.Status, &scsiAttr.StatusReason)
 			if forcedFailure {

--- a/webapp/backend/pkg/models/measurements/smart_test.go
+++ b/webapp/backend/pkg/models/measurements/smart_test.go
@@ -11,6 +11,7 @@ import (
 	mock_config "github.com/analogj/scrutiny/webapp/backend/pkg/config/mock"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/models/collector"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/models/measurements"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/overrides"
 	"github.com/golang/mock/gomock"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
@@ -150,10 +151,10 @@ func TestSmart_Flatten_SCSI(t *testing.T) {
 		"attr.read_errors_corrected_by_eccfast.thresh":            int64(0),
 		"attr.read_errors_corrected_by_eccfast.transformed_value": int64(0),
 		"attr.read_errors_corrected_by_eccfast.value":             int64(300357663),
-		"logical_block_size":                                      int64(512),
-		"power_cycle_count":                                       int64(10),
-		"power_on_hours":                                          int64(10),
-		"temp":                                                    int64(50)},
+		"logical_block_size": int64(512),
+		"power_cycle_count":  int64(10),
+		"power_on_hours":     int64(10),
+		"temp":               int64(50)},
 		fields)
 }
 
@@ -1750,4 +1751,30 @@ func TestNewSmartFromInfluxDB_WithFarmAttributes(t *testing.T) {
 	require.True(t, ok, "farm_poh should be SmartFarmAttribute type")
 	require.Equal(t, "farm_poh", farmAttr.AttributeId)
 	require.Equal(t, int64(2344), farmAttr.Value)
+}
+
+func TestSmartApplyOverridesProjectsStableDeviceOverride(t *testing.T) {
+	smart := measurements.Smart{
+		DeviceWWN:      "nvme-serial",
+		DeviceProtocol: pkg.DeviceProtocolNvme,
+		Attributes: map[string]measurements.SmartAttribute{
+			"media_errors": &measurements.SmartNvmeAttribute{
+				AttributeId: "media_errors",
+				Value:       3,
+				Status:      pkg.AttributeStatusFailedScrutiny,
+			},
+		},
+	}
+
+	smart.ApplyOverrides([]overrides.AttributeOverride{{
+		Protocol:    pkg.DeviceProtocolNvme,
+		AttributeId: "media_errors",
+		DeviceID:    "b62e6d86-6ce0-50da-8bff-b2ee54c4af4e",
+		Action:      overrides.AttributeOverrideActionForceStatus,
+		Status:      "passed",
+	}}, "b62e6d86-6ce0-50da-8bff-b2ee54c4af4e")
+
+	attribute := smart.Attributes["media_errors"].(*measurements.SmartNvmeAttribute)
+	require.Equal(t, pkg.AttributeStatusPassed, attribute.Status)
+	require.Equal(t, "Status forced by user configuration", attribute.StatusReason)
 }

--- a/webapp/backend/pkg/overrides/applier.go
+++ b/webapp/backend/pkg/overrides/applier.go
@@ -31,6 +31,9 @@ type AttributeOverride struct {
 	// Optional: Limit override to specific device by WWN
 	WWN string `json:"wwn,omitempty" mapstructure:"wwn"`
 
+	// Optional: Limit override to one stable Scrutiny device identifier.
+	DeviceID string `json:"device_id,omitempty" mapstructure:"device_id"`
+
 	// Optional: Action to take (ignore or force_status)
 	// If not set, custom thresholds are applied
 	Action AttributeOverrideAction `json:"action,omitempty" mapstructure:"action"`
@@ -47,14 +50,17 @@ type AttributeOverride struct {
 }
 
 // Matches checks if this override applies to the given attribute
-func (ao *AttributeOverride) Matches(protocol, attributeId, wwn string) bool {
+func (ao *AttributeOverride) Matches(protocol, attributeId, deviceID, wwn string) bool {
 	if ao.Protocol != protocol {
 		return false
 	}
 	if ao.AttributeId != attributeId {
 		return false
 	}
-	// WWN is optional - if not set, matches all devices
+	if ao.DeviceID != "" {
+		return ao.DeviceID == deviceID
+	}
+	// WWN is optional legacy selector - if not set, matches all devices.
 	if ao.WWN != "" && ao.WWN != wwn {
 		return false
 	}
@@ -76,13 +82,27 @@ func (ao *AttributeOverride) GetForcedStatus() pkg.AttributeStatus {
 }
 
 // FindOverride searches the override list for a matching override
-func FindOverride(overrides []AttributeOverride, protocol, attributeId, wwn string) *AttributeOverride {
+func FindOverride(overrides []AttributeOverride, protocol, attributeId, deviceID, wwn string) *AttributeOverride {
+	var selected *AttributeOverride
+	selectedPriority := -1
 	for i := range overrides {
-		if overrides[i].Matches(protocol, attributeId, wwn) {
-			return &overrides[i]
+		override := &overrides[i]
+		if !override.Matches(protocol, attributeId, deviceID, wwn) {
+			continue
+		}
+		priority := 0
+		if override.WWN != "" {
+			priority = 1
+		}
+		if override.DeviceID != "" {
+			priority = 2
+		}
+		if priority > selectedPriority {
+			selected = override
+			selectedPriority = priority
 		}
 	}
-	return nil
+	return selected
 }
 
 // Result contains the outcome of applying an override
@@ -122,7 +142,7 @@ func ParseOverrides(cfg config.Interface) []AttributeOverride {
 // Returns nil if no override matches.
 func Apply(cfg config.Interface, protocol, attributeId, wwn string) *Result {
 	overrideList := ParseOverrides(cfg)
-	override := FindOverride(overrideList, protocol, attributeId, wwn)
+	override := FindOverride(overrideList, protocol, attributeId, "", wwn)
 
 	if override == nil {
 		return nil
@@ -190,13 +210,13 @@ func MergeOverrides(configOverrides, dbOverrides []AttributeOverride) []Attribut
 
 	// Add config overrides first (lower priority)
 	for _, o := range configOverrides {
-		key := fmt.Sprintf("%s|%s|%s", o.Protocol, o.AttributeId, o.WWN)
+		key := fmt.Sprintf("%s|%s|%s|%s", o.Protocol, o.AttributeId, o.DeviceID, o.WWN)
 		merged[key] = o
 	}
 
 	// Add/override with database overrides (higher priority)
 	for _, o := range dbOverrides {
-		key := fmt.Sprintf("%s|%s|%s", o.Protocol, o.AttributeId, o.WWN)
+		key := fmt.Sprintf("%s|%s|%s|%s", o.Protocol, o.AttributeId, o.DeviceID, o.WWN)
 		merged[key] = o
 	}
 
@@ -210,8 +230,8 @@ func MergeOverrides(configOverrides, dbOverrides []AttributeOverride) []Attribut
 // ApplyWithOverrides checks if an override exists in the provided list and returns the result.
 // This is used when the caller has already merged config and database overrides.
 // Returns nil if no override matches.
-func ApplyWithOverrides(overrideList []AttributeOverride, protocol, attributeId, wwn string) *Result {
-	override := FindOverride(overrideList, protocol, attributeId, wwn)
+func ApplyWithOverrides(overrideList []AttributeOverride, protocol, attributeId, deviceID, wwn string) *Result {
+	override := FindOverride(overrideList, protocol, attributeId, deviceID, wwn)
 
 	if override == nil {
 		return nil

--- a/webapp/backend/pkg/overrides/applier_test.go
+++ b/webapp/backend/pkg/overrides/applier_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/analogj/scrutiny/webapp/backend/pkg"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAttributeOverride_Matches(t *testing.T) {
@@ -84,7 +85,7 @@ func TestAttributeOverride_Matches(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := tt.override.Matches(tt.protocol, tt.attributeId, tt.wwn)
+			got := tt.override.Matches(tt.protocol, tt.attributeId, "", tt.wwn)
 			assert.Equal(t, tt.expected, got)
 		})
 	}
@@ -189,7 +190,7 @@ func TestFindOverride(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := FindOverride(overrides, tt.protocol, tt.attributeId, tt.wwn)
+			result := FindOverride(overrides, tt.protocol, tt.attributeId, "", tt.wwn)
 			if tt.expectFound {
 				assert.NotNil(t, result)
 				assert.Equal(t, tt.expectId, result.AttributeId)
@@ -198,6 +199,18 @@ func TestFindOverride(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestFindOverride_PrefersStableDeviceIDOverLegacyAndGlobalSelectors(t *testing.T) {
+	overrides := []AttributeOverride{
+		{Protocol: "NVMe", AttributeId: "media_errors", Action: AttributeOverrideActionIgnore},
+		{Protocol: "NVMe", AttributeId: "media_errors", WWN: "serial-1", Status: "warn", Action: AttributeOverrideActionForceStatus},
+		{Protocol: "NVMe", AttributeId: "media_errors", DeviceID: "b62e6d86-6ce0-50da-8bff-b2ee54c4af4e", Status: "passed", Action: AttributeOverrideActionForceStatus},
+	}
+
+	result := FindOverride(overrides, "NVMe", "media_errors", "b62e6d86-6ce0-50da-8bff-b2ee54c4af4e", "serial-1")
+	require.NotNil(t, result)
+	assert.Equal(t, "b62e6d86-6ce0-50da-8bff-b2ee54c4af4e", result.DeviceID)
 }
 
 func TestApplyThresholds(t *testing.T) {

--- a/webapp/backend/pkg/web/handler/attribute_overrides.go
+++ b/webapp/backend/pkg/web/handler/attribute_overrides.go
@@ -2,17 +2,14 @@ package handler
 
 import (
 	"net/http"
-	"regexp"
 	"strconv"
 
 	"github.com/analogj/scrutiny/webapp/backend/pkg/database"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/models"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/validation"
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
 )
-
-// wwnPattern matches a valid WWN: optional 0x prefix followed by 1-16 hex digits.
-var wwnPattern = regexp.MustCompile(`(?i)^(0x)?[0-9a-f]{1,16}$`)
 
 // validProtocols defines the allowed protocol values
 var validProtocols = map[string]bool{
@@ -70,8 +67,14 @@ func validateAttributeOverride(o *models.AttributeOverride) string {
 	if !validActions[o.Action] {
 		return "Invalid action. Must be empty, 'ignore', or 'force_status'"
 	}
-	if o.WWN != "" && !wwnPattern.MatchString(o.WWN) {
-		return "Invalid WWN format. Must be a hex value (e.g. 0x5000cca264eb01d7)"
+	if o.DeviceID != "" && o.WWN != "" {
+		return "Choose either device_id or legacy wwn, not both"
+	}
+	if o.DeviceID != "" && validation.ValidateUUID(o.DeviceID) != nil {
+		return "Invalid device_id format"
+	}
+	if o.WWN != "" && validation.ValidateWWN(o.WWN) != nil {
+		return "Invalid WWN format"
 	}
 	if o.Action == "force_status" {
 		return validateForceStatus(o)
@@ -184,7 +187,11 @@ func recalculateDeviceStatusForOverride(c *gin.Context, logger *logrus.Entry, de
 	}
 	for i := range devices {
 		device := &devices[i]
-		if override.WWN != "" {
+		if override.DeviceID != "" {
+			if device.DeviceID != override.DeviceID {
+				continue
+			}
+		} else if override.WWN != "" {
 			// Override applies to specific device - match by WWN
 			if device.WWN != override.WWN {
 				continue

--- a/webapp/backend/pkg/web/handler/attribute_overrides.go
+++ b/webapp/backend/pkg/web/handler/attribute_overrides.go
@@ -187,16 +187,17 @@ func recalculateDeviceStatusForOverride(c *gin.Context, logger *logrus.Entry, de
 	}
 	for i := range devices {
 		device := &devices[i]
-		if override.DeviceID != "" {
+		switch {
+		case override.DeviceID != "":
 			if device.DeviceID != override.DeviceID {
 				continue
 			}
-		} else if override.WWN != "" {
+		case override.WWN != "":
 			// Override applies to specific device - match by WWN
 			if device.WWN != override.WWN {
 				continue
 			}
-		} else if device.DeviceProtocol != override.Protocol {
+		case device.DeviceProtocol != override.Protocol:
 			// Override applies to all devices of this protocol
 			continue
 		}

--- a/webapp/backend/pkg/web/handler/attribute_overrides_test.go
+++ b/webapp/backend/pkg/web/handler/attribute_overrides_test.go
@@ -1,6 +1,7 @@
 package handler_test
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -253,7 +254,7 @@ func TestSaveAttributeOverride_InvalidWWN(t *testing.T) {
 
 	router := setupOverridesRouter(t, mockRepo)
 
-	body := strings.NewReader(`{"protocol": "ATA", "attribute_id": "5", "action": "ignore", "wwn": "not-a-wwn"}`)
+	body := strings.NewReader(`{"protocol": "ATA", "attribute_id": "5", "action": "ignore", "wwn": "not/a/wwn"}`)
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest("POST", "/api/settings/overrides", body)
 	req.Header.Set("Content-Type", "application/json")
@@ -263,6 +264,25 @@ func TestSaveAttributeOverride_InvalidWWN(t *testing.T) {
 	var response map[string]interface{}
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
 	require.Contains(t, response["error"], "WWN")
+}
+
+func TestSaveAttributeOverride_ValidDeviceID(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	t.Cleanup(mockCtrl.Finish)
+	mockRepo := mock_database.NewMockDeviceRepo(mockCtrl)
+	mockRepo.EXPECT().SaveAttributeOverride(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, override *models.AttributeOverride) error {
+		require.Equal(t, "b62e6d86-6ce0-50da-8bff-b2ee54c4af4e", override.DeviceID)
+		return nil
+	})
+	mockRepo.EXPECT().GetDevices(gomock.Any()).Return([]models.Device{}, nil)
+
+	router := setupOverridesRouter(t, mockRepo)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, "/api/settings/overrides", strings.NewReader(`{"protocol":"NVMe","attribute_id":"media_errors","action":"ignore","device_id":"b62e6d86-6ce0-50da-8bff-b2ee54c4af4e"}`))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
 }
 
 func TestSaveAttributeOverride_ValidIgnore(t *testing.T) {

--- a/webapp/backend/pkg/web/handler/get_device_details.go
+++ b/webapp/backend/pkg/web/handler/get_device_details.go
@@ -30,6 +30,10 @@ func GetDeviceDetails(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
 		return
 	}
+	mergedOverrides := deviceRepo.GetMergedOverrides(c)
+	for i := range smartResults {
+		smartResults[i].ApplyOverrides(mergedOverrides, device.DeviceID)
+	}
 
 	var deviceMetadata interface{}
 	if device.IsAta() {

--- a/webapp/frontend/src/app/core/config/app.config.ts
+++ b/webapp/frontend/src/app/core/config/app.config.ts
@@ -73,6 +73,7 @@ export interface AttributeOverride {
     id?: number;
     protocol: OverrideProtocol;
     attribute_id: string;
+    device_id?: string;
     wwn?: string;
     action?: OverrideAction;
     status?: OverrideStatus;

--- a/webapp/frontend/src/app/layout/common/dashboard-settings/dashboard-settings.component.html
+++ b/webapp/frontend/src/app/layout/common/dashboard-settings/dashboard-settings.component.html
@@ -492,6 +492,11 @@
                         <td mat-cell *matCellDef="let override">{{ override.attribute_id }}</td>
                     </ng-container>
 
+                    <ng-container matColumnDef="device">
+                        <th mat-header-cell *matHeaderCellDef>Device</th>
+                        <td mat-cell *matCellDef="let override">{{ overrideDeviceLabel(override) }}</td>
+                    </ng-container>
+
                     <ng-container matColumnDef="action">
                         <th mat-header-cell *matHeaderCellDef>Action</th>
                         <td mat-cell *matCellDef="let override">{{ getActionLabel(override.action) }}</td>
@@ -577,16 +582,28 @@
                         }
 
                         <mat-form-field class="flex-1 min-w-[200px]">
-                            <mat-label>Device WWN (optional)</mat-label>
-                            <input matInput [(ngModel)]="newOverride.wwn" placeholder="Leave empty for all devices" />
+                            <mat-label>Device (optional)</mat-label>
+                            <mat-select [(ngModel)]="newOverride.device_id">
+                                <mat-option value="">All devices</mat-option>
+                                @for (device of overrideDevices; track device.device_id) {
+                                <mat-option [value]="device.device_id">{{ device.model_name }} ({{ device.serial_number || device.device_name || device.device_id }})</mat-option>
+                                }
+                            </mat-select>
+                            <mat-hint>Uses stable Scrutiny device identity.</mat-hint>
                         </mat-form-field>
                     </div>
+
+                    @if (overrideError) {
+                    <p class="text-red-600 mt-2" role="alert" aria-live="assertive">{{ overrideError }}</p>
+                    }
+                    <p id="override-form-hint" class="text-gray-500 mt-2">Choose a protocol and attribute ID. Custom thresholds need at least one value.</p>
 
                     <button
                         mat-raised-button
                         color="primary"
                         class="mt-4"
                         (click)="addOverride()"
+                        aria-describedby="override-form-hint"
                         [disabled]="
                             !newOverride.protocol ||
                             !newOverride.attribute_id ||

--- a/webapp/frontend/src/app/layout/common/dashboard-settings/dashboard-settings.component.ts
+++ b/webapp/frontend/src/app/layout/common/dashboard-settings/dashboard-settings.component.ts
@@ -23,6 +23,8 @@ import {
 } from 'app/core/config/app.config';
 import { ScrutinyConfigService } from 'app/core/config/scrutiny-config.service';
 import { AttributeOverrideService } from 'app/core/config/attribute-override.service';
+import { DashboardService } from 'app/modules/dashboard/dashboard.service';
+import { DeviceModel } from 'app/core/models/device-model';
 import { NotifyUrlService } from 'app/core/config/notify-url.service';
 import { getBasePath } from 'app/app.routing';
 import { Subject } from 'rxjs';
@@ -86,6 +88,7 @@ import { HelpLinkIconComponent } from 'app/layout/common/help-link-icon/help-lin
 export class DashboardSettingsComponent implements OnInit {
     private readonly _configService = inject(ScrutinyConfigService);
     private readonly _overrideService = inject(AttributeOverrideService);
+    private readonly _dashboardService = inject(DashboardService);
     private readonly _notifyUrlService = inject(NotifyUrlService);
     private readonly _httpClient = inject(HttpClient);
 
@@ -157,7 +160,9 @@ export class DashboardSettingsComponent implements OnInit {
 
     // Attribute overrides
     overrides: AttributeOverride[] = [];
-    displayedColumns: string[] = ['protocol', 'attribute_id', 'action', 'source', 'actions'];
+    overrideDevices: DeviceModel[] = [];
+    overrideError: string | null = null;
+    displayedColumns: string[] = ['protocol', 'attribute_id', 'device', 'action', 'source', 'actions'];
     protocols: OverrideProtocol[] = ['ATA', 'NVMe', 'SCSI'];
     actions: { value: OverrideAction; label: string }[] = [
         { value: 'ignore', label: 'Ignore' },
@@ -282,6 +287,7 @@ export class DashboardSettingsComponent implements OnInit {
 
         // Load attribute overrides
         this.loadOverrides();
+        this.loadOverrideDevices();
 
         // Load notification URLs
         this.loadNotifyUrls();
@@ -296,8 +302,19 @@ export class DashboardSettingsComponent implements OnInit {
             });
     }
 
+    loadOverrideDevices(): void {
+        this._dashboardService
+            .getSummaryData()
+            .pipe(takeUntil(this._unsubscribeAll))
+            .subscribe((summary) => {
+                this.overrideDevices = Object.values(summary).map((entry) => entry.device);
+            });
+    }
+
     addOverride(): void {
+        this.overrideError = null;
         if (!this.newOverride.protocol || !this.newOverride.attribute_id) {
+            this.overrideError = 'Choose a protocol and attribute ID.';
             return;
         }
         if (this.newOverride.action === '' && this.newOverride.warn_above == null && this.newOverride.fail_above == null) {
@@ -312,6 +329,7 @@ export class DashboardSettingsComponent implements OnInit {
             this.newOverride.fail_above != null &&
             this.newOverride.warn_above >= this.newOverride.fail_above
         ) {
+            this.overrideError = 'Fail Above must be greater than Warn Above. Use only Fail Above for a fail-only threshold.';
             return;
         }
 
@@ -319,7 +337,7 @@ export class DashboardSettingsComponent implements OnInit {
             protocol: this.newOverride.protocol as OverrideProtocol,
             attribute_id: this.newOverride.attribute_id,
             action: this.newOverride.action as OverrideAction,
-            wwn: this.newOverride.wwn || '',
+            device_id: this.newOverride.device_id || '',
             status: this.newOverride.status as OverrideStatus,
             warn_above: this.newOverride.warn_above,
             fail_above: this.newOverride.fail_above,
@@ -328,15 +346,23 @@ export class DashboardSettingsComponent implements OnInit {
         this._overrideService
             .saveOverride(override)
             .pipe(takeUntil(this._unsubscribeAll))
-            .subscribe((saved) => {
-                this.overrides = [...this.overrides, saved];
-                // Reset form
-                this.newOverride = {
-                    protocol: 'ATA',
-                    attribute_id: '',
-                    action: 'ignore',
-                };
+            .subscribe({
+                next: (saved) => {
+                    this.overrides = [...this.overrides, saved];
+                    this.newOverride = { protocol: 'ATA', attribute_id: '', action: 'ignore' };
+                },
+                error: (error) => {
+                    this.overrideError = error?.error?.error || 'Could not save override.';
+                },
             });
+    }
+
+    overrideDeviceLabel(override: AttributeOverride): string {
+        const device = this.overrideDevices.find((entry) => entry.device_id === override.device_id);
+        if (device) {
+            return `${device.model_name} (${device.serial_number || device.device_name || device.device_id})`;
+        }
+        return override.wwn ? `Legacy WWN: ${override.wwn}` : 'All devices';
     }
 
     removeOverride(override: AttributeOverride): void {


### PR DESCRIPTION
## Summary

- Adds device-scoped SMART attribute overrides with legacy WWN compatibility.
- Applies overrides to device details and status recalculation.
- Corrects the Zeus develop image namespace.

## Linked Issues

Closes #755

## Test plan

- `go test ./...`
- `fnm exec --using v24.18.0 -- npm test -- --watch=false`
- `fnm exec --using v24.18.0 -- npm run lint`
- Zeus develop rollout: health passed; temporary NVMe override stored, threshold applied, and cleanup confirmed.