### PR TITLE
fix(release): preserve release note provenance

### DIFF
--- a/.github/scripts/generate-release-notes.sh
+++ b/.github/scripts/generate-release-notes.sh
@@ -3,9 +3,9 @@
 # Usage: ./generate-release-notes.sh <previous-tag> <new-tag>
 #
 # This script is deterministic:
-# - commits reachable from the release tag determine included PRs
+# - merged PR commits in the tagged range determine included PRs
 # - PR ## Summary blocks provide normal note content
-# - Release promotion PRs preserve authored sections through ## Test plan
+# - user-facing PRs opt in through a ## Product changes section
 # - linked issues come from PR bodies
 # - completeness is validated before notes are emitted
 
@@ -15,9 +15,6 @@ PREV_TAG="${1:-$(git describe --tags --abbrev=0 HEAD~1 2>/dev/null || echo "")}"
 NEW_TAG="${2:-$(git describe --tags --abbrev=0 HEAD 2>/dev/null || echo "HEAD")}"
 REPO="${GITHUB_REPOSITORY:-Starosdev/scrutiny}"
 MAX_SUMMARY_BULLETS=8
-# Operational-only PRs excluded from user-facing release notes.
-EXCLUDED_PRS_REGEX='^(701|719|724|726)$'
-
 if [ -z "$PREV_TAG" ]; then
     echo "Error: Could not determine previous tag" >&2
     exit 1
@@ -30,7 +27,10 @@ RELEASE_DATE=$(git log -1 --format=%as "$NEW_TAG" 2>/dev/null || date +%Y-%m-%d)
 PRS_JSON=$(mktemp)
 OUTPUT_FILE=$(mktemp)
 EXPECTED_FILE=$(mktemp)
-trap 'rm -f "$PRS_JSON" "$OUTPUT_FILE" "$EXPECTED_FILE"' EXIT
+RANGE_COMMITS_FILE=$(mktemp)
+trap 'rm -f "$PRS_JSON" "$OUTPUT_FILE" "$EXPECTED_FILE" "$RANGE_COMMITS_FILE"' EXIT
+
+git rev-list "$PREV_TAG..$NEW_TAG" > "$RANGE_COMMITS_FILE"
 
 while IFS= read -r commit; do
     [ -z "$commit" ] && continue
@@ -39,27 +39,43 @@ while IFS= read -r commit; do
             number,
             title,
             mergedAt: .merged_at,
+            mergeCommitSha: .merge_commit_sha,
             body,
+            baseRefName: .base.ref,
             headRefName: .head.ref
         }]' >> "$PRS_JSON"
 done < <(git rev-list "$PREV_TAG..$NEW_TAG")
 
