### PR TITLE
feat(overrides): add acknowledge action pinned to an attribute's current value

### DIFF
--- a/README.md
+++ b/README.md
@@ -582,7 +582,7 @@ Scrutiny allows you to customize how individual SMART attributes are evaluated. 
 1. Click on a drive to open its detail page
 2. Find the attribute in the SMART table
 3. Click the three-dot menu in the **Actions** column (appears on failed/warning attributes)
-4. Select **Ignore attribute** to suppress it, or **Force passed** to override its status
+4. Select **Ignore attribute** to suppress it, **Force passed** to override its status, or **Acknowledge current value** to accept the value as it stands today
 
 These quick actions create device-specific overrides. To remove an override, click the purple tune icon and select **Remove override**.
 
@@ -593,7 +593,8 @@ These quick actions create device-specific overrides. To remove an override, cli
 3. Fill in the override form:
    - **Protocol**: ATA, NVMe, or SCSI
    - **Attribute ID**: The attribute identifier (e.g., `199` for UltraDMA CRC Error Count, `media_errors` for NVMe)
-   - **Action**: Ignore, Force Status, or Custom Threshold
+   - **Action**: Ignore, Force Status, Acknowledge Current Value, or Custom Threshold
+   - **Device**: required for Acknowledge, since it pins the pass to one device's current value
    - **Device WWN** (optional): Leave empty to apply globally, or specify a WWN for a single device
 4. Click **Add Override**
 
