### PR TITLE
docs(collector): document PowerShell schedule overrides

### DIFF
--- a/collector/pkg/omnibus/config_test.go
+++ b/collector/pkg/omnibus/config_test.go
@@ -104,6 +104,39 @@ collectors:
 	require.ErrorContains(t, err, `collector "metrics" binary`)
 }
 
+// A PowerShell operator cannot pass an empty schedule override: assigning ""
+// deletes the variable. Documented workaround is a whitespace value, which the
+// loader trims. Both halves are a documented contract in
+// docs/INSTALL_COLLECTOR_OMNIBUS.md, so pin them here.
+func TestLoadConfigScheduleOverrideClearingBehavior(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, filepath.Join(dir, executableName("scrutiny-collector-metrics")))
+	writeTestFile(t, filepath.Join(dir, "collector.yaml"))
+	configPath := filepath.Join(dir, "collector-omnibus.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte(`
+collectors:
+  metrics:
+    enabled: true
+    schedule: "0 0 * * *"
+    run_on_startup: true
+    config: collector.yaml
+`), 0o600))
+	executablePath := filepath.Join(dir, "scrutiny-collector-omnibus")
+
+	absent, err := LoadConfig(configPath, executablePath, mapLookup(nil))
+	require.NoError(t, err)
+	assert.Equal(t, "0 0 * * *", absent.Collectors["metrics"].Schedule)
+
+	whitespace, err := LoadConfig(configPath, executablePath, mapLookup(map[string]string{
+		"COLLECTOR_CRON_SCHEDULE": " ",
+	}))
+	require.NoError(t, err)
+	metrics := whitespace.Collectors["metrics"]
+	assert.Empty(t, metrics.Schedule)
+	assert.True(t, metrics.Enabled)
+	assert.True(t, metrics.RunOnStartup)
+}
+
 func mapLookup(values map[string]string) LookupEnv {
 	return func(key string) (string, bool) {
 		value, ok := values[key]

--- a/docs/INSTALL_COLLECTOR_OMNIBUS.md
+++ b/docs/INSTALL_COLLECTOR_OMNIBUS.md
@@ -80,6 +80,10 @@ Optional collector prefixes are `COLLECTOR_ZFS`, `COLLECTOR_MDADM`,
 schedule or a true startup override enables that collector unless its
 `*_ENABLED` variable explicitly disables it.
 
+A schedule override is trimmed before it is applied, so a whitespace value
+clears the YAML schedule. See "Windows PowerShell schedule overrides" below for
+why that matters on Windows.
+
 Use `COLLECTOR_OMNIBUS_CONFIG` instead of `--config` when a service definition
 provides configuration through its environment.
 `COLLECTOR_OMNIBUS_BINARY_DIR` overrides `binary_dir`.
@@ -88,3 +92,58 @@ Collector API, host, logging, and device settings remain in their existing
 collector YAML files and environment variables. The manager removes scheduling
 variables from child processes so each scheduled child performs exactly one
 collection and exits.
+
+## Windows PowerShell schedule overrides
+
+PowerShell deletes an environment variable when it is assigned an empty string.
+`$env:COLLECTOR_CRON_SCHEDULE = ""` removes the variable instead of passing an
+empty value, so the manager finds no override and the YAML schedule stays
+active:
+
+```powershell
+# Does not clear the schedule. The manager logs "collector scheduled".
+$env:COLLECTOR_CRON_SCHEDULE = ""
+.\bin\scrutiny-collector-omnibus.exe run --config .\config\collector-omnibus.yaml
+```
+
+For persistent configuration, clear the schedule in YAML and enable the startup
+run. This is the preferred form because it does not depend on shell quoting:
+
+```yaml
+collectors:
+  metrics:
+    enabled: true
+    schedule: ""
+    run_on_startup: true
+    config: collector.yaml
+```
+
+For a temporary override in one PowerShell session, assign a whitespace value.
+The variable survives, and the manager trims the override to an empty schedule:
+
+```powershell
+$env:COLLECTOR_CRON_SCHEDULE = " "
+$env:COLLECTOR_RUN_STARTUP = "true"
+.\bin\scrutiny-collector-omnibus.exe run --config .\config\collector-omnibus.yaml
+```
+
+With no collector holding a schedule, the manager runs each startup collector
+once and exits.
+
+An enabled collector needs either a schedule or a startup run. Clearing the
+schedule while `run_on_startup` is false fails validation with
+`collector "metrics" is enabled but has no schedule or startup run`. Set
+`run_on_startup: true`, or the matching `*_RUN_STARTUP` variable, alongside the
+cleared schedule.
+
+The same rules apply to every optional collector schedule variable:
+`COLLECTOR_ZFS_CRON_SCHEDULE`, `COLLECTOR_MDADM_CRON_SCHEDULE`,
+`COLLECTOR_BTRFS_CRON_SCHEDULE`, `COLLECTOR_FILESYSTEM_CRON_SCHEDULE`, and
+`COLLECTOR_PERF_CRON_SCHEDULE`. Each pairs with its own `*_RUN_STARTUP`
+variable.
+
+`cmd.exe` behaves the same way: `set COLLECTOR_CRON_SCHEDULE=` removes the
+variable, and `set COLLECTOR_CRON_SCHEDULE= ` assigns a whitespace value that
+the manager trims. Unix shells pass an empty value directly, so
+`COLLECTOR_CRON_SCHEDULE="" ./bin/scrutiny-collector-omnibus run` needs no
+workaround.


### PR DESCRIPTION
## Summary

PowerShell deletes an environment variable when it is assigned an empty string, so `$env:COLLECTOR_CRON_SCHEDULE = ""` removes the override rather than passing an empty value. The omnibus manager finds no override, keeps the YAML schedule, logs `collector scheduled`, and stays running, which is the opposite of what the operator asked for.

This is documentation plus a regression test. No runtime behavior changes.

## Changes

- `docs/INSTALL_COLLECTOR_OMNIBUS.md`: new "Windows PowerShell schedule overrides" section, and a pointer to it from "Configuration precedence".
- `collector/pkg/omnibus/config_test.go`: `TestLoadConfigScheduleOverrideClearingBehavior` pins both halves of the documented contract.

## What the docs now state

- Assigning `""` in PowerShell removes the variable, so the YAML schedule survives.
- Preferred persistent form is `schedule: ""` with `run_on_startup: true` in `collector-omnibus.yaml`, because it does not depend on shell quoting.
- Temporary PowerShell override uses a whitespace value, which the loader trims to an empty schedule.
- An enabled collector with an empty schedule and `run_on_startup` false fails validation with `collector "metrics" is enabled but has no schedule or startup run`.
- The same rules apply to `COLLECTOR_ZFS_CRON_SCHEDULE`, `COLLECTOR_MDADM_CRON_SCHEDULE`, `COLLECTOR_BTRFS_CRON_SCHEDULE`, `COLLECTOR_FILESYSTEM_CRON_SCHEDULE`, and `COLLECTOR_PERF_CRON_SCHEDULE`.
- `cmd.exe` behaves the same way; Unix shells pass an empty value directly and need no workaround.

## Why a test for a docs change

The whitespace workaround relies on the `strings.TrimSpace` call in `applyEnvironmentOverrides` (`collector/pkg/omnibus/config.go`). Nothing asserted that, so a later refactor could drop the trim and silently invalidate the documented guidance. The test asserts an absent override keeps the YAML schedule and a whitespace override clears it while leaving the collector enabled for its startup run.

## Validation

- `go test ./collector/...` passes.
- `gofmt -l collector/pkg/omnibus/` is clean.
- Mutation check: replacing `strings.TrimSpace(value)` with `strings.Clone(value)` fails the new test with `collector "metrics" has invalid schedule " "`, confirming the test is not vacuous. Change reverted.

Closes #689
