### PR TITLE
fix(smart): preserve ATA self-test chronology across lifetime rollover

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,6 +102,14 @@ unless the task specifically requires host-level device access from Zeus.
     ```
 6. open your browser to [http://localhost:8080/web](http://localhost:8080/web)
 
+## ATA self-test chronology
+
+ATA self-test lifetime hours wrap independently of the device's reported Power-On Hours. Keep the raw value unchanged and resolve an absolute age only when the controller's newest-first log order and a trustworthy current Power-On Hours value allow one epoch. A lone value such as 100 at device age 68,000 could mean either 100 or 65,636 hours; choosing the latest possible epoch would invent certainty.
+
+Retention uses collection time and controller log position. Repeated raw values can describe separate occurrences, so matching must consider resolved ages and the power-on context of earlier observations. If a later collection allows a new epoch but cannot identify the occurrence, retaining an ambiguous row alongside the earlier record is safer than overwriting history. This can retain a possible duplicate until the 21-row retention limit removes it. Without a collection timestamp, arrival time is the fallback and stale replay detection is unavailable.
+
+Migration preserves legacy raw values and IDs. Do not backfill absolute ages from raw sorting or database insertion order; only a fresh collection can supply the missing context. Regression checks must cover rollover ordering, repeated uploads, cross-epoch collisions, legacy migration, and ambiguous ages in both layouts.
+
 # Modifying the Scrutiny Frontend Angular SPA
 
 The frontend is written in Angular. If you're working on the frontend and can use mocked data rather than a real backend, you can follow the instructions below:

--- a/README.md
+++ b/README.md
@@ -566,7 +566,10 @@ Scrutiny now retains ATA SMART self-test log entries that are already present in
 
 - Data is read from normal SMART uploads; no separate self-test collector is required
 - Only ATA devices show this section today
-- Scrutiny keeps the most recent 21 recorded entries per physical ATA device identity
+- Scrutiny keeps the most recent 21 entries per physical ATA device identity using collection time and controller log position, including when lifetime hours wrap
+- Raw controller hours remain available. Absolute power-on ages are shown only when the current Power-On Hours and log order identify one rollover epoch; otherwise the UI shows "Unknown (may be wrapped)"
+- Existing history remains intact during upgrade. Ages stay unknown until a new collection provides enough context; already pruned or overwritten records cannot be recovered
+- Rolling back to a web release that uses the old raw-lifetime uniqueness key requires restoring a pre-upgrade database backup
 - The API route `GET /api/device/{id}/selftest` returns the same history used by the device detail page
 - This feature records and displays history only; it does not trigger or schedule drive self-tests from the web UI
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -41,7 +41,7 @@ See [AUTH.md](./AUTH.md) for configuration and deployment details.
 
 - The OpenAPI document is the source of truth. Do not add new standalone API tables elsewhere in the repo.
 - Some collector payloads are intentionally documented as structured objects with representative fields because the backend accepts large collector-origin JSON models.
-- `GET /api/device/{id}/selftest` returns ATA SMART self-test history already recorded during normal SMART uploads. The separate `POST /api/device/{id}/selftest` route remains reserved for future ingestion work.
+- `GET /api/device/{id}/selftest` returns ATA SMART self-test history already recorded during normal SMART uploads. Each entry preserves raw `lifetime_hours` and includes nullable `effective_lifetime_hours`; null means the absolute power-on age could not be resolved. Results follow newest observed controller log order, rather than raw lifetime values. The separate `POST /api/device/{id}/selftest` route remains reserved for future ingestion work.
 - Notification URL endpoints cover existing Shoutrrr syntax, explicit `apprise+...` targets, `script://` targets, and raw `http(s)` webhooks.
 - The replacement-risk endpoint includes ATA-specific metadata describing whether a bundled consumer-drive profile was enabled and applied for that score, plus provenance fields (source, sample count, match method, catalog version) when a profile is applied.
 - `GET /api/device/{id}/drive-profile` is a debug surface reporting the full consumer-drive profile match path: match method, confidence gate result, applied overrides, and fallback reason.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -487,7 +487,7 @@ paths:
     get:
       tags: [Devices]
       summary: Get ATA SMART self-test history for a device
-      description: Returns the ATA SMART self-test entries already recorded from normal SMART uploads for the resolved device identity.
+      description: Returns up to 21 ATA SMART self-test entries in newest observed log order. Absolute power-on ages are null when rollover cannot be resolved from the collection.
       parameters:
         - $ref: "#/components/parameters/DeviceId"
       responses:
@@ -1963,6 +1963,12 @@ components:
           type: boolean
         lifetime_hours:
           type: integer
+          description: Raw controller lifetime counter, preserved without adjustment.
+        effective_lifetime_hours:
+          type: integer
+          format: int64
+          nullable: true
+          description: Absolute power-on age resolved from controller log order and current Power-On Hours, or null when context is missing, unreliable, or allows multiple rollover epochs.
       required:
         - id
         - device_id
@@ -1973,6 +1979,7 @@ components:
         - status_string
         - status_passed
         - lifetime_hours
+        - effective_lifetime_hours
     DeviceSelfTestsResponse:
       type: object
       properties:

--- a/webapp/backend/pkg/database/scrutiny_repository_device_self_tests.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_device_self_tests.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/analogj/scrutiny/webapp/backend/pkg"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/models"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/models/collector"
 	"gorm.io/gorm"
-	"gorm.io/gorm/clause"
 )
 
 const maxDeviceSelfTestsPerDevice = 21
@@ -21,65 +21,125 @@ func deviceSelfTestIdentity(device *models.Device) string {
 	return device.DeviceID
 }
 