@@ -607,6 +608,7 @@ Add overrides to `scrutiny.yaml` under `smart.attribute_overrides`. See [example
 | ------ | -------- |
 | Ignore | Attribute marked as passed; excluded from device failure status and notifications |
 | Force Status | Overrides computed status to passed, warn, or failed |
+| Acknowledge Current Value | Attribute passes while its value stays where it is now. Any change restores the normal verdict, so a one-off event stops alerting without hiding the next one. Requires a device. A manufacturer SMART failure is never masked |
 | Custom Threshold | Replaces default thresholds with user-defined warn_above/fail_above values |
 
 Overrides apply at the next SMART data collection. Device status is recalculated immediately when overrides are added or removed via the UI.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2215,9 +2215,11 @@ components:
           type: string
         wwn:
           type: string
+        device_id:
+          type: string
         action:
           type: string
-          enum: ["", ignore, force_status]
+          enum: ["", ignore, force_status, acknowledge]
         status:
           type: string
           enum: [passed, warn, failed]
@@ -2227,6 +2229,14 @@ components:
         fail_above:
           type: integer
           format: int64
+        pinned_value:
+          type: integer
+          format: int64
+          description: >-
+            Set by the server for acknowledge overrides, read from the device's latest SMART
+            submission. The attribute passes only while its value equals this; any change
+            restores the underlying evaluation. Acknowledge requires device_id or wwn, and
+            sending pinned_value with any other action is rejected.
         source:
           type: string
         created_at:

--- a/example.scrutiny.yaml
+++ b/example.scrutiny.yaml
@@ -314,6 +314,16 @@ failures:
 #      warn_above: 80
 #      fail_above: 95
 
+#    # Example 6: Acknowledge a value you have already looked at. Unlike force_status,
+#    # this passes only while the value stays put; any change restores the normal
+#    # verdict. pinned_value is required here because the config file has no device
+#    # context to read a current value from. The UI fills it in for you.
+#    - protocol: ATA
+#      attribute_id: "197"          # Current_Pending_Sector
+#      wwn: "0x5000cca264eb01d7"
+#      action: acknowledge
+#      pinned_value: 8              # Passes at 8; fails again at 9
+
 # Notification "urls" support Shoutrrr, Apprise, custom scripts, and raw webhooks.
 # Shoutrrr documentation: https://nicholas-fedor.github.io/shoutrrr/
 # Apprise documentation: https://appriseit.com/

--- a/webapp/backend/pkg/database/migrations/m20260906000000/attribute_override.go
+++ b/webapp/backend/pkg/database/migrations/m20260906000000/attribute_override.go
@@ -1,0 +1,28 @@
+package m20260906000000
+
+import "time"
+
+// AttributeOverride is the migration-scoped struct after adding pinned_value,
+// which stores the value an "acknowledge" override is pinned to (#775). The
+// column is nullable: every pre-existing override predates the action and must
+// stay unpinned. AutoMigrate adds only the missing column, so re-running the
+// migration on a database that already has it is a no-op.
+type AttributeOverride struct {
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+	WarnAbove   *int64    `json:"warn_above,omitempty"`
+	FailAbove   *int64    `json:"fail_above,omitempty"`
+	PinnedValue *int64    `json:"pinned_value,omitempty"`
+	Protocol    string    `json:"protocol" gorm:"not null;uniqueIndex:idx_override_lookup"`
+	AttributeId string    `json:"attribute_id" gorm:"not null;uniqueIndex:idx_override_lookup"`
+	DeviceID    string    `json:"device_id,omitempty" gorm:"uniqueIndex:idx_override_lookup"`
+	WWN         string    `json:"wwn,omitempty" gorm:"uniqueIndex:idx_override_lookup"`
+	Action      string    `json:"action,omitempty"`
+	Status      string    `json:"status,omitempty"`
+	Source      string    `json:"source" gorm:"default:'ui'"`
+	ID          uint      `json:"id" gorm:"primaryKey"`
+}
+
+func (AttributeOverride) TableName() string {
+	return "attribute_overrides"
+}

--- a/webapp/backend/pkg/database/scrutiny_repository_migrations.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_migrations.go
@@ -34,6 +34,7 @@ import (
 	m20260608000000 "github.com/analogj/scrutiny/webapp/backend/pkg/database/migrations/m20260608000000"
 	m20260610000000 "github.com/analogj/scrutiny/webapp/backend/pkg/database/migrations/m20260610000000"
 	m20260616000000 "github.com/analogj/scrutiny/webapp/backend/pkg/database/migrations/m20260616000000"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/database/migrations/m20260906000000"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/deviceid"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/models"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/models/collector"
@@ -665,6 +666,12 @@ func (sr *scrutinyRepository) Migrate(ctx context.Context) error {
 			},
 		},
 		{ID: "m20260905000000", Migrate: migrateSelfTestChronology},
+		{
+			ID: "m20260906000000", // add pinned_value to attribute overrides for acknowledge action (#775)
+			Migrate: func(tx *gorm.DB) error {
+				return tx.AutoMigrate(&m20260906000000.AttributeOverride{})
+			},
+		},
 	})
 
 	if err := m.Migrate(); err != nil {

--- a/webapp/backend/pkg/database/scrutiny_repository_migrations_test.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_migrations_test.go
@@ -585,3 +585,34 @@ func TestMigrateSelfTestChronologyPreservesLegacyHistory(t *testing.T) {
 	require.False(t, repo.gormClient.Migrator().HasIndex(&models.DeviceSelfTest{}, "idx_device_self_tests_identity"))
 	require.NoError(t, repo.gormClient.Exec(`INSERT INTO device_self_tests(device_identity,type_value,lifetime_hours,effective_lifetime_hours) VALUES ('wwn-1',1,2464,68000)`).Error)
 }
+
+// A pre-existing override must survive the pinned_value migration with the column
+// NULL rather than 0: zero is a legitimate acknowledged value, so a defaulted column
+// would read as "acknowledged at 0" for every override created before the feature.
+func TestMigrateAttributeOverridesAddsNullablePinnedValue(t *testing.T) {
+	repo := createMigrationTestRepository(t)
+	ctx := context.Background()
+	require.NoError(t, repo.Migrate(ctx))
+
+	existing := models.AttributeOverride{Protocol: "NVMe", AttributeId: "media_errors", DeviceID: "b62e6d86-6ce0-50da-8bff-b2ee54c4af4e", Action: "ignore"}
+	require.NoError(t, repo.gormClient.Create(&existing).Error)
+
+	var stored models.AttributeOverride
+	require.NoError(t, repo.gormClient.First(&stored, existing.ID).Error)
+	require.Nil(t, stored.PinnedValue)
+
+	pinned := int64(0)
+	acknowledged := models.AttributeOverride{
+		Protocol:    "NVMe",
+		AttributeId: "media_errors",
+		DeviceID:    "c4ac4ff4-1a4d-52aa-9724-40fbc47dd306",
+		Action:      "acknowledge",
+		PinnedValue: &pinned,
+	}
+	require.NoError(t, repo.gormClient.Create(&acknowledged).Error)
+
+	var readBack models.AttributeOverride
+	require.NoError(t, repo.gormClient.First(&readBack, acknowledged.ID).Error)
+	require.NotNil(t, readBack.PinnedValue)
+	require.Equal(t, int64(0), *readBack.PinnedValue)
+}

--- a/webapp/backend/pkg/models/attribute_override.go
+++ b/webapp/backend/pkg/models/attribute_override.go
@@ -14,6 +14,7 @@ type AttributeOverride struct {
 	UpdatedAt   time.Time `json:"updated_at"`
 	WarnAbove   *int64    `json:"warn_above,omitempty"`
 	FailAbove   *int64    `json:"fail_above,omitempty"`
+	PinnedValue *int64    `json:"pinned_value,omitempty"`
 	Protocol    string    `json:"protocol" gorm:"not null;uniqueIndex:idx_override_lookup"`
 	AttributeId string    `json:"attribute_id" gorm:"not null;uniqueIndex:idx_override_lookup"`
 	DeviceID    string    `json:"device_id,omitempty" gorm:"uniqueIndex:idx_override_lookup"`
@@ -40,6 +41,7 @@ func (ao *AttributeOverride) ToOverride() overrides.AttributeOverride {
 		Status:      ao.Status,
 		WarnAbove:   ao.WarnAbove,
 		FailAbove:   ao.FailAbove,
+		PinnedValue: ao.PinnedValue,
 	}
 }
 

--- a/webapp/backend/pkg/models/measurements/smart.go
+++ b/webapp/backend/pkg/models/measurements/smart.go
@@ -17,6 +17,8 @@ import (
 // Custom threshold status reason strings (S1192: deduplicated string literals)
 const statusReasonWithinThreshold = "Within custom threshold"
 const statusReasonThresholdExceeded = "Custom threshold exceeded"
+const statusReasonAcknowledged = "Acknowledged at value %d"
+const statusReasonAcknowledgementStale = "Acknowledgement no longer applies: value changed from %d to %d"
 
 // applyOverrideResult applies a parsed override Result to an attribute's status fields.
 // thresholdValue is the value compared against custom WarnAbove/FailAbove thresholds.
@@ -31,6 +33,8 @@ func applyOverrideResult(result *overrides.Result, thresholdValue int64, status 
 		*status = pkg.AttributeStatusPassed
 		*statusReason = result.StatusReason
 		return true, false
+	case result.AcknowledgedValue != nil:
+		applyAcknowledgement(*result.AcknowledgedValue, thresholdValue, status, statusReason)
 	case result.Status != nil:
 		*status = *result.Status
 		*statusReason = result.StatusReason
@@ -46,6 +50,43 @@ func applyOverrideResult(result *overrides.Result, thresholdValue int64, status 
 		}
 	}
 	return false, false
+}
+
+// applyAcknowledgement passes an attribute only while its value still equals the value the
+// user acknowledged. Any change restores the underlying evaluation, which is the difference
+// between this and force_status. A manufacturer SMART failure is never masked, matching
+// ApplyDeltaEvaluation: the drive itself reporting failure is not a Scrutiny verdict the
+// user can acknowledge away.
+func applyAcknowledgement(pinnedValue, currentValue int64, status *pkg.AttributeStatus, statusReason *string) {
+	if currentValue != pinnedValue {
+		*statusReason = fmt.Sprintf(statusReasonAcknowledgementStale, pinnedValue, currentValue)
+		return
+	}
+	if pkg.AttributeStatusHas(*status, pkg.AttributeStatusFailedSmart) {
+		return
+	}
+	*status = pkg.AttributeStatusPassed
+	*statusReason = fmt.Sprintf(statusReasonAcknowledged, pinnedValue)
+}
+
+// AttributeThresholdValue returns the value an attribute is evaluated against by
+// applyOverrideResult. It is the single source of truth for which field each protocol
+// compares, so callers that need to pin or threshold a value never restate the rule.
+func AttributeThresholdValue(attribute SmartAttribute) (int64, bool) {
+	switch attr := attribute.(type) {
+	case *SmartAtaAttribute:
+		return attr.RawValue, true
+	case *SmartAtaDeviceStatAttribute:
+		return attr.Value, true
+	case *SmartFarmAttribute:
+		return attr.Value, true
+	case *SmartNvmeAttribute:
+		return attr.Value, true
+	case *SmartScsiAttribute:
+		return attr.Value, true
+	default:
+		return 0, false
+	}
 }
 
 // ApplyOverrideToAttribute applies an override to one in-memory attribute.

--- a/webapp/backend/pkg/models/measurements/smart_test.go
+++ b/webapp/backend/pkg/models/measurements/smart_test.go
@@ -1778,3 +1778,74 @@ func TestSmartApplyOverridesProjectsStableDeviceOverride(t *testing.T) {
 	require.Equal(t, pkg.AttributeStatusPassed, attribute.Status)
 	require.Equal(t, "Status forced by user configuration", attribute.StatusReason)
 }
+
+// acknowledgeOverride builds a device-scoped acknowledge override pinned to value.
+func acknowledgeOverride(deviceID string, value int64) []overrides.AttributeOverride {
+	return []overrides.AttributeOverride{{
+		Protocol:    pkg.DeviceProtocolNvme,
+		AttributeId: "media_errors",
+		DeviceID:    deviceID,
+		Action:      overrides.AttributeOverrideActionAcknowledge,
+		PinnedValue: &value,
+	}}
+}
+
+// nvmeSmartWithMediaErrors builds a failing NVMe result carrying one media_errors attribute.
+func nvmeSmartWithMediaErrors(value int64, status pkg.AttributeStatus) measurements.Smart {
+	return measurements.Smart{
+		DeviceWWN:      "nvme-serial",
+		DeviceProtocol: pkg.DeviceProtocolNvme,
+		Attributes: map[string]measurements.SmartAttribute{
+			"media_errors": &measurements.SmartNvmeAttribute{
+				AttributeId: "media_errors",
+				Value:       value,
+				Status:      status,
+			},
+		},
+	}
+}
+
+func TestSmartApplyOverridesAcknowledgePassesAtPinnedValue(t *testing.T) {
+	deviceID := "b62e6d86-6ce0-50da-8bff-b2ee54c4af4e"
+	smart := nvmeSmartWithMediaErrors(3, pkg.AttributeStatusFailedScrutiny)
+
+	smart.ApplyOverrides(acknowledgeOverride(deviceID, 3), deviceID)
+
+	attribute := smart.Attributes["media_errors"].(*measurements.SmartNvmeAttribute)
+	require.Equal(t, pkg.AttributeStatusPassed, attribute.Status)
+	require.Equal(t, "Acknowledged at value 3", attribute.StatusReason)
+}
+
+func TestSmartApplyOverridesAcknowledgeRefailsWhenValueChanges(t *testing.T) {
+	deviceID := "b62e6d86-6ce0-50da-8bff-b2ee54c4af4e"
+	smart := nvmeSmartWithMediaErrors(4, pkg.AttributeStatusFailedScrutiny)
+
+	// The acknowledgement was pinned to 3; the drive has since reported 4.
+	smart.ApplyOverrides(acknowledgeOverride(deviceID, 3), deviceID)
+
+	attribute := smart.Attributes["media_errors"].(*measurements.SmartNvmeAttribute)
+	require.Equal(t, pkg.AttributeStatusFailedScrutiny, attribute.Status)
+	require.Equal(t, "Acknowledgement no longer applies: value changed from 3 to 4", attribute.StatusReason)
+}
+
+func TestSmartApplyOverridesAcknowledgeNeverMasksSmartFailure(t *testing.T) {
+	deviceID := "b62e6d86-6ce0-50da-8bff-b2ee54c4af4e"
+	smart := nvmeSmartWithMediaErrors(3, pkg.AttributeStatusFailedSmart)
+
+	smart.ApplyOverrides(acknowledgeOverride(deviceID, 3), deviceID)
+
+	attribute := smart.Attributes["media_errors"].(*measurements.SmartNvmeAttribute)
+	require.Equal(t, pkg.AttributeStatusFailedSmart, attribute.Status)
+}
+
+func TestAttributeThresholdValueMatchesEvaluatedField(t *testing.T) {
+	// ATA is evaluated on the raw value; every other protocol on the normalized one.
+	// The acknowledge handler pins whatever this returns, so the two must not diverge.
+	ataValue, ok := measurements.AttributeThresholdValue(&measurements.SmartAtaAttribute{RawValue: 42, Value: 7})
+	require.True(t, ok)
+	require.Equal(t, int64(42), ataValue)
+
+	nvmeValue, ok := measurements.AttributeThresholdValue(&measurements.SmartNvmeAttribute{Value: 9})
+	require.True(t, ok)
+	require.Equal(t, int64(9), nvmeValue)
+}

--- a/webapp/backend/pkg/overrides/applier.go
+++ b/webapp/backend/pkg/overrides/applier.go
@@ -14,6 +14,10 @@ type AttributeOverrideAction string
 const (
 	AttributeOverrideActionIgnore      AttributeOverrideAction = "ignore"
 	AttributeOverrideActionForceStatus AttributeOverrideAction = "force_status"
+	// AttributeOverrideActionAcknowledge passes an attribute only while its value stays
+	// at PinnedValue. Any change re-exposes the underlying evaluation, unlike
+	// force_status which masks the attribute permanently.
+	AttributeOverrideActionAcknowledge AttributeOverrideAction = "acknowledge"
 )
 
 // AttributeOverride defines a user-configured override for SMART attribute evaluation
@@ -47,6 +51,10 @@ type AttributeOverride struct {
 
 	// Custom threshold: fail when value exceeds this (takes precedence over warn)
 	FailAbove *int64 `json:"fail_above,omitempty" mapstructure:"fail_above"`
+
+	// For acknowledge action: the value the acknowledgement is pinned to.
+	// The attribute passes only while its current value equals this.
+	PinnedValue *int64 `json:"pinned_value,omitempty" mapstructure:"pinned_value"`
 }
 
 // Matches checks if this override applies to the given attribute
@@ -117,6 +125,10 @@ type Result struct {
 	WarnAbove *int64
 	// FailAbove is the custom failure threshold
 	FailAbove *int64
+	// AcknowledgedValue is the value an acknowledgement is pinned to. The attribute
+	// passes only while its current value equals this; any change restores the
+	// underlying evaluation.
+	AcknowledgedValue *int64
 }
 
 // ParseOverrides converts raw config data to typed AttributeOverride slice
@@ -159,6 +171,10 @@ func Apply(cfg config.Interface, protocol, attributeId, wwn string) *Result {
 		status := override.GetForcedStatus()
 		result.Status = &status
 		result.StatusReason = "Status forced by user configuration"
+
+	case AttributeOverrideActionAcknowledge:
+		result.AcknowledgedValue = override.PinnedValue
+
 	}
 
 	// Custom thresholds are only evaluated when action is empty (see smart.go).
@@ -248,6 +264,10 @@ func ApplyWithOverrides(overrideList []AttributeOverride, protocol, attributeId,
 		status := override.GetForcedStatus()
 		result.Status = &status
 		result.StatusReason = "Status forced by user configuration"
+
+	case AttributeOverrideActionAcknowledge:
+		result.AcknowledgedValue = override.PinnedValue
+
 	}
 
 	// Custom thresholds are only evaluated when action is empty (see smart.go).

--- a/webapp/backend/pkg/web/handler/attribute_overrides.go
+++ b/webapp/backend/pkg/web/handler/attribute_overrides.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/analogj/scrutiny/webapp/backend/pkg/database"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/models"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/models/measurements"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/validation"
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
@@ -23,6 +24,7 @@ var validActions = map[string]bool{
 	"":             true, // empty means custom thresholds only
 	"ignore":       true,
 	"force_status": true,
+	"acknowledge":  true,
 }
 
 // validStatuses defines the allowed status values for force_status action
@@ -76,11 +78,26 @@ func validateAttributeOverride(o *models.AttributeOverride) string {
 	if o.WWN != "" && validation.ValidateWWN(o.WWN) != nil {
 		return "Invalid WWN format"
 	}
-	if o.Action == "force_status" {
-		return validateForceStatus(o)
+	if o.Action != "acknowledge" && o.PinnedValue != nil {
+		return "pinned_value is only valid when action is 'acknowledge'"
 	}
-	if o.Action == "" {
+	switch o.Action {
+	case "force_status":
+		return validateForceStatus(o)
+	case "acknowledge":
+		return validateAcknowledge(o)
+	case "":
 		return validateThresholds(o)
+	}
+	return ""
+}
+
+// validateAcknowledge checks an acknowledge override. Acknowledgement pins a
+// status to one device's current value, so a fleet-wide rule cannot express it:
+// the same attribute holds a different value on every device.
+func validateAcknowledge(o *models.AttributeOverride) string {
+	if o.DeviceID == "" && o.WWN == "" {
+		return "Acknowledge requires a specific device (device_id or wwn)"
 	}
 	return ""
 }
@@ -131,6 +148,13 @@ func SaveAttributeOverride(c *gin.Context) {
 	// Source is always "ui" for API-created overrides
 	override.Source = "ui"
 
+	if override.Action == "acknowledge" && override.PinnedValue == nil {
+		if errMsg := resolvePinnedValue(c, deviceRepo, &override); errMsg != "" {
+			c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": errMsg})
+			return
+		}
+	}
+
 	if err := deviceRepo.SaveAttributeOverride(c, &override); err != nil {
 		logger.Errorln("Error saving attribute override:", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": "Failed to save override"})
@@ -141,6 +165,42 @@ func SaveAttributeOverride(c *gin.Context) {
 	recalculateDeviceStatusForOverride(c, logger, deviceRepo, &override)
 
 	c.JSON(http.StatusOK, gin.H{"success": true, "data": override})
+}
+
+// resolvePinnedValue fills in the value an acknowledgement pins to, read from the device's
+// latest stored SMART submission. The server resolves it rather than trusting a client-sent
+// value because which field an attribute is evaluated against differs by protocol (ATA
+// compares the raw value, every other protocol the normalized one) and that rule already
+// lives in measurements.AttributeThresholdValue. Restating it in the frontend would let the
+// two drift apart silently.
+func resolvePinnedValue(c *gin.Context, deviceRepo database.DeviceRepo, override *models.AttributeOverride) string {
+	var device models.Device
+	var err error
+	if override.DeviceID != "" {
+		device, err = deviceRepo.GetDeviceByID(c, override.DeviceID)
+	} else {
+		device, err = deviceRepo.GetDeviceByWWN(c, override.WWN)
+	}
+	if err != nil {
+		return "Device not found for acknowledge override"
+	}
+
+	submissions, err := deviceRepo.GetLatestSmartSubmission(c, device.WWN)
+	if err != nil || len(submissions) == 0 {
+		return "No SMART data available to acknowledge for this device"
+	}
+
+	attribute, found := submissions[0].Attributes[override.AttributeId]
+	if !found {
+		return "Attribute not present in the device's latest SMART data"
+	}
+
+	value, ok := measurements.AttributeThresholdValue(attribute)
+	if !ok {
+		return "Attribute type cannot be acknowledged"
+	}
+	override.PinnedValue = &value
+	return ""
 }
 
 // DeleteAttributeOverride removes an attribute override by ID

--- a/webapp/backend/pkg/web/handler/attribute_overrides_test.go
+++ b/webapp/backend/pkg/web/handler/attribute_overrides_test.go
@@ -10,6 +10,7 @@ import (
 
 	mock_database "github.com/analogj/scrutiny/webapp/backend/pkg/database/mock"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/models"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/models/measurements"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/web/handler"
 	"github.com/gin-gonic/gin"
 	"github.com/golang/mock/gomock"
@@ -396,4 +397,86 @@ func TestDeleteAttributeOverride_Success(t *testing.T) {
 	var response map[string]interface{}
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
 	require.Equal(t, true, response["success"])
+}
+
+// --- acknowledge action ---
+
+const acknowledgeDeviceID = "b62e6d86-6ce0-50da-8bff-b2ee54c4af4e"
+
+// postOverride sends one override body to the handler and returns the recorder.
+func postOverride(t *testing.T, mockRepo *mock_database.MockDeviceRepo, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	router := setupOverridesRouter(t, mockRepo)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, "/api/settings/overrides", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+	return w
+}
+
+func TestSaveAttributeOverride_AcknowledgeRequiresDevice(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	t.Cleanup(mockCtrl.Finish)
+	mockRepo := mock_database.NewMockDeviceRepo(mockCtrl)
+
+	w := postOverride(t, mockRepo, `{"protocol":"NVMe","attribute_id":"media_errors","action":"acknowledge"}`)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	require.Contains(t, w.Body.String(), "Acknowledge requires a specific device")
+}
+
+func TestSaveAttributeOverride_PinnedValueRejectedForOtherActions(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	t.Cleanup(mockCtrl.Finish)
+	mockRepo := mock_database.NewMockDeviceRepo(mockCtrl)
+
+	w := postOverride(t, mockRepo, `{"protocol":"NVMe","attribute_id":"media_errors","action":"ignore","pinned_value":3}`)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	require.Contains(t, w.Body.String(), "pinned_value is only valid")
+}
+
+func TestSaveAttributeOverride_AcknowledgeResolvesPinnedValueFromLatestSubmission(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	t.Cleanup(mockCtrl.Finish)
+	mockRepo := mock_database.NewMockDeviceRepo(mockCtrl)
+
+	mockRepo.EXPECT().GetDeviceByID(gomock.Any(), acknowledgeDeviceID).Return(models.Device{
+		DeviceID: acknowledgeDeviceID,
+		WWN:      "nvme-serial",
+	}, nil)
+	mockRepo.EXPECT().GetLatestSmartSubmission(gomock.Any(), "nvme-serial").Return([]measurements.Smart{{
+		Attributes: map[string]measurements.SmartAttribute{
+			"media_errors": &measurements.SmartNvmeAttribute{AttributeId: "media_errors", Value: 7},
+		},
+	}}, nil)
+	mockRepo.EXPECT().SaveAttributeOverride(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, override *models.AttributeOverride) error {
+		require.NotNil(t, override.PinnedValue)
+		require.Equal(t, int64(7), *override.PinnedValue)
+		return nil
+	})
+	mockRepo.EXPECT().GetDevices(gomock.Any()).Return([]models.Device{}, nil)
+
+	w := postOverride(t, mockRepo, `{"protocol":"NVMe","attribute_id":"media_errors","action":"acknowledge","device_id":"`+acknowledgeDeviceID+`"}`)
+
+	require.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestSaveAttributeOverride_AcknowledgeRejectsAttributeAbsentFromLatestSubmission(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	t.Cleanup(mockCtrl.Finish)
+	mockRepo := mock_database.NewMockDeviceRepo(mockCtrl)
+
+	mockRepo.EXPECT().GetDeviceByID(gomock.Any(), acknowledgeDeviceID).Return(models.Device{
+		DeviceID: acknowledgeDeviceID,
+		WWN:      "nvme-serial",
+	}, nil)
+	mockRepo.EXPECT().GetLatestSmartSubmission(gomock.Any(), "nvme-serial").Return([]measurements.Smart{{
+		Attributes: map[string]measurements.SmartAttribute{},
+	}}, nil)
+
+	w := postOverride(t, mockRepo, `{"protocol":"NVMe","attribute_id":"media_errors","action":"acknowledge","device_id":"`+acknowledgeDeviceID+`"}`)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	require.Contains(t, w.Body.String(), "Attribute not present")
 }

--- a/webapp/frontend/src/app/core/config/app.config.ts
+++ b/webapp/frontend/src/app/core/config/app.config.ts
@@ -58,7 +58,7 @@ export enum MetricsStatusThreshold {
 export type OverrideProtocol = 'ATA' | 'NVMe' | 'SCSI';
 
 // Action types for attribute overrides
-export type OverrideAction = 'ignore' | 'force_status' | '';
+export type OverrideAction = 'ignore' | 'force_status' | 'acknowledge' | '';
 
 // Status types for force_status action
 export type OverrideStatus = 'passed' | 'warn' | 'failed';
@@ -79,6 +79,8 @@ export interface AttributeOverride {
     status?: OverrideStatus;
     warn_above?: number;
     fail_above?: number;
+    // Set by the server for 'acknowledge' overrides: the value the pass is pinned to.
+    pinned_value?: number;
     source?: OverrideSource;
 }
 

--- a/webapp/frontend/src/app/layout/common/dashboard-settings/dashboard-settings.component.html
+++ b/webapp/frontend/src/app/layout/common/dashboard-settings/dashboard-settings.component.html
@@ -596,7 +596,10 @@
                     @if (overrideError) {
                     <p class="text-red-600 mt-2" role="alert" aria-live="assertive">{{ overrideError }}</p>
                     }
-                    <p id="override-form-hint" class="text-gray-500 mt-2">Choose a protocol and attribute ID. Custom thresholds need at least one value.</p>
+                    <p id="override-form-hint" class="text-gray-500 mt-2">
+                        Choose a protocol and attribute ID. Custom thresholds need at least one value. Acknowledge needs a device: it pins the pass to that device's current value
+                        and fails again if the value changes.
+                    </p>
 
                     <button
                         mat-raised-button
@@ -610,7 +613,8 @@
                             (newOverride.action === '' &&
                                 (newOverride.warn_above === null || newOverride.warn_above === undefined) &&
                                 (newOverride.fail_above === null || newOverride.fail_above === undefined)) ||
-                            (newOverride.action === 'force_status' && !newOverride.status)
+                            (newOverride.action === 'force_status' && !newOverride.status) ||
+                            (newOverride.action === 'acknowledge' && !newOverride.device_id)
                         "
                     >
                         Add Override

--- a/webapp/frontend/src/app/layout/common/dashboard-settings/dashboard-settings.component.ts
+++ b/webapp/frontend/src/app/layout/common/dashboard-settings/dashboard-settings.component.ts
@@ -167,6 +167,7 @@ export class DashboardSettingsComponent implements OnInit {
     actions: { value: OverrideAction; label: string }[] = [
         { value: 'ignore', label: 'Ignore' },
         { value: 'force_status', label: 'Force Status' },
+        { value: 'acknowledge', label: 'Acknowledge Current Value' },
         { value: '', label: 'Custom Threshold' },
     ];
     statuses: OverrideStatus[] = ['passed', 'warn', 'failed'];

--- a/webapp/frontend/src/app/modules/detail/detail.component.html
+++ b/webapp/frontend/src/app/modules/detail/detail.component.html
@@ -497,6 +497,9 @@
                         <button mat-stroked-button class="text-xs" (click)="ignoreAttribute(attribute); $event.stopPropagation()">
                             <mat-icon class="icon-size-16 mr-1" [svgIcon]="'visibility_off'"></mat-icon> Ignore
                         </button>
+                        <button mat-stroked-button class="text-xs" (click)="acknowledgeAttribute(attribute); $event.stopPropagation()">
+                            <mat-icon class="icon-size-16 mr-1" [svgIcon]="'check_circle_outline'"></mat-icon> Acknowledge
+                        </button>
                         }
                     </div>
                 </div>
@@ -686,9 +689,7 @@
 
                                 <mat-menu #overrideMenu="matMenu">
                                     @if (getOverrideForAttribute(attribute.attribute_id); as override) {
-                                    <div class="px-4 py-2 text-secondary text-sm" mat-menu-item disabled>
-                                        Override: {{ override.action === 'ignore' ? 'Ignored' : 'Forced ' + override.status }}
-                                    </div>
+                                    <div class="px-4 py-2 text-secondary text-sm" mat-menu-item disabled>Override: {{ overrideDescription(override) }}</div>
                                     <button mat-menu-item (click)="removeOverride(attribute)">
                                         <mat-icon class="icon-size-20" [svgIcon]="'close'"></mat-icon>
                                         <span>Remove override</span>
@@ -701,6 +702,10 @@
                                     <button mat-menu-item (click)="forcePassedAttribute(attribute)">
                                         <mat-icon class="icon-size-20" [svgIcon]="'check_circle'"></mat-icon>
                                         <span>Force passed</span>
+                                    </button>
+                                    <button mat-menu-item (click)="acknowledgeAttribute(attribute)" matTooltip="Passes at the current value only; fails again if the value changes">
+                                        <mat-icon class="icon-size-20" [svgIcon]="'check_circle_outline'"></mat-icon>
+                                        <span>Acknowledge current value</span>
                                     </button>
                                     }
                                 </mat-menu>

--- a/webapp/frontend/src/app/modules/detail/detail.component.spec.ts
+++ b/webapp/frontend/src/app/modules/detail/detail.component.spec.ts
@@ -639,4 +639,15 @@ describe('DetailComponent', () => {
             expect(component.getSSDWearoutValue()).toBe(87);
         });
     });
+
+    describe('overrideDescription', () => {
+        it('names the pinned value for an acknowledge override', () => {
+            expect(component.overrideDescription({ protocol: 'NVMe', attribute_id: 'media_errors', action: 'acknowledge', pinned_value: 3 })).toBe('Acknowledged at 3');
+        });
+
+        it('distinguishes acknowledge from the permanent force_status override', () => {
+            expect(component.overrideDescription({ protocol: 'NVMe', attribute_id: 'media_errors', action: 'force_status', status: 'passed' })).toBe('Forced passed');
+            expect(component.overrideDescription({ protocol: 'NVMe', attribute_id: 'media_errors', action: 'ignore' })).toBe('Ignored');
+        });
+    });
 });

--- a/webapp/frontend/src/app/modules/detail/detail.component.ts
+++ b/webapp/frontend/src/app/modules/detail/detail.component.ts
@@ -743,6 +743,37 @@ export class DetailComponent implements OnInit, AfterViewInit, OnDestroy {
             });
     }
 
+    acknowledgeAttribute(attr: SmartAttributeModel): void {
+        // No pinned_value is sent: the server reads the device's latest SMART submission and
+        // pins the same field its own evaluation compares, which differs by protocol.
+        const override: AttributeOverride = {
+            protocol: this.device.device_protocol as OverrideProtocol,
+            attribute_id: String(attr.attribute_id),
+            wwn: this.device.wwn,
+            action: 'acknowledge',
+        };
+        this._overrideService
+            .saveOverride(override)
+            .pipe(takeUntil(this._unsubscribeAll))
+            .subscribe({
+                next: () => this._refreshAfterOverrideChange(),
+                error: (err) => console.error('Failed to save override:', err),
+            });
+    }
+
+    overrideDescription(override: AttributeOverride): string {
+        switch (override.action) {
+            case 'ignore':
+                return 'Ignored';
+            case 'acknowledge':
+                return `Acknowledged at ${override.pinned_value}`;
+            case 'force_status':
+                return `Forced ${override.status}`;
+            default:
+                return 'Custom threshold';
+        }
+    }
+
     removeOverride(attr: SmartAttributeModel): void {
         const override = this.getOverrideForAttribute(attr.attribute_id);
         if (override?.id) {


### PR DESCRIPTION
Closes #775

## Problem

`ignore` and `force_status` both mask an attribute permanently. A user who has looked at one bad value and accepted it - reallocated sectors that settled a year ago, a packed Command Timeout value that Scrutiny misreads - loses the signal for every later change too. The request in #775 is to accept the *current* state without giving up on the next one.

## Solution

A third action, `acknowledge`, pinned to a value:

- The attribute passes only while its value equals the pinned one.
- Any change restores the underlying evaluation, so a new event alerts normally.
- A manufacturer SMART failure is never masked. This matches `ApplyDeltaEvaluation`: the drive reporting its own failure is not a Scrutiny verdict a user can acknowledge away.
- Acknowledge requires a device (`device_id` or `wwn`). A fleet-wide rule cannot express a pinned value, because the same attribute holds a different value on every device.

The status reason distinguishes the two states: `Acknowledged at value 3`, or `Acknowledgement no longer applies: value changed from 3 to 4`.

## Where the pinned value comes from

The server resolves it from the device's latest SMART submission rather than trusting a client-sent value. Which field an attribute is evaluated against differs by protocol - ATA compares the raw value, every other protocol the normalized one - and that rule already lives in the evaluation path. Restating it in the frontend would let the two drift apart silently, so it is exported as `measurements.AttributeThresholdValue` and the handler pins whatever that returns. The UI sends no value at all.

Sending `pinned_value` with any other action is rejected.

## Migration

`m20260906000000` adds `pinned_value` via `AutoMigrate`, which only adds the missing column and is a no-op on a database that already has it. The column is nullable rather than defaulted: `0` is a legitimate acknowledged value, and a defaulted column would read every pre-existing override as acknowledged at zero.

## UI

Device detail page: `Acknowledge current value` in the attribute actions menu and beside the inline `Ignore` button. Active overrides now describe themselves through one `overrideDescription` helper, so an acknowledge row reads `Acknowledged at 3` rather than falling through to a wrong label.

Dashboard settings: the action is selectable and the form requires a device for it.

The menu icon is `check_circle_outline`; `task_alt` was tried first and is not present in `material-twotone.svg`, which fails silently at runtime.

## Testing

- `go build ./webapp/...` clean; `go vet` clean on all changed packages.
- New backend tests: passes at pinned value, re-fails when the value changes, never masks `AttributeStatusFailedSmart`, `AttributeThresholdValue` returns the field each protocol is evaluated on.
- New handler tests: device required, `pinned_value` rejected for other actions, pinned value resolved from the latest submission, attribute absent from that submission rejected.
- New migration test: a pre-existing override reads back with `pinned_value` NULL, and `0` round-trips as `0`.
- `webapp/backend/pkg/{overrides,models,web/handler,database}` suites pass.
- Frontend: `ng build` clean, 193 specs pass.

## Docs

README override table and both UI walkthroughs, `docs/openapi.yaml` schema (including the previously missing `device_id`), and a config-file example. `CHANGELOG.md` is left alone - semantic-release generates it.