-MERGED_JSON=$(jq -s 'flatten | unique_by(.number) | sort_by(.mergedAt, .number)' "$PRS_JSON")
+MERGED_JSON=$(jq -s --rawfile range_commits "$RANGE_COMMITS_FILE" '
+    flatten
+    | unique_by(.number)
+    | map(select(
+        .baseRefName == "master"
+        and (.mergeCommitSha as $merge_commit
+          | $merge_commit != null
+          | ($range_commits | split("\n") | index($merge_commit)) != null)
+    ))
+    | sort_by(.mergedAt, .number)
+' "$PRS_JSON")
 
 get_summary_block() {
     local body="$1"
     [ -z "$body" ] && return
 
-    if echo "$body" | grep -q '^## Product changes$'; then
-        echo "$body" | awk '
-            /^## Summary$/ { in_release=1 }
-            /^## Test plan$/ { in_release=0 }
-            in_release { print }
-        '
-        return
-    fi
+    echo "$body" | awk '
+        /^## Product changes$/ { product_changes=1; next }
+        product_changes && /^## Summary$/ { in_summary=1; next }
+        in_summary && /^## / { exit }
+        in_summary { print }
+    '
+}
 
-    echo "$body" | tr -d '\r' | sed -n '/^## Summary/,/^## /{/^## /d; p;}'
+has_product_changes() {
+    local body="$1"
+    local summary
+    summary=$(get_summary_block "$body")
+
+    [ -n "$summary" ] && ! printf '%s\n' "$summary" | tr -d '\r' | sed '/^[[:space:]]*$/d' | grep -qx 'None\.'
 }
 
 clean_text() {
@@ -176,15 +192,7 @@ for ((i = 0; i < PR_COUNT; i++)); do
 
     [ -z "$pr_num" ] && continue
 
-    if [[ "$pr_num" =~ $EXCLUDED_PRS_REGEX ]]; then
-        continue
-    fi
-
-    if [[ "$pr_title" =~ ^(docs|style|chore|test|ci)(\(.+\))?!?: ]]; then
-        continue
-    fi
-
-    if [[ "$pr_title" =~ ^Release:|^chore\(release\) ]]; then
+    if ! has_product_changes "$pr_body"; then
         continue
     fi
 

--- a/.github/workflows/promotion-policy.yaml
+++ b/.github/workflows/promotion-policy.yaml
@@ -18,6 +18,22 @@ jobs:
         run: |
           echo "Only pull requests from develop may target master."
           exit 1
+      - name: Require product-change declaration
+        if: github.event_name != 'merge_group' && github.head_ref == 'develop'
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          if ! awk '
+            /^## Product changes$/ { product_changes = 1; next }
+            product_changes && /^## Summary$/ { summary = 1; next }
+            summary && /^## / { exit }
+            summary && $0 !~ /^[[:space:]]*$/ { content = 1 }
+            END { exit !(product_changes && summary && content) }
+          ' <<< "$PR_BODY"; then
+            echo "Master promotion PRs need ## Product changes followed by ## Summary content."
+            echo "Use None. as summary content when there is no user-facing change."
+            exit 1
+          fi
       - name: Confirm develop promotion branch
         if: github.event_name == 'merge_group' || github.head_ref == 'develop'
         run: echo "develop promotion branch confirmed"

--- a/docs/DEPLOYMENTS.md
+++ b/docs/DEPLOYMENTS.md
@@ -52,8 +52,8 @@ npm ci, then runs .github/scripts/run-semantic-release.mjs. Update
 package.json and package-lock.json together when changing release tooling.
 
 - Semantic versioning still comes from conventional commits and `semantic-release`.
-- Raw release notes are generated deterministically from PRs associated with commits reachable between the previous tag and the new tag.
-- The generator uses merged `master` PR metadata as the source of truth, renders note content from each PR's `## Summary` block plus linked issues, and preserves authored release-promotion sections through `## Test plan`.
+- Raw release notes are generated deterministically from `master` PR merge commits reachable between the previous tag and the new tag.
+- The generator uses merged PR metadata as the source of truth. Master promotion PRs must contain `## Product changes` followed by `## Summary`. Only non-`None.` summaries are user-facing; their linked issues supply release-note content.
 - Validation checks that extracted summary content survives note formatting before it emits notes.
 - If note generation fails, the release workflow fails for manual repair instead of silently completing with semantic-release defaults.
 

--- a/docs/RELEASE_VERSION_VERIFICATION.md
+++ b/docs/RELEASE_VERSION_VERIFICATION.md
@@ -7,7 +7,7 @@ This note documents how release binaries get their version string and how to ver
 - `webapp/backend/pkg/version/version.go` stores the shared `VERSION` constant used by the web binary, collector banners, and API `server_version`.
 - `.releaserc.json` updates that constant during the semantic-release prepare step.
 - `.github/workflows/release.yaml` builds binaries from `ref: v${{ needs.release.outputs.new_release_version }}`, which means the release job compiles the tagged release commit after the version constant has been updated.
-- That same workflow is manual-only via `workflow_dispatch` and generates raw release notes deterministically from `master` PRs associated with commits in the tagged range.
+- That same workflow is manual-only via `workflow_dispatch` and generates raw release notes from `master` PR merge commits in the tagged range. Promotion PRs must provide `## Product changes` followed by `## Summary`; use `None.` for an operational-only promotion.
 - `Makefile` passes only `main.goos` and `main.goarch` through `-ldflags`. It does not overwrite `version.VERSION`.
 
 ## Verified Paths

--- a/scripts/tests/generate-release-notes_test.sh
+++ b/scripts/tests/generate-release-notes_test.sh
@@ -18,6 +18,10 @@ case "$1" in
         ;;
     rev-list)
         echo "released-commit"
+        echo "released-merge"
+        echo "stale-commit"
+        echo "operational-commit"
+        echo "operational-merge"
         echo "develop-only-commit"
         ;;
 esac
@@ -28,12 +32,22 @@ cat > "$MOCK_BIN/gh" <<'EOF'
 case "${!#}" in
     */released-commit/pulls)
         cat <<'JSON'
