### PR TITLE
ci: run promotion checks in merge queue

### DIFF
--- a/.github/workflows/osv.yml
+++ b/.github/workflows/osv.yml
@@ -12,6 +12,9 @@ on:
     branches:
       - master
       - develop
+  merge_group:
+    branches:
+      - master
 
 permissions:
   contents: read

--- a/.github/workflows/promotion-policy.yaml
+++ b/.github/workflows/promotion-policy.yaml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches:
       - master
+  merge_group:
+    branches:
+      - master
 
 jobs:
   promotion-policy:
@@ -11,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Require develop promotion branch
-        if: github.head_ref != 'develop'
+        if: github.event_name != 'merge_group' && github.head_ref != 'develop'
         run: |
           echo "Only pull requests from develop may target master."
           exit 1
       - name: Confirm develop promotion branch
-        if: github.head_ref == 'develop'
+        if: github.event_name == 'merge_group' || github.head_ref == 'develop'
         run: echo "develop promotion branch confirmed"

--- a/.github/workflows/promotion-policy.yaml
+++ b/.github/workflows/promotion-policy.yaml
@@ -1,0 +1,20 @@
+name: Promotion Policy
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  promotion-policy:
+    name: Promotion Policy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require develop promotion branch
+        if: github.head_ref != 'develop'
+        run: |
+          echo "Only pull requests from develop may target master."
+          exit 1
+      - name: Confirm develop promotion branch
+        if: github.head_ref == 'develop'
+        run: echo "develop promotion branch confirmed"

--- a/.github/workflows/security-gitleaks.yml
+++ b/.github/workflows/security-gitleaks.yml
@@ -9,6 +9,9 @@ on:
     branches:
       - master
       - develop
+  merge_group:
+    branches:
+      - master
   schedule:
     - cron: "17 3 * * 1"
   workflow_dispatch:


### PR DESCRIPTION
## Summary

- Run `gitleaks`, `osv`, and promotion policy checks for `master` merge groups.
- Keep required checks available after merge queue is enabled.

## Linked Issues

- None.

## Test plan

- `actionlint .github/workflows/security-gitleaks.yml .github/workflows/osv.yml .github/workflows/promotion-policy.yaml`