-func (sr *scrutinyRepository) syncDeviceSelfTests(ctx context.Context, device *models.Device, collectorSmartData *collector.SmartInfo) error {
+// The controller log is newest first. Observation order also works when the
+// power-on counter is missing, wrapped, or reset; raw lifetime order does not.
+const selfTestHistoryOrder = "observed_at DESC, log_index ASC, id DESC"
+const selfTestLifetimePeriod int64 = 65536
+
+// selfTestLifetimeBounds intersects the possible epochs with both log order and
+// the current power-on age. A lone wrapped value can have several valid epochs.
+func selfTestLifetimeBounds(entries []collector.AtaSmartSelfTestLogEntry, powerOnHours int64) ([]int64, []int64) {
+	minimum := make([]int64, len(entries))
+	maximum := make([]int64, len(entries))
+	for i := range maximum {
+		maximum[i] = -1
+	}
+	if powerOnHours <= 0 {
+		return minimum, maximum
+	}
+	for _, entry := range entries {
+		if entry.LifetimeHours < 0 || int64(entry.LifetimeHours) >= selfTestLifetimePeriod {
+			return minimum, maximum
+		}
+	}
+	var lower int64
+	for i := len(entries) - 1; i >= 0; i-- {
+		raw := int64(entries[i].LifetimeHours)
+		lower += (raw - lower%selfTestLifetimePeriod + selfTestLifetimePeriod) % selfTestLifetimePeriod
+		minimum[i] = lower
+	}
+	upper := powerOnHours
+	for i, entry := range entries {
+		raw := int64(entry.LifetimeHours)
+		upper -= (upper%selfTestLifetimePeriod - raw + selfTestLifetimePeriod) % selfTestLifetimePeriod
+		if upper < minimum[i] {
+			for j := range maximum {
+				maximum[j] = -1
+			}
+			return minimum, maximum
+		}
+		maximum[i] = upper
+	}
+	return minimum, maximum
+}
+
+func (sr *scrutinyRepository) syncDeviceSelfTests(ctx context.Context, device *models.Device, collectorSmartData *collector.SmartInfo, powerOnHours int64) error {
 	if collectorSmartData.Device.Protocol != pkg.DeviceProtocolAta {
 		return nil
 	}
-
-	selfTestEntries := collectorSmartData.AtaSmartSelfTestLog.Entries()
-	if len(selfTestEntries) == 0 {
+	entries := collectorSmartData.AtaSmartSelfTestLog.Entries()
+	if len(entries) == 0 {
 		return nil
 	}
-
-	deviceIdentity := deviceSelfTestIdentity(device)
+	identity := deviceSelfTestIdentity(device)
+	observedAt := collectorSmartData.LocalTime.TimeT
+	if observedAt <= 0 {
+		observedAt = time.Now().Unix()
+	}
+	minimum, maximum := selfTestLifetimeBounds(entries, powerOnHours)
 
 	return sr.gormClient.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		for _, selfTestEntry := range selfTestEntries {
+		var existing []models.DeviceSelfTest
+		if err := tx.Where("device_identity = ?", identity).Order(selfTestHistoryOrder).Find(&existing).Error; err != nil {
+			return err
+		}
+		// Replayed older collections must not reorder or prune newer history.
+		if len(existing) > 0 && existing[0].ObservedAt > observedAt {
+			return nil
+		}
+		used := make(map[uint]bool)
+		for index, entry := range entries {
 			row := models.DeviceSelfTest{
-				DeviceID:       device.DeviceID,
-				DeviceWWN:      device.WWN,
-				DeviceIdentity: deviceIdentity,
-				TypeValue:      selfTestEntry.Type.Value,
-				TypeString:     selfTestEntry.Type.String,
-				StatusValue:    selfTestEntry.Status.Value,
-				StatusString:   selfTestEntry.Status.String,
-				StatusPassed:   selfTestEntry.Status.Passed,
-				LifetimeHours:  selfTestEntry.LifetimeHours,
+				DeviceID: device.DeviceID, DeviceWWN: device.WWN, DeviceIdentity: identity,
+				TypeValue: entry.Type.Value, TypeString: entry.Type.String,
+				StatusValue: entry.Status.Value, StatusString: entry.Status.String,
+				StatusPassed: entry.Status.Passed, LifetimeHours: entry.LifetimeHours,
+				ObservedAt: observedAt, LogIndex: index, ObservationPowerOnHours: powerOnHours,
 			}
-
-			if err := tx.Clauses(clause.OnConflict{
-				Columns: []clause.Column{
-					{Name: "device_identity"},
-					{Name: "type_value"},
-					{Name: "lifetime_hours"},
-				},
-				DoUpdates: clause.AssignmentColumns([]string{
-					"device_id",
-					"device_wwn",
-					"type_string",
-					"status_value",
-					"status_string",
-					"status_passed",
-					"updated_at",
-				}),
-			}).Create(&row).Error; err != nil {
+			if maximum[index] >= 0 && minimum[index] == maximum[index] {
+				hours := maximum[index]
+				row.EffectiveLifetimeHours = &hours
+			}
+			for oldIndex := range existing {
+				old := &existing[oldIndex]
+				if used[old.ID] || old.TypeValue != row.TypeValue || old.LifetimeHours != row.LifetimeHours {
+					continue
+				}
+				if row.EffectiveLifetimeHours != nil {
+					if old.EffectiveLifetimeHours != nil && *old.EffectiveLifetimeHours != *row.EffectiveLifetimeHours {
+						continue
+					}
+					if old.ObservationPowerOnHours > 0 && *row.EffectiveLifetimeHours > old.ObservationPowerOnHours {
+						continue
+					}
+				} else {
+					// A newly possible epoch can represent a different test even
+					// when the raw value and type match an earlier observation.
+					if old.ObservationPowerOnHours > 0 && (maximum[index] > old.ObservationPowerOnHours || powerOnHours-old.ObservationPowerOnHours >= selfTestLifetimePeriod) {
+						continue
+					}
+					if old.EffectiveLifetimeHours != nil && maximum[index] >= 0 {
+						if *old.EffectiveLifetimeHours < minimum[index] || *old.EffectiveLifetimeHours > maximum[index] {
+							continue
+						}
+					}
+				}
+				row.ID, row.CreatedAt = old.ID, old.CreatedAt
+				used[old.ID] = true
+				break
+			}
+			if err := tx.Save(&row).Error; err != nil {
 				return err
 			}
 		}
-
 		var staleIDs []uint
-		if err := tx.Model(&models.DeviceSelfTest{}).
-			Where("device_identity = ?", deviceIdentity).
-			Order("lifetime_hours DESC, updated_at DESC, id DESC").
-			Offset(maxDeviceSelfTestsPerDevice).
-			Pluck("id", &staleIDs).Error; err != nil {
+		if err := tx.Model(&models.DeviceSelfTest{}).Where("device_identity = ?", identity).
+			Order(selfTestHistoryOrder).Offset(maxDeviceSelfTestsPerDevice).Pluck("id", &staleIDs).Error; err != nil {
 			return err
 		}
-
 		if len(staleIDs) == 0 {
 			return nil
 		}
-
 		return tx.Delete(&models.DeviceSelfTest{}, staleIDs).Error
 	})
 }
@@ -94,7 +154,7 @@ func (sr *scrutinyRepository) GetDeviceSelfTests(ctx context.Context, deviceID s
 	selfTests := []models.DeviceSelfTest{}
 	if err := sr.gormClient.WithContext(ctx).
 		Where("device_identity = ?", deviceIdentity).
-		Order("lifetime_hours DESC, id DESC").
+		Order(selfTestHistoryOrder).
 		Find(&selfTests).Error; err != nil {
 		return nil, fmt.Errorf("could not get device self-tests from DB: %v", err)
 	}

--- a/webapp/backend/pkg/database/scrutiny_repository_device_self_tests_test.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_device_self_tests_test.go
@@ -4,13 +4,16 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/analogj/scrutiny/webapp/backend/pkg"
 	mock_config "github.com/analogj/scrutiny/webapp/backend/pkg/config/mock"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/models"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/models/collector"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/models/measurements"
 	"github.com/glebarez/sqlite"
 	"github.com/golang/mock/gomock"
 	influxapi "github.com/influxdata/influxdb-client-go/v2/api"
@@ -69,7 +72,7 @@ func createDeviceSelfTestRepository(t *testing.T) *scrutinyRepository {
 
 	db, err := gorm.Open(sqlite.Open("file:"+t.Name()+"?mode=memory&cache=shared"), &gorm.Config{})
 	require.NoError(t, err)
-	require.NoError(t, db.AutoMigrate(&models.Device{}, &models.DeviceSelfTest{}, &models.AttributeOverride{}))
+	require.NoError(t, db.AutoMigrate(&models.Device{}, &models.DeviceSelfTest{}, &models.AttributeOverride{}, &models.DeviceEnduranceOverride{}))
 
 	return &scrutinyRepository{
 		appConfig:      fakeConfig,
@@ -163,8 +166,8 @@ func TestSyncDeviceSelfTestsDedupesByDeviceIdentity(t *testing.T) {
 	updatedPayload.AtaSmartSelfTestLog.Standard.Table[0].Status.String = "Completed without error"
 	updatedPayload.AtaSmartSelfTestLog.Standard.Table[0].Status.Passed = true
 
-	require.NoError(t, repo.syncDeviceSelfTests(ctx, &initialDevice, &initialPayload))
-	require.NoError(t, repo.syncDeviceSelfTests(ctx, &replacementDevice, &updatedPayload))
+	require.NoError(t, repo.syncDeviceSelfTests(ctx, &initialDevice, &initialPayload, 100))
+	require.NoError(t, repo.syncDeviceSelfTests(ctx, &replacementDevice, &updatedPayload, 100))
 
 	var selfTests []models.DeviceSelfTest
 	require.NoError(t, repo.gormClient.WithContext(ctx).Find(&selfTests).Error)
@@ -187,7 +190,7 @@ func TestSyncDeviceSelfTestsPrunesOldEntries(t *testing.T) {
 
 	payload := collector.SmartInfo{}
 	payload.Device.Protocol = "ATA"
-	for lifetime := 1; lifetime <= 25; lifetime++ {
+	for lifetime := 25; lifetime >= 1; lifetime-- {
 		entry := collector.AtaSmartSelfTestLogEntry{
 			LifetimeHours: lifetime,
 		}
@@ -199,7 +202,7 @@ func TestSyncDeviceSelfTestsPrunesOldEntries(t *testing.T) {
 		payload.AtaSmartSelfTestLog.Standard.Table = append(payload.AtaSmartSelfTestLog.Standard.Table, entry)
 	}
 
-	require.NoError(t, repo.syncDeviceSelfTests(ctx, &device, &payload))
+	require.NoError(t, repo.syncDeviceSelfTests(ctx, &device, &payload, 25))
 
 	var selfTests []models.DeviceSelfTest
 	require.NoError(t, repo.gormClient.WithContext(ctx).
@@ -209,4 +212,185 @@ func TestSyncDeviceSelfTestsPrunesOldEntries(t *testing.T) {
 	require.Len(t, selfTests, 21)
 	require.Equal(t, 25, selfTests[0].LifetimeHours)
 	require.Equal(t, 5, selfTests[len(selfTests)-1].LifetimeHours)
+}
+
+func selfTestPayload(hours, observed int64, lifetimes ...int) collector.SmartInfo {
+	payload := collector.SmartInfo{}
+	payload.Device.Protocol = "ATA"
+	payload.PowerOnTime.Hours = hours
+	payload.LocalTime.TimeT = observed
+	for _, lifetime := range lifetimes {
+		entry := collector.AtaSmartSelfTestLogEntry{LifetimeHours: lifetime}
+		entry.Type.Value = 1
+		entry.Type.String = "Short offline"
+		entry.Status.Passed = true
+		payload.AtaSmartSelfTestLog.Standard.Table = append(payload.AtaSmartSelfTestLog.Standard.Table, entry)
+	}
+	return payload
+}
+
+func TestSelfTestLifetimeBounds(t *testing.T) {
+	tests := []struct {
+		name     string
+		hours    int64
+		raw      []int
+		expected []int64 // -1 means ambiguous
+	}{
+		{"reported rollover", 68000, []int{2464, 39224}, []int64{68000, 39224}},
+		{"before rollover", 65000, []int{64000, 100}, []int64{64000, 100}},
+		{"rollover boundary", 65536, []int{0, 65535}, []int64{65536, 65535}},
+		{"multiple possible epochs", 68000, []int{100}, []int64{-1}},
+		{"multiple witnessed wraps", 131100, []int{28, 65535, 0, 65535}, []int64{131100, 131071, 65536, 65535}},
+		{"missing hours", 0, []int{2464, 39224}, []int64{-1, -1}},
+		{"negative hours", -1, []int{100}, []int64{-1}},
+		{"inconsistent current counter", 100, []int{200, 100}, []int64{-1, -1}},
+		{"invalid raw value", 68000, []int{-1, 100}, []int64{-1, -1}},
+		{"outside ATA field", 68000, []int{65536}, []int64{-1}},
+		{"same hour", 100, []int{100, 100}, []int64{100, 100}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			payload := selfTestPayload(tt.hours, 1000, tt.raw...)
+			minimum, maximum := selfTestLifetimeBounds(payload.AtaSmartSelfTestLog.Entries(), tt.hours)
+			for i, want := range tt.expected {
+				if want < 0 {
+					require.True(t, maximum[i] < 0 || minimum[i] != maximum[i])
+					continue
+				}
+				require.Equal(t, want, minimum[i])
+				require.Equal(t, want, maximum[i])
+			}
+		})
+	}
+}
+
+func TestSelfTestChronologyAcrossCollections(t *testing.T) {
+	repo := createDeviceSelfTestRepository(t)
+	ctx := context.Background()
+	device := models.Device{DeviceID: "device-1", WWN: "wwn-1", DeviceProtocol: "ATA"}
+	require.NoError(t, repo.gormClient.Create(&device).Error)
+	save := func(payload collector.SmartInfo) []models.DeviceSelfTest {
+		t.Helper()
+		require.NoError(t, repo.syncDeviceSelfTests(ctx, &device, &payload, payload.PowerOnTime.Hours))
+		rows, err := repo.GetDeviceSelfTests(ctx, device.DeviceID)
+		require.NoError(t, err)
+		return rows
+	}
+	old := save(selfTestPayload(40000, 1000, 39224, 2464))
+	require.Len(t, old, 2)
+	oldID := old[1].ID
+	payload := selfTestPayload(68000, 2000, 2464, 39224)
+	rows := save(payload)
+	require.Len(t, rows, 3)
+	require.Equal(t, int64(68000), *rows[0].EffectiveLifetimeHours)
+	require.Equal(t, 2464, rows[0].LifetimeHours)
+	require.NotEqual(t, oldID, rows[0].ID)
+	require.Equal(t, int64(39224), *rows[1].EffectiveLifetimeHours)
+	require.Equal(t, oldID, rows[2].ID)
+	require.Equal(t, int64(2464), *rows[2].EffectiveLifetimeHours)
+	ids := []uint{rows[0].ID, rows[1].ID, rows[2].ID}
+	payload.LocalTime.TimeT = 3000
+	payload.AtaSmartSelfTestLog.Standard.Table[0].Status.String = "Updated status"
+	rows = save(payload)
+	require.Len(t, rows, 3)
+	require.Equal(t, ids, []uint{rows[0].ID, rows[1].ID, rows[2].ID})
+	require.Equal(t, "Updated status", rows[0].StatusString)
+	rows = save(selfTestPayload(40000, 1500, 39224, 2464))
+	require.Equal(t, ids, []uint{rows[0].ID, rows[1].ID, rows[2].ID})
+	require.Equal(t, int64(3000), rows[0].ObservedAt)
+}
+
+func TestSelfTestRetentionUsesControllerOrder(t *testing.T) {
+	for _, hours := range []int64{68000, 0} {
+		t.Run(fmt.Sprint(hours), func(t *testing.T) {
+			repo := createDeviceSelfTestRepository(t)
+			ctx := context.Background()
+			device := models.Device{DeviceID: "device-1"}
+			payload := selfTestPayload(hours, 1000, 2464)
+			for raw := 65000; raw > 64975; raw-- {
+				entry := collector.AtaSmartSelfTestLogEntry{LifetimeHours: raw}
+				payload.AtaSmartSelfTestLog.Standard.Table = append(payload.AtaSmartSelfTestLog.Standard.Table, entry)
+			}
+			require.NoError(t, repo.syncDeviceSelfTests(ctx, &device, &payload, hours))
+			var rows []models.DeviceSelfTest
+			require.NoError(t, repo.gormClient.Order(selfTestHistoryOrder).Find(&rows).Error)
+			require.Len(t, rows, 21)
+			require.Equal(t, 2464, rows[0].LifetimeHours)
+			require.Equal(t, 64981, rows[20].LifetimeHours)
+			if hours == 0 {
+				require.Nil(t, rows[0].EffectiveLifetimeHours)
+			}
+		})
+	}
+}
+
+func TestSelfTestAmbiguousOccurrenceDoesNotOverwriteEarlierEpoch(t *testing.T) {
+	repo := createDeviceSelfTestRepository(t)
+	ctx := context.Background()
+	device := models.Device{DeviceID: "device-1"}
+	before := selfTestPayload(65000, 1000, 100)
+	require.NoError(t, repo.syncDeviceSelfTests(ctx, &device, &before, 65000))
+	after := selfTestPayload(65636, 2000, 100)
+	for i := 0; i < 2; i++ {
+		require.NoError(t, repo.syncDeviceSelfTests(ctx, &device, &after, 65636))
+	}
+	var rows []models.DeviceSelfTest
+	require.NoError(t, repo.gormClient.Order(selfTestHistoryOrder).Find(&rows).Error)
+	require.Len(t, rows, 2)
+	require.Nil(t, rows[0].EffectiveLifetimeHours)
+	require.Equal(t, int64(100), *rows[1].EffectiveLifetimeHours)
+}
+
+func TestSelfTestSameHourOccurrencesAndExtendedFallback(t *testing.T) {
+	repo := createDeviceSelfTestRepository(t)
+	ctx := context.Background()
+	device := models.Device{DeviceID: "device-1"}
+	payload := selfTestPayload(100, 1000, 100, 100)
+	payload.AtaSmartSelfTestLog.Extended.Table = payload.AtaSmartSelfTestLog.Standard.Table
+	payload.AtaSmartSelfTestLog.Standard.Table = nil
+	for i := 0; i < 2; i++ {
+		require.NoError(t, repo.syncDeviceSelfTests(ctx, &device, &payload, 100))
+	}
+	var rows []models.DeviceSelfTest
+	require.NoError(t, repo.gormClient.Find(&rows).Error)
+	require.Len(t, rows, 2)
+	payload.Device.Protocol = "NVMe"
+	payload.AtaSmartSelfTestLog.Extended.Table[0].LifetimeHours = 99
+	require.NoError(t, repo.syncDeviceSelfTests(ctx, &device, &payload, 100))
+	require.NoError(t, repo.gormClient.Find(&rows).Error)
+	require.Len(t, rows, 2)
+}
+
+func TestSelfTestRejectsUnreliablePowerOnContext(t *testing.T) {
+	current := measurements.Smart{PowerOnHours: 68000}
+	require.Equal(t, int64(68000), selfTestPowerOnHours(&current, nil))
+	previous := measurements.Smart{PowerOnHours: 69000}
+	require.Zero(t, selfTestPowerOnHours(&current, &previous))
+	current.Attributes = map[string]measurements.SmartAttribute{"9": &measurements.SmartAtaAttribute{Status: pkg.AttributeStatusWarningScrutiny}}
+	require.Zero(t, selfTestPowerOnHours(&current, nil))
+}
+
+func TestSaveSmartAttributesResolvesSelfTestRollover(t *testing.T) {
+	repo := createDeviceSelfTestRepository(t)
+	ctx := context.Background()
+	device := models.Device{DeviceID: "device-1", WWN: "wwn-1", DeviceProtocol: "ATA"}
+	require.NoError(t, repo.gormClient.Create(&device).Error)
+	payload := loadSmartInfoFixture(t, filepath.Join("..", "web", "testdata", "upload-device-metrics-req.json"))
+	payload.PowerOnTime.Hours = 68000
+	payload.AtaSmartSelfTestLog = selfTestPayload(68000, 1000, 2464, 39224).AtaSmartSelfTestLog
+	for i := range payload.AtaSmartAttributes.Table {
+		attribute := &payload.AtaSmartAttributes.Table[i]
+		if attribute.ID == 9 {
+			attribute.Raw.Value = 68000
+			attribute.Raw.String = "68000"
+		}
+	}
+	_, err := repo.SaveSmartAttributes(ctx, device.WWN, payload)
+	require.NoError(t, err)
+	rows, err := repo.GetDeviceSelfTests(ctx, device.DeviceID)
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+	require.NotNil(t, rows[0].EffectiveLifetimeHours)
+	require.Equal(t, int64(68000), *rows[0].EffectiveLifetimeHours)
+	require.Equal(t, int64(39224), *rows[1].EffectiveLifetimeHours)
 }

--- a/webapp/backend/pkg/database/scrutiny_repository_device_smart_attributes.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_device_smart_attributes.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/analogj/scrutiny/webapp/backend/pkg"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/models/collector"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/models/measurements"
 	influxdb2 "github.com/influxdata/influxdb-client-go/v2"
@@ -56,7 +57,7 @@ func (sr *scrutinyRepository) SaveSmartAttributes(ctx context.Context, wwn strin
 	tags, fields := deviceSmartData.Flatten()
 
 	if devErr == nil {
-		if err := sr.syncDeviceSelfTests(ctx, &device, &collectorSmartData); err != nil {
+		if err := sr.syncDeviceSelfTests(ctx, &device, &collectorSmartData, selfTestPowerOnHours(&deviceSmartData, previousSmart)); err != nil {
 			return measurements.Smart{}, err
 		}
 	}
@@ -340,4 +341,16 @@ func (sr *scrutinyRepository) generateSmartAttributesSubquery(wwn string, durati
 	partialQueryStr = append(partialQueryStr, "|> schema.fieldsAsCols()")
 
 	return strings.Join(partialQueryStr, "\n")
+}
+
+// Self-test epochs require a trustworthy absolute upper bound. A warning or a
+// counter decrease is evidence against treating the reported hours as absolute.
+func selfTestPowerOnHours(current, previous *measurements.Smart) int64 {
+	if previous != nil && previous.PowerOnHours > current.PowerOnHours {
+		return 0
+	}
+	if attribute, ok := current.Attributes["9"].(*measurements.SmartAtaAttribute); ok && pkg.AttributeStatusHas(attribute.Status, pkg.AttributeStatusWarningScrutiny) {
+		return 0
+	}
+	return current.PowerOnHours
 }

--- a/webapp/backend/pkg/database/scrutiny_repository_migrations.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_migrations.go
@@ -664,6 +664,7 @@ func (sr *scrutinyRepository) Migrate(ctx context.Context) error {
 				return tx.Exec("CREATE UNIQUE INDEX idx_override_lookup ON attribute_overrides (protocol, attribute_id, device_id, wwn)").Error
 			},
 		},
+		{ID: "m20260905000000", Migrate: migrateSelfTestChronology},
 	})
 
 	if err := m.Migrate(); err != nil {
@@ -1613,4 +1614,16 @@ func (sr *scrutinyRepository) migrateM20260701000000(tx *gorm.DB) error {
 		SettingValueString:    "",
 	}
 	return tx.Create(&defaultSetting).Error
+}
+
+// Existing rows have no reliable epoch or controller position. Preserve their
+// raw values and IDs; the next collection can supply chronology for matching rows.
+func migrateSelfTestChronology(tx *gorm.DB) error {
+	if err := tx.Exec("DROP INDEX IF EXISTS idx_device_self_tests_identity").Error; err != nil {
+		return err
+	}
+	if err := tx.Exec("DROP INDEX IF EXISTS idx_device_self_tests_history").Error; err != nil {
+		return err
+	}
+	return tx.AutoMigrate(&models.DeviceSelfTest{})
 }

--- a/webapp/backend/pkg/database/scrutiny_repository_migrations_test.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_migrations_test.go
@@ -563,3 +563,25 @@ func TestMigrateEnablesTemperatureHistoryStorage(t *testing.T) {
 	require.Equal(t, "bool", setting.SettingDataType)
 	require.True(t, setting.SettingValueBool)
 }
+
+func TestMigrateSelfTestChronologyPreservesLegacyHistory(t *testing.T) {
+	repo := createMigrationTestRepository(t)
+	require.NoError(t, repo.gormClient.Exec(`CREATE TABLE device_self_tests (
+        id INTEGER PRIMARY KEY, created_at DATETIME, updated_at DATETIME, deleted_at DATETIME,
+        device_identity TEXT, device_id TEXT, device_wwn TEXT, type_value INTEGER,
+        type_string TEXT, status_value INTEGER, status_string TEXT, status_passed NUMERIC, lifetime_hours INTEGER
+    )`).Error)
+	require.NoError(t, repo.gormClient.Exec(`CREATE UNIQUE INDEX idx_device_self_tests_identity ON device_self_tests(device_identity,type_value,lifetime_hours)`).Error)
+	require.NoError(t, repo.gormClient.Exec(`CREATE INDEX idx_device_self_tests_history ON device_self_tests(device_identity,lifetime_hours)`).Error)
+	require.NoError(t, repo.gormClient.Exec(`INSERT INTO device_self_tests(id,device_identity,device_id,device_wwn,type_value,lifetime_hours) VALUES (42,'wwn-1','device-1','wwn-1',1,2464)`).Error)
+	require.NoError(t, repo.gormClient.Exec(`INSERT INTO migrations(id) VALUES ('m20260616000000')`).Error)
+	require.NoError(t, repo.Migrate(context.Background()))
+	require.NoError(t, repo.Migrate(context.Background()))
+	var row models.DeviceSelfTest
+	require.NoError(t, repo.gormClient.First(&row, 42).Error)
+	require.Equal(t, 2464, row.LifetimeHours)
+	require.Nil(t, row.EffectiveLifetimeHours)
+	require.Zero(t, row.ObservedAt)
+	require.False(t, repo.gormClient.Migrator().HasIndex(&models.DeviceSelfTest{}, "idx_device_self_tests_identity"))
+	require.NoError(t, repo.gormClient.Exec(`INSERT INTO device_self_tests(device_identity,type_value,lifetime_hours,effective_lifetime_hours) VALUES ('wwn-1',1,2464,68000)`).Error)
+}

--- a/webapp/backend/pkg/models/device_selftests.go
+++ b/webapp/backend/pkg/models/device_selftests.go
@@ -3,17 +3,21 @@ package models
 import "time"
 
 type DeviceSelfTest struct {
-	CreatedAt      time.Time  `json:"created_at"`
-	UpdatedAt      time.Time  `json:"updated_at"`
-	DeletedAt      *time.Time `json:"deleted_at,omitempty"`
-	DeviceIdentity string     `json:"-" gorm:"index:idx_device_self_tests_identity,unique;index:idx_device_self_tests_history"`
-	DeviceID       string     `json:"device_id" gorm:"index"`
-	DeviceWWN      string     `json:"device_wwn" gorm:"index"`
-	TypeString     string     `json:"type_string"`
-	StatusString   string     `json:"status_string"`
-	ID             uint       `json:"id" gorm:"primaryKey"`
-	TypeValue      int        `json:"type_value" gorm:"index:idx_device_self_tests_identity,unique"`
-	StatusValue    int        `json:"status_value"`
-	LifetimeHours  int        `json:"lifetime_hours" gorm:"index:idx_device_self_tests_identity,unique;index:idx_device_self_tests_history"`
-	StatusPassed   bool       `json:"status_passed"`
+	CreatedAt               time.Time  `json:"created_at"`
+	UpdatedAt               time.Time  `json:"updated_at"`
+	DeletedAt               *time.Time `json:"deleted_at,omitempty"`
+	DeviceIdentity          string     `json:"-" gorm:"index:idx_device_self_tests_history"`
+	DeviceID                string     `json:"device_id" gorm:"index"`
+	DeviceWWN               string     `json:"device_wwn" gorm:"index"`
+	TypeString              string     `json:"type_string"`
+	StatusString            string     `json:"status_string"`
+	ID                      uint       `json:"id" gorm:"primaryKey"`
+	TypeValue               int        `json:"type_value"`
+	StatusValue             int        `json:"status_value"`
+	LifetimeHours           int        `json:"lifetime_hours"`
+	EffectiveLifetimeHours  *int64     `json:"effective_lifetime_hours"`
+	ObservedAt              int64      `json:"-" gorm:"index:idx_device_self_tests_history"`
+	LogIndex                int        `json:"-" gorm:"index:idx_device_self_tests_history"`
+	ObservationPowerOnHours int64      `json:"-"`
+	StatusPassed            bool       `json:"status_passed"`
 }

--- a/webapp/backend/pkg/web/handler/get_device_self_tests_test.go
+++ b/webapp/backend/pkg/web/handler/get_device_self_tests_test.go
@@ -24,17 +24,20 @@ func TestGetDeviceSelfTests(t *testing.T) {
 
 	fakeRepo := mock_database.NewMockDeviceRepo(mockCtrl)
 	device := models.Device{DeviceID: "device-1", WWN: testDeviceWWN, DeviceName: "/dev/sda"}
+	effectiveHours := int64(68000)
 	selfTests := []models.DeviceSelfTest{
 		{
-			DeviceID:      "device-1",
-			DeviceWWN:     testDeviceWWN,
-			TypeValue:     1,
-			TypeString:    "Short offline",
-			StatusValue:   0,
-			StatusString:  "Completed without error",
-			StatusPassed:  true,
-			LifetimeHours: 1708,
+			DeviceID:               "device-1",
+			DeviceWWN:              testDeviceWWN,
+			TypeValue:              1,
+			TypeString:             "Short offline",
+			StatusValue:            0,
+			StatusString:           "Completed without error",
+			StatusPassed:           true,
+			LifetimeHours:          2464,
+			EffectiveLifetimeHours: &effectiveHours,
 		},
+		{LifetimeHours: 100},
 	}
 
 	fakeRepo.EXPECT().GetDeviceDetails(gomock.Any(), "device-1").Return(device, nil)
@@ -63,8 +66,11 @@ func TestGetDeviceSelfTests(t *testing.T) {
 	}
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
 	require.True(t, response.Success)
-	require.Len(t, response.Data.SelfTests, 1)
-	require.Equal(t, 1708, response.Data.SelfTests[0].LifetimeHours)
+	require.Len(t, response.Data.SelfTests, 2)
+	require.Nil(t, response.Data.SelfTests[1].EffectiveLifetimeHours)
+	require.Contains(t, w.Body.String(), `"effective_lifetime_hours":null`)
+	require.Equal(t, 2464, response.Data.SelfTests[0].LifetimeHours)
+	require.Equal(t, int64(68000), *response.Data.SelfTests[0].EffectiveLifetimeHours)
 	require.Equal(t, "Short offline", response.Data.SelfTests[0].TypeString)
 }
 

--- a/webapp/frontend/src/app/core/models/device-selftest-model.ts
+++ b/webapp/frontend/src/app/core/models/device-selftest-model.ts
@@ -10,4 +10,5 @@ export interface DeviceSelfTestModel {
     status_string: string;
     status_passed: boolean;
     lifetime_hours: number;
+    effective_lifetime_hours?: number | null;
 }

--- a/webapp/frontend/src/app/modules/detail/detail.component.html
+++ b/webapp/frontend/src/app/modules/detail/detail.component.html
@@ -367,11 +367,10 @@
                                     </span>
                                 </td>
                                 <td class="py-2 pr-4 text-secondary">{{ selfTest.status_string }}</td>
-                                <td
-                                    class="py-2 text-right"
-                                    matTooltip="{{ humanizeDuration(selfTest.lifetime_hours * 60 * 60 * 1000, { conjunction: ' and ', serialComma: false }) }}"
-                                >
-                                    {{ selfTest.lifetime_hours | deviceHours : config.powered_on_hours_unit : { round: true, largest: 1, units: ['y', 'd', 'h'] } }}
+                                <td class="py-2 text-right" [matTooltip]="selfTestAgeTooltip(selfTest)">
+                                    @if (selfTest.effective_lifetime_hours !== null && selfTest.effective_lifetime_hours !== undefined) {
+                                    {{ selfTest.effective_lifetime_hours | deviceHours : config.powered_on_hours_unit : { round: true, largest: 1, units: ['y', 'd', 'h'] } }}
+                                    } @else { Unknown (may be wrapped) }
                                 </td>
                             </tr>
                             }
@@ -391,11 +390,10 @@
                                 <span class="w-2 h-2 rounded-full mr-2" [ngClass]="selfTestDotClass(selfTest)"></span>
                                 {{ selfTestStatusLabel(selfTest) }}
                             </div>
-                            <div
-                                class="text-xs text-secondary mt-1"
-                                matTooltip="{{ humanizeDuration(selfTest.lifetime_hours * 60 * 60 * 1000, { conjunction: ' and ', serialComma: false }) }}"
-                            >
-                                {{ selfTest.lifetime_hours | deviceHours : config.powered_on_hours_unit : { round: true, largest: 1, units: ['y', 'd', 'h'] } }}
+                            <div class="text-xs text-secondary mt-1" [matTooltip]="selfTestAgeTooltip(selfTest)">
+                                @if (selfTest.effective_lifetime_hours !== null && selfTest.effective_lifetime_hours !== undefined) {
+                                {{ selfTest.effective_lifetime_hours | deviceHours : config.powered_on_hours_unit : { round: true, largest: 1, units: ['y', 'd', 'h'] } }}
+                                } @else { Unknown (may be wrapped) }
                             </div>
                         </div>
                     </div>

--- a/webapp/frontend/src/app/modules/detail/detail.component.spec.ts
+++ b/webapp/frontend/src/app/modules/detail/detail.component.spec.ts
@@ -120,6 +120,54 @@ describe('DetailComponent', () => {
         expect(mockDetailService.getSelfTestData).toHaveBeenCalledWith('device-1');
     });
 
+    describe('self-test power-on age', () => {
+        const row: DeviceSelfTestModel = {
+            id: 1,
+            created_at: '',
+            updated_at: '',
+            device_id: 'device-1',
+            device_wwn: 'wwn-1',
+            type_value: 2,
+            type_string: 'Extended offline',
+            status_value: 0,
+            status_string: 'Completed without error',
+            status_passed: true,
+            lifetime_hours: 2464,
+            effective_lifetime_hours: 68000,
+        };
+
+        it('keeps raw and resolved hours in the tooltip', () => {
+            expect(component.selfTestAgeTooltip(row)).toContain('Controller lifetime: 2464 hours.');
+            expect(component.selfTestAgeTooltip(row)).toContain('Resolved power-on age: 68000 hours.');
+        });
+
+        for (const hours of [null, undefined]) {
+            it(`explains ambiguous age for ${hours}`, () => {
+                const tooltip = component.selfTestAgeTooltip({ ...row, effective_lifetime_hours: hours });
+                expect(tooltip).toContain('Absolute power-on age is unknown');
+                expect(tooltip).toContain('2464 hours');
+            });
+        }
+
+        for (const mobile of [false, true]) {
+            it(`renders resolved and ambiguous ages with mobile=${mobile}`, () => {
+                fixture.detectChanges();
+                component.isMobile = mobile;
+                component.config.powered_on_hours_unit = 'device_hours';
+                component.selfTestsLoading = false;
+                component.selfTestsLoaded = true;
+                component.selfTests = [row, { ...row, id: 2, effective_lifetime_hours: null }, { ...row, id: 3, effective_lifetime_hours: 0 }];
+                fixture.changeDetectorRef.markForCheck();
+                fixture.detectChanges();
+                const text = fixture.nativeElement.textContent;
+                expect(text).toContain('68000 hours');
+                expect(text).toContain('Unknown (may be wrapped)');
+                expect(text).toContain('0 hours');
+                expect(text).not.toContain('2464 hours');
+            });
+        }
+    });
+
     describe('selfTestStatusLabel', () => {
         it('should return Passed for successful self-tests', () => {
             const selfTest = { status_passed: true } as DeviceSelfTestModel;

--- a/webapp/frontend/src/app/modules/detail/detail.component.ts
+++ b/webapp/frontend/src/app/modules/detail/detail.component.ts
@@ -806,6 +806,14 @@ export class DetailComponent implements OnInit, AfterViewInit, OnDestroy {
         };
     }
 
+    selfTestAgeTooltip(selfTest: DeviceSelfTestModel): string {
+        const raw = `Controller lifetime: ${selfTest.lifetime_hours} hours.`;
+        if (selfTest.effective_lifetime_hours == null) {
+            return `${raw} Absolute power-on age is unknown because the lifetime counter may have wrapped or power-on context is unavailable.`;
+        }
+        return `${raw} Resolved power-on age: ${selfTest.effective_lifetime_hours} hours.`;
+    }
+
     selfTestStatusLabel(selfTest: DeviceSelfTestModel): string {
         return selfTest.status_passed ? 'Passed' : 'Attention';
     }


### PR DESCRIPTION
## Summary

ATA self-test lifetime hours wrap at 65,536. Raw-value sorting could put new tests behind old tests, prune them from the 21-row history, and overwrite a same-type test from an earlier epoch. For the reported 68,000-hour drive, the new code resolves log values 2,464 and 39,224 to 68,000 and 39,224 hours in that order.

The backend preserves raw hours, resolves absolute ages only when controller log order and current Power-On Hours identify one epoch, and orders retention by collection time and log position. Desktop and mobile show an explicit unknown age when context is ambiguous. The migration preserves existing row IDs and raw values and replaces the old raw-value uniqueness index.

## Linked Issues

Closes #780

## Type of Change

- [x] Bug fix
- [x] Documentation update
- [x] Database migration with rollback constraints

## Test plan

- [x] Focused Go tests across database, API handler, measurement, and collector model packages, rerun after integrating current `develop`.
- [x] Regression cases cover the reported example, multiple wraps, retention, cross-epoch collisions, repeat and stale uploads, missing or unreliable hours, extended-log fallback, API nullability, and legacy migration.
- [x] 33 frontend component/service tests, including desktop and mobile rendering.
- [x] Backend lint with the pinned linter and Go 1.25.0; frontend lint and formatting.
- [x] Self-review and documentation updates.
- [ ] GitHub Actions full suite and platform builds.
- [ ] Zeus deployment and physical-drive acceptance.

## Additional Notes

Legacy ages remain unknown until a new collection supplies enough context. Indistinguishable occurrences may retain a possible duplicate instead of overwriting earlier history; the 21-row limit still applies. Payloads without a collection timestamp use arrival time and cannot be checked for stale replay.

Rolling back to a web version that uses the old raw-lifetime upsert requires a pre-upgrade database backup. Previously overwritten or pruned records cannot be recovered by this migration.
