### PR TITLE
feat(smart): add WD Gold WD102KRYZ drive profile

### DIFF
--- a/webapp/backend/pkg/thresholds/consumer_drive_profiles.json
+++ b/webapp/backend/pkg/thresholds/consumer_drive_profiles.json
@@ -1602,6 +1602,46 @@
       },
       "model_pattern": "^TOSHIBA[_ ]HDWG(11A|160|180|21C|21E|440|460|480).*$",
       "sample_count": 73
+    },
+    {
+      "protocol": "ATA",
+      "source": "linuxhw/SMART curated WD Gold HDD profile",
+      "vendor": "WDC",
+      "model_family": "Western Digital Gold WD102KRYZ",
+      "ata_counter_severity_overrides": {
+        "10": {
+          "low": 0,
+          "moderate": 1,
+          "high": 2,
+          "critical": 4
+        },
+        "196": {
+          "low": 0,
+          "moderate": 1,
+          "high": 4,
+          "critical": 10
+        },
+        "197": {
+          "low": 0,
+          "moderate": 1,
+          "high": 3,
+          "critical": 8
+        },
+        "198": {
+          "low": 0,
+          "moderate": 1,
+          "high": 3,
+          "critical": 8
+        },
+        "5": {
+          "low": 0,
+          "moderate": 1,
+          "high": 4,
+          "critical": 10
+        }
+      },
+      "model_pattern": "^(WDC[_ ])?WD102KRYZ-.*$",
+      "sample_count": 20
     }
   ],
   "aliases": {

--- a/webapp/backend/pkg/thresholds/testdata/consumer_drive_profile_fixtures.json
+++ b/webapp/backend/pkg/thresholds/testdata/consumer_drive_profile_fixtures.json
@@ -118,6 +118,24 @@
     "expect_applied": false
   },
   {
+    "description": "WD Gold WD102KRYZ resolves via model pattern",
+    "protocol": "ATA",
+    "model_family": "Western Digital Gold",
+    "model_name": "WDC WD102KRYZ-01A5AB0",
+    "expect_matched": true,
+    "expect_applied": true,
+    "expect_family": "Western Digital Gold WD102KRYZ",
+    "expect_method": "model_pattern"
+  },
+  {
+    "description": "adjacent WD Gold model stays outside the WD102KRYZ profile",
+    "protocol": "ATA",
+    "model_family": "Western Digital Gold",
+    "model_name": "WDC WD103KRYZ-01A5AB0",
+    "expect_matched": false,
+    "expect_applied": false
+  },
+  {
     "description": "unknown Toshiba drive stays unmatched and falls back to generic ATA rules",
     "protocol": "ATA",
     "model_family": "",

--- a/webapp/backend/pkg/web/handler/get_device_replacement_risk_test.go
+++ b/webapp/backend/pkg/web/handler/get_device_replacement_risk_test.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/analogj/scrutiny/webapp/backend/pkg/config"
@@ -68,6 +69,55 @@ func TestComputeRiskContributions_FallbackWithoutProfile(t *testing.T) {
 	require.Equal(t, 0.0, contributions[0].TrendScore)
 	require.Equal(t, 6.25, totalScore)
 	require.Equal(t, 0.0, totalTrendBonus)
+}
+
+func TestWD102KRYZProfileReplacementRiskBoundaries(t *testing.T) {
+	profile, ok := thresholds.LookupConsumerDriveProfile("ATA", "", "WDC WD102KRYZ-01A5AB0")
+	require.True(t, ok)
+	require.NotNil(t, profile)
+
+	weightsByAttribute := make(map[string]thresholds.ReplacementRiskWeight)
+	for _, weight := range thresholds.ReplacementRiskWeightsForProtocol("ATA") {
+		weightsByAttribute[weight.AttributeID] = weight
+	}
+
+	testCases := []struct {
+		attributeID string
+		values      []int64
+		severities  []float64
+	}{
+		{attributeID: "5", values: []int64{0, 1, 2, 4, 5, 10, 11}, severities: []float64{0, 0.25, 0.50, 0.50, 0.75, 0.75, 1}},
+		{attributeID: "10", values: []int64{0, 1, 2, 3, 4, 5}, severities: []float64{0, 0.25, 0.50, 0.75, 0.75, 1}},
+		{attributeID: "196", values: []int64{0, 1, 2, 4, 5, 10, 11}, severities: []float64{0, 0.25, 0.50, 0.50, 0.75, 0.75, 1}},
+		{attributeID: "197", values: []int64{0, 1, 2, 3, 4, 8, 9}, severities: []float64{0, 0.25, 0.50, 0.50, 0.75, 0.75, 1}},
+		{attributeID: "198", values: []int64{0, 1, 2, 3, 4, 8, 9}, severities: []float64{0, 0.25, 0.50, 0.50, 0.75, 0.75, 1}},
+	}
+
+	for _, testCase := range testCases {
+		weight, found := weightsByAttribute[testCase.attributeID]
+		require.True(t, found, "missing replacement-risk weight for attribute %s", testCase.attributeID)
+
+		for index, value := range testCase.values {
+			t.Run(fmt.Sprintf("attribute_%s_value_%d", testCase.attributeID, value), func(t *testing.T) {
+				latest := map[string]measurements.SmartAttribute{
+					testCase.attributeID: &measurements.SmartAtaAttribute{RawValue: value},
+				}
+
+				contributions, totalScore, totalTrendBonus := computeRiskContributions(
+					[]thresholds.ReplacementRiskWeight{weight},
+					latest,
+					nil,
+					profile,
+				)
+
+				expectedScore := testCase.severities[index] * weight.Weight
+				require.Len(t, contributions, 1)
+				require.Equal(t, expectedScore, contributions[0].Score)
+				require.Equal(t, expectedScore, totalScore)
+				require.Zero(t, totalTrendBonus)
+			})
+		}
+	}
 }
 
 func TestConsumerDriveProfilesEnabledDefaultsTrueWhenUnset(t *testing.T) {


### PR DESCRIPTION
## Summary

- add a narrowly matched WD Gold WD102KRYZ consumer ATA profile
- use the 20 exact-model samples currently published by linuxhw/SMART
- add a positive WD102KRYZ match fixture and a WD103KRYZ near-miss fixture

## Evidence

- linuxhw/SMART exact-model dataset: https://github.com/linuxhw/SMART/blob/master/HDD/WDC/README.md#L1030
- linuxhw/EnterpriseDrive supplemental dataset: https://github.com/linuxhw/EnterpriseDrive/blob/master/Top1000_HDD.md
- Western Digital WD102KRYZ product page: https://www.westerndigital.com/products/internal-drives/wd-gold-sata-hdd?sku=WD102KRYZ

## Validation

- `make catalog-fix`
- `make catalog-lint`
- `go test ./webapp/backend/pkg/thresholds/`
- `git diff --check`

Closes #768
