### PR TITLE
feat(smart): add Toshiba N300 drive profile

### DIFF
--- a/webapp/backend/pkg/thresholds/consumer_drive_profiles.json
+++ b/webapp/backend/pkg/thresholds/consumer_drive_profiles.json
@@ -1,5 +1,5 @@
 {
-  "version": "2026.07.0",
+  "version": "2026.08.0",
   "profiles": [
     {
       "protocol": "ATA",
@@ -1562,6 +1562,46 @@
         }
       },
       "sample_count": 167
+    },
+    {
+      "protocol": "ATA",
+      "source": "linuxhw/SMART curated Toshiba N300 HDD profile",
+      "vendor": "Toshiba",
+      "model_family": "Toshiba N300",
+      "ata_counter_severity_overrides": {
+        "10": {
+          "low": 0,
+          "moderate": 1,
+          "high": 2,
+          "critical": 4
+        },
+        "196": {
+          "low": 0,
+          "moderate": 1,
+          "high": 4,
+          "critical": 10
+        },
+        "197": {
+          "low": 0,
+          "moderate": 1,
+          "high": 3,
+          "critical": 8
+        },
+        "198": {
+          "low": 0,
+          "moderate": 1,
+          "high": 3,
+          "critical": 8
+        },
+        "5": {
+          "low": 0,
+          "moderate": 1,
+          "high": 4,
+          "critical": 10
+        }
+      },
+      "model_pattern": "^TOSHIBA[_ ]HDWG(11A|160|180|21C|21E|440|460|480).*$",
+      "sample_count": 73
     }
   ],
   "aliases": {

--- a/webapp/backend/pkg/thresholds/testdata/consumer_drive_profile_fixtures.json
+++ b/webapp/backend/pkg/thresholds/testdata/consumer_drive_profile_fixtures.json
@@ -100,6 +100,24 @@
     "expect_method": "model_pattern"
   },
   {
+    "description": "Toshiba N300 HDWG11A resolves via model pattern",
+    "protocol": "ATA",
+    "model_family": "",
+    "model_name": "TOSHIBA HDWG11A",
+    "expect_matched": true,
+    "expect_applied": true,
+    "expect_family": "Toshiba N300",
+    "expect_method": "model_pattern"
+  },
+  {
+    "description": "Toshiba X300 model near miss stays unmatched",
+    "protocol": "ATA",
+    "model_family": "",
+    "model_name": "TOSHIBA HDWR11A",
+    "expect_matched": false,
+    "expect_applied": false
+  },
+  {
     "description": "unknown Toshiba drive stays unmatched and falls back to generic ATA rules",
     "protocol": "ATA",
     "model_family": "",


### PR DESCRIPTION
## Summary

- add a Toshiba N300 consumer ATA profile for known HDWG model codes
- use 73 linuxhw/SMART samples across the HDWG family without lowering the catalog confidence gate
- add a positive HDWG11A match fixture and an HDWR11A near-miss fixture

## Evidence

- linuxhw/SMART Toshiba dataset: https://github.com/linuxhw/SMART/blob/master/HDD/Toshiba/README.md
- Toshiba N300 model range: https://www.toshiba-storage.com/products/toshiba-internal-hard-drives-n300-2024/

## Validation

- `make catalog-fix`
- `make catalog-lint`
- `go test ./webapp/backend/pkg/thresholds/`
- `git diff --check`

Closes #767
