### PR TITLE
fix(database): respect retention during AnalogJ history repair

### DIFF
--- a/docs/TROUBLESHOOTING_INFLUXDB.md
+++ b/docs/TROUBLESHOOTING_INFLUXDB.md
@@ -81,6 +81,28 @@ then retrieving the API token, and writing it to your `scrutiny.yaml` config fil
 
 ![influx db admin token](./influxdb-admin-token.png)
 
+## AnalogJ 0.9.x history repair and expired points
+
+Migration `m20260803000000` restores the `device_wwn` history tag used by this
+fork. Issue #776 exposed a startup failure when its rewrite encountered points
+older than a bucket's retention period. InfluxDB can still return expired points
+until its retention service removes their shard group; querying them does not
+mean they can be written again. See [InfluxDB retention enforcement](https://docs.influxdata.com/influxdb/v2/reference/internals/data-retention/).
+
+The repair reads each bucket's actual retention rule and limits the Flux query
+to that window. Unlimited buckets retain the full history query. This respects
+custom retention periods without changing bucket configuration.
+
+Do not suppress all HTTP 422 or partial-write errors: Flux may stop before all
+eligible history is copied, and streamed errors do not carry an HTTP status.
+Legacy series are deleted only after the rewrite completes successfully. A
+write failure, including a point expiring during the query, still stops the
+migration and preserves that source series for a retry.
+
+The integration regression seeds old and current SMART and temperature points
+with unlimited retention, shortens retention, then verifies that current points
+survive, unlimited history remains, legacy tags are removed, and reruns are safe.
+
 ## Upgrading from v0.3.x to v0.4.x
 
 When upgrading from v0.3.x to v0.4.x, some users have noticed problems such as:

--- a/webapp/backend/pkg/database/scrutiny_repository_analogj_migration.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_analogj_migration.go
@@ -220,10 +220,18 @@ func (sr *scrutinyRepository) rewriteAnalogJInfluxHistory(ctx context.Context, m
 	deleteStart := time.Unix(0, 0).UTC()
 	deleteStop := time.Now().UTC().Add(24 * time.Hour)
 	for _, bucket := range buckets {
+		bucketInfo, err := sr.influxClient.BucketsAPI().FindBucketByName(ctx, bucket)
+		if err != nil {
+			return fmt.Errorf("could not inspect retention for AnalogJ history in bucket %s: %w", bucket, err)
+		}
+		var retentionSeconds int64
+		if len(bucketInfo.RetentionRules) > 0 {
+			retentionSeconds = bucketInfo.RetentionRules[0].EverySeconds
+		}
 		for _, legacyUUID := range legacyUUIDs {
 			targetWWN := mapping[legacyUUID]
 			sr.logger.Debugf("Rewriting AnalogJ history in bucket %s from scrutiny_uuid %s to device_wwn %s", bucket, legacyUUID, targetWWN)
-			query := analogJInfluxMigrationQuery(bucket, org, legacyUUID, targetWWN)
+			query := analogJInfluxMigrationQuery(bucket, org, legacyUUID, targetWWN, retentionSeconds)
 			result, err := sr.influxQueryApi.Query(ctx, query)
 			if err != nil {
 				return fmt.Errorf("could not rewrite AnalogJ history in bucket %s for %s: %w", bucket, legacyUUID, err)
@@ -253,12 +261,18 @@ func (sr *scrutinyRepository) rewriteAnalogJInfluxHistory(ctx context.Context, m
 	return nil
 }
 
-func analogJInfluxMigrationQuery(bucket, org, legacyUUID, targetWWN string) string {
+func analogJInfluxMigrationQuery(bucket, org, legacyUUID, targetWWN string, retentionSeconds int64) string {
+	// Expired shards can remain queryable even though their points can no longer
+	// be written. Use the server's retention window, including custom durations.
+	start := "0"
+	if retentionSeconds > 0 {
+		start = fmt.Sprintf("-%ds", retentionSeconds)
+	}
 	return fmt.Sprintf(`from(bucket: %q)
-|> range(start: 0)
+|> range(start: %s)
 |> filter(fn: (r) => r["_measurement"] == "smart" or r["_measurement"] == "temp")
 |> filter(fn: (r) => exists r["scrutiny_uuid"] and r["scrutiny_uuid"] == %q)
 |> drop(columns: ["scrutiny_uuid"])
 |> set(key: "device_wwn", value: %q)
-|> to(bucket: %q, org: %q)`, bucket, legacyUUID, targetWWN, bucket, org)
+|> to(bucket: %q, org: %q)`, bucket, start, legacyUUID, targetWWN, bucket, org)
 }

--- a/webapp/backend/pkg/database/scrutiny_repository_analogj_migration_test.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_analogj_migration_test.go
@@ -2,11 +2,15 @@ package database
 
 import (
 	"context"
+	"encoding/csv"
+	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -17,6 +21,7 @@ import (
 	"github.com/glebarez/sqlite"
 	"github.com/golang/mock/gomock"
 	influxdb2 "github.com/influxdata/influxdb-client-go/v2"
+	"github.com/influxdata/influxdb-client-go/v2/domain"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"gorm.io/gorm"
@@ -28,6 +33,7 @@ func TestAnalogJInfluxMigrationQueryRewritesOnlyLegacySmartData(t *testing.T) {
 		"scrutiny",
 		"9027cd65-fe19-562d-ac5d-0bb05818087f",
 		"nvme123",
+		0,
 	)
 
 	require.Contains(t, query, `from(bucket: "metrics_weekly")`)
@@ -48,6 +54,73 @@ func TestLegacyScrutinyUUIDMatchesAnalogJIdentity(t *testing.T) {
 		"7a14ef35-ed3a-552a-9980-46291bd986e3",
 		legacyScrutinyUUID("WDC WD80EFZZ-68BTXN0", "WD-CA2XZ08L", "0x50014ee2c06ce3c3"),
 	)
+}
+
+func TestAnalogJHistoryRewritePreservesSourceOnFailureAndRetries(t *testing.T) {
+	for _, failure := range []string{"bucket lookup", "HTTP rejection", "streamed retention", "streamed field conflict", "delete"} {
+		t.Run(failure, func(t *testing.T) {
+			var fail atomic.Bool
+			fail.Store(true)
+			var deletes atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/api/v2/buckets":
+					if fail.Load() && failure == "bucket lookup" {
+						http.Error(w, "bucket access denied", http.StatusForbidden)
+						return
+					}
+					w.Header().Set("Content-Type", "application/json")
+					_ = json.NewEncoder(w).Encode(map[string]interface{}{
+						"buckets": []domain.Bucket{{Name: r.URL.Query().Get("name"), RetentionRules: domain.RetentionRules{{EverySeconds: 5443200}}}},
+					})
+				case "/api/v2/query":
+					if fail.Load() && failure == "HTTP rejection" {
+						w.Header().Set("Content-Type", "application/json")
+						w.WriteHeader(http.StatusUnprocessableEntity)
+						_, _ = w.Write([]byte(`{"code":"unprocessable entity","message":"field type conflict"}`))
+						return
+					}
+					w.Header().Set("Content-Type", "text/csv")
+					if fail.Load() && strings.HasPrefix(failure, "streamed") {
+						message := "partial write: field type conflict"
+						if failure == "streamed retention" {
+							message = "partial write: dropped 268 points outside retention policy of duration 1512h0m0s"
+						}
+						writer := csv.NewWriter(w)
+						_ = writer.WriteAll([][]string{{"#datatype", "string", "string"}, {"", "error", "reference"}, {"", message, ""}})
+					}
+				case "/api/v2/delete":
+					if fail.Load() && failure == "delete" {
+						http.Error(w, "delete access denied", http.StatusForbidden)
+						return
+					}
+					deletes.Add(1)
+					w.WriteHeader(http.StatusNoContent)
+				default:
+					t.Errorf("unexpected request: %s %s", r.Method, r.URL)
+					http.NotFound(w, r)
+				}
+			}))
+			t.Cleanup(server.Close)
+			client := influxdb2.NewClient(server.URL, "test-token")
+			t.Cleanup(client.Close)
+			mockCtrl := gomock.NewController(t)
+			fakeConfig := mock_config.NewMockInterface(mockCtrl)
+			fakeConfig.EXPECT().GetString(cfgInfluxDBBucket).Return("metrics").AnyTimes()
+			fakeConfig.EXPECT().GetString(cfgInfluxDBOrg).Return("scrutiny").AnyTimes()
+			repo := &scrutinyRepository{
+				appConfig: fakeConfig, influxClient: client,
+				influxQueryApi: client.QueryAPI("scrutiny"), logger: logrus.New(),
+			}
+			mapping := map[string]string{"legacy-uuid": "current-wwn"}
+			err := repo.rewriteAnalogJInfluxHistory(context.Background(), mapping)
+			require.Error(t, err)
+			require.Zero(t, deletes.Load(), "failed rewrites must not delete source history")
+			fail.Store(false)
+			require.NoError(t, repo.rewriteAnalogJInfluxHistory(context.Background(), mapping))
+			require.EqualValues(t, 4, deletes.Load(), "retry must complete all four buckets")
+		})
+	}
 }
 
 func TestPrepareAnalogJDeviceRepairRestoresNVMeIdentityAndMergesDuplicate(t *testing.T) {
@@ -231,18 +304,36 @@ func TestAnalogJMigrationIntegration(t *testing.T) {
 	for _, bucket := range buckets {
 		writeAPI := repo.influxClient.WriteAPIBlocking("scrutiny", bucket)
 		tags := map[string]string{"scrutiny_uuid": legacyUUID, "device_protocol": pkg.DeviceProtocolNvme}
-		require.NoError(t, writeAPI.WritePoint(ctx, influxdb2.NewPoint(
-			"smart",
-			tags,
-			map[string]interface{}{"temp": int64(41), "power_on_hours": int64(694)},
-			pointTime,
-		)))
-		require.NoError(t, writeAPI.WritePoint(ctx, influxdb2.NewPoint(
-			"temp",
-			tags,
-			map[string]interface{}{"temp": int64(41)},
-			pointTime,
-		)))
+		// Seed expired history while retention is unlimited, then shorten the
+		// window. InfluxDB can still read these points until shard cleanup (#776).
+		for _, timestamp := range []time.Time{pointTime.Add(-64 * 24 * time.Hour), pointTime} {
+			require.NoError(t, writeAPI.WritePoint(ctx, influxdb2.NewPoint(
+				"smart",
+				tags,
+				map[string]interface{}{"temp": int64(41), "power_on_hours": int64(694)},
+				timestamp,
+			)))
+			require.NoError(t, writeAPI.WritePoint(ctx, influxdb2.NewPoint(
+				"temp",
+				tags,
+				map[string]interface{}{"temp": int64(41)},
+				timestamp,
+			)))
+		}
+		if bucket != "metrics_yearly" {
+			bucketInfo, err := repo.influxClient.BucketsAPI().FindBucketByName(ctx, bucket)
+			require.NoError(t, err)
+			originalRules := bucketInfo.RetentionRules
+			t.Cleanup(func() {
+				bucketInfo.RetentionRules = originalRules
+				_, err := repo.influxClient.BucketsAPI().UpdateBucket(ctx, bucketInfo)
+				require.NoError(t, err)
+			})
+			bucketInfo.RetentionRules = domain.RetentionRules{{EverySeconds: 63 * 24 * 60 * 60}}
+			_, err = repo.influxClient.BucketsAPI().UpdateBucket(ctx, bucketInfo)
+			require.NoError(t, err)
+		}
+		require.Equal(t, 6, influxRecordCount(t, repo, bucket, "scrutiny_uuid", legacyUUID))
 	}
 
 	deleteStart := time.Unix(0, 0).UTC()
@@ -262,7 +353,11 @@ func TestAnalogJMigrationIntegration(t *testing.T) {
 	require.NoError(t, repo.gormClient.Where(queryDeviceID, currentDeviceID).First(&repaired).Error)
 	require.Equal(t, targetWWN, repaired.WWN)
 	for _, bucket := range buckets {
-		require.Positive(t, influxRecordCount(t, repo, bucket, "device_wwn", targetWWN))
+		expectedFields := 3
+		if bucket == "metrics_yearly" {
+			expectedFields = 6
+		}
+		require.Equal(t, expectedFields, influxRecordCount(t, repo, bucket, "device_wwn", targetWWN))
 		require.Zero(t, influxRecordCount(t, repo, bucket, "scrutiny_uuid", legacyUUID))
 	}
 
@@ -274,7 +369,7 @@ func TestAnalogJMigrationIntegration(t *testing.T) {
 	require.NoError(t, repo.gormClient.Transaction(func(tx *gorm.DB) error {
 		return repo.migrateM20260803000000(ctx, tx)
 	}))
-	require.Positive(t, influxRecordCount(t, repo, "metrics", "device_wwn", targetWWN))
+	require.Equal(t, 3, influxRecordCount(t, repo, "metrics", "device_wwn", targetWWN))
 }
 
 func influxRecordCount(t *testing.T, repo *scrutinyRepository, bucket, tag, value string) int {
@@ -288,7 +383,7 @@ func influxRecordCount(t *testing.T, repo *scrutinyRepository, bucket, tag, valu
 	defer result.Close()
 	count := 0
 	for result.Next() {
-		count++
+		count += int(result.Record().Value().(int64))
 	}
 	require.NoError(t, result.Err())
 	return count


### PR DESCRIPTION
## Summary

Fix startup failures in `m20260803000000` when AnalogJ 0.9.x history contains expired points that InfluxDB can still query. The rewrite now reads each bucket's actual retention rule and selects only its retention window; unlimited buckets keep the full history query. Custom retention settings remain unchanged.

Keep query and write errors fatal, and delete legacy series only after a successful rewrite. A point expiring during the query still stops the migration and preserves that source series for retry. Document this behavior and why ignoring all HTTP 422 or partial-write errors is unsafe.

## Linked Issues

Closes #776

## Test plan

- Reproduced the reported streamed retention error against an isolated InfluxDB 2.9.1 container on Zeus before the fix.
- The same integration regression passes after the fix: mixed expired/current SMART and temperature history, finite and unlimited retention, legacy tag cleanup, and idempotent rerun.
- Failure-path tests cover bucket lookup, HTTP rejection, streamed retention errors, streamed field conflicts, and delete failures; unsuccessful rewrites do not delete source history and retries complete all four buckets.
- Full database package tests pass with Go 1.25.0 and Go 1.27.1.
- `go vet ./webapp/backend/pkg/database/...` and `git diff --check` pass.
- golangci-lint 2.4.0 with Go 1.25.0 reports zero new issues against the base revision. Unrestricted database lint reports 53 existing findings.

Test container and SSH tunnel were removed. Production containers were not changed; this PR does not establish production upgrade acceptance.