-[{"number":42,"title":"feat: release change","merged_at":"2026-09-05T00:00:00Z","body":"## Summary\n\n- Visible change\n\nCloses #41\n\n## Test plan\n\n- test","base":{"ref":"master"},"head":{"ref":"feature/released"}}]
+[{"number":42,"title":"feat: release change","merged_at":"2026-09-05T00:00:00Z","merge_commit_sha":"released-merge","body":"## Product changes\n\n## Summary\n\n- Visible change\n\nCloses #41\n\n## Test plan\n\n- test","base":{"ref":"master"},"head":{"ref":"develop"}}]
+JSON
+        ;;
+    */stale-commit/pulls)
+        cat <<'JSON'
+[{"number":99,"title":"feat: stale association","merged_at":"2026-08-01T00:00:00Z","merge_commit_sha":"stale-merge","body":"## Product changes\n\n## Summary\n\n- Stale change","base":{"ref":"master"},"head":{"ref":"develop"}}]
+JSON
+        ;;
+    */operational-commit/pulls)
+        cat <<'JSON'
+[{"number":44,"title":"fix(release): workflow repair","merged_at":"2026-09-05T00:00:00Z","merge_commit_sha":"operational-merge","body":"## Product changes\n\n## Summary\n\nNone.\n\n## Test plan\n\n- test","base":{"ref":"master"},"head":{"ref":"develop"}}]
 JSON
         ;;
     */develop-only-commit/pulls)
         cat <<'JSON'
-[{"number":43,"title":"feat: unreleased change","merged_at":"2026-09-05T00:00:00Z","body":"## Summary\n\n- Unreleased change","base":{"ref":"develop"},"head":{"ref":"feature/develop"}},{"number":44,"title":"chore: release administration","merged_at":"2026-09-05T00:00:00Z","body":"## Summary\n\n- Internal change","base":{"ref":"master"},"head":{"ref":"chore/release"}}]
+[{"number":43,"title":"feat: develop-only change","merged_at":"2026-09-05T00:00:00Z","merge_commit_sha":"develop-only-commit","body":"## Product changes\n\n## Summary\n\n- Develop-only change","base":{"ref":"develop"},"head":{"ref":"feature/develop"}},{"number":44,"title":"chore: release administration","merged_at":"2026-09-05T00:00:00Z","body":"## Summary\n\n- Internal change","base":{"ref":"master"},"head":{"ref":"chore/release"}}]
 JSON
         ;;
 esac
@@ -46,4 +60,7 @@ NOTES=$(PATH="$MOCK_BIN:$PATH" "$ROOT/.github/scripts/generate-release-notes.sh"
 grep -Fq "[#42](https://github.com/Starosdev/scrutiny/pull/42)" <<< "$NOTES"
 grep -Fq "Visible change" <<< "$NOTES"
 ! grep -Fq "#43" <<< "$NOTES"
+! grep -Fq "Develop-only change" <<< "$NOTES"
 ! grep -Fq "#44" <<< "$NOTES"
+! grep -Fq "#99" <<< "$NOTES"
+! grep -Fq "Stale change" <<< "$NOTES"


### PR DESCRIPTION
## Summary

- Include a pull request only when its `master` merge commit falls inside the release tag range.
- Require promotion pull requests to declare product changes and omit `None.` operational declarations.
- Cover stale commit associations, develop-only pull requests, and operational promotions.

## Linked Issues

None.

## Test plan

- `bash scripts/tests/generate-release-notes_test.sh`
- `bash -n .github/scripts/generate-release-notes.sh`
- `actionlint .github/workflows/promotion-policy.yaml`
- `git diff --check`