### PR TITLE
ci: require develop promotions to master

### DIFF
--- a/.github/workflows/promotion-policy.yaml
+++ b/.github/workflows/promotion-policy.yaml
@@ -1,0 +1,20 @@
+name: Promotion Policy
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  promotion-policy:
+    name: Promotion Policy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require develop promotion branch
+        if: github.head_ref != 'develop'
+        run: |
+          echo "Only pull requests from develop may target master."
+          exit 1
+      - name: Confirm develop promotion branch
+        if: github.head_ref == 'develop'
+        run: echo "develop promotion branch confirmed"


### PR DESCRIPTION
## Summary

- Add required promotion-policy check for pull requests targeting `master`.
- Permit only `develop` as the source branch.

## Linked Issues

- None.

## Test plan

- `actionlint .github/workflows/promotion-policy.yaml`
- Verify check passes on `develop` to `master` pull request.