### PR TITLE
fix(theme): preserve Angular Material system map in Treo adapter

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,6 +31,12 @@ jobs:
       - name: Test Frontend
         run: |
           make binary-frontend-test-coverage
+      - name: Guard Material theme tokens
+        # The Treo theme adapter must merge into the Angular Material theme map.
+        # Rebuilding it drops '_mat-system' and the theme silently emits no color
+        # tokens, which is how overlay backgrounds went transparent in #541.
+        # Runs after Test Frontend because that target installs node_modules.
+        run: npm --prefix webapp/frontend run test:theme
   test-backend:
     name: Test Backend
     runs-on: ubuntu-latest

--- a/webapp/frontend/package.json
+++ b/webapp/frontend/package.json
@@ -11,6 +11,7 @@
     "build:prod:mem": "node --max_old_space_size=6144 ./node_modules/@angular/cli/bin/ng build --prod",
     "test": "ng test",
     "test:icons": "node scripts/check-icon-references.mjs",
+    "test:theme": "node scripts/check-theme-tokens.mjs",
     "lint": "ng lint",
     "lint:fix": "ng lint --fix",
     "format": "prettier --write \"src/**/*.{ts,html,json}\"",

--- a/webapp/frontend/scripts/check-theme-tokens.mjs
+++ b/webapp/frontend/scripts/check-theme-tokens.mjs
@@ -1,0 +1,127 @@
+// Guards the Treo -> Angular Material theme adapter.
+//
+// Angular Material derives every component color token from '_mat-system', a
+// flat map that 'mat.m2-define-*-theme' attaches to the theme. A theme adapter
+// that rebuilds the theme map instead of merging into it drops that key, every
+// token resolves to null, and the generated stylesheet silently emits no color
+// custom properties at all. Overlay-rendered components then render on a
+// transparent background (#541), and nothing in the build reports an error.
+//
+// This check compiles the real theme entrypoint and asserts that a
+// representative token still lands on each generated theme class.
+
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const frontendRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const entrypoint = join(frontendRoot, 'src', '@treo', 'styles', 'main.scss');
+const nodeModules = join(frontendRoot, 'node_modules');
+
+// Every theme class generated from '$treo-themes' in 'src/styles/themes.scss'.
+const themeClasses = ['treo-theme-dark', 'treo-theme-light', 'theme-dark', 'theme-light'];
+
+// One token per component named in the acceptance criteria of #543, plus the
+// app surface. Each resolves from a different system key, so a partial
+// regression cannot pass.
+const requiredTokens = [
+    '--mat-select-panel-background-color',
+    '--mat-menu-container-color',
+    '--mat-autocomplete-background-color',
+    '--mat-dialog-container-color',
+    '--mat-expansion-container-background-color',
+    '--mat-option-label-text-color',
+    '--mat-app-background-color',
+    '--mat-form-field-filled-container-color',
+];
+
+if (!existsSync(join(nodeModules, 'sass'))) {
+    console.error("Cannot find 'sass' in node_modules. Run 'npm ci' in webapp/frontend first.");
+    process.exit(1);
+}
+
+const sass = await import('sass');
+
+const css = sass.compile(entrypoint, {
+    loadPaths: [nodeModules, join(frontendRoot, 'src', '@treo', 'styles')],
+    silenceDeprecations: ['if-function', 'import', 'global-builtin', 'color-functions'],
+}).css;
+
+// Walk top-level rules. Nested selectors such as '.treo-theme-dark .mat-warn'
+// set the same tokens with palette variants, so matching on the theme class
+// alone would read a descendant's value.
+function* topLevelRules(source) {
+    let index = 0;
+
+    while (index < source.length) {
+        const open = source.indexOf('{', index);
+
+        if (open < 0) {
+            return;
+        }
+
+        const selector = source.slice(index, open).trim();
+        let depth = 1;
+        let cursor = open + 1;
+
+        while (cursor < source.length && depth > 0) {
+            if (source[cursor] === '{') {
+                depth += 1;
+            } else if (source[cursor] === '}') {
+                depth -= 1;
+            }
+
+            cursor += 1;
+        }
+
+        yield [selector, source.slice(open + 1, cursor - 1)];
+        index = cursor;
+    }
+}
+
+const tokensByTheme = new Map(themeClasses.map((name) => [name, new Map()]));
+
+for (const [selector, body] of topLevelRules(css)) {
+    for (const part of selector.split(',')) {
+        const themeClass = part.trim().slice(1);
+
+        if (!tokensByTheme.has(themeClass) || part.trim() !== `.${themeClass}`) {
+            continue;
+        }
+
+        for (const match of body.matchAll(/(--mat-[a-z0-9-]+):\s*([^;]+);/g)) {
+            tokensByTheme.get(themeClass).set(match[1], match[2].trim());
+        }
+    }
+}
+
+const failures = [];
+
+for (const themeClass of themeClasses) {
+    const tokens = tokensByTheme.get(themeClass);
+
+    if (tokens.size === 0) {
+        failures.push(`.${themeClass} emits no --mat-* tokens at all`);
+        continue;
+    }
+
+    for (const token of requiredTokens) {
+        if (!tokens.has(token)) {
+            failures.push(`.${themeClass} is missing ${token}`);
+        }
+    }
+}
+
+if (failures.length > 0) {
+    console.error('The generated Angular Material theme is missing color tokens:');
+    console.error(failures.join('\n'));
+    console.error(
+        "\nThe theme adapter in src/@treo/styles/utilities/_colors.scss must merge into the" +
+        "\nAngular Material theme map, never rebuild it, so that '_mat-system' survives." +
+        '\nSee _treo-modify-angular-material-theme-colors and _treo-system-color-overrides.'
+    );
+    process.exitCode = 1;
+} else {
+    const counts = themeClasses.map((name) => `${name}=${tokensByTheme.get(name).size}`).join(' ');
+    console.log(`Angular Material theme tokens present on every theme class (${counts}).`);
+}

--- a/webapp/frontend/src/@treo/styles/utilities/_colors.scss
+++ b/webapp/frontend/src/@treo/styles/utilities/_colors.scss
@@ -79,6 +79,47 @@
 }
 
 ///
+/// Map Treo's foreground and background intent onto the Angular Material system
+/// map. Component token functions read the system map, not the legacy
+/// 'foreground' and 'background' palettes, so a value set only in those two
+/// palettes never reaches a rendered component.
+///
+/// Only the surface family is overridden here. 'primary', 'secondary', 'error'
+/// and the palette-derived 'on-*' keys are already correct because they are
+/// built from the palettes passed to the theme. The 'surface-container*' and
+/// 'neutral*' keys are read on the M3 path only and are left untouched.
+///
+/// @access private
+/// @param {Boolean} $is-dark - Whether the theme is a dark theme
+/// @param {Map} $foreground - Treo's modified foreground palette
+/// @param {Map} $background - Treo's modified background palette
+///
+@function _treo-system-color-overrides($is-dark, $foreground, $background) {
+    @return (
+        // Overlay and container surfaces: select panel, menu, autocomplete,
+        // dialog, expansion, table, card, toolbar, paginator, sidenav.
+        surface: map.get($background, card),
+        background: map.get($background, background),
+
+        // Text and iconography.
+        on-surface: map.get($foreground, text),
+        on-surface-variant: map.get($foreground, secondary-text),
+
+        // Filled form field container and slide toggle icons. Treo has no
+        // existing value for this surface, so it is defined here.
+        surface-variant: if($is-dark, rgba(255, 255, 255, 0.06), treo-color('cool-gray', 100)),
+
+        // Form field outlines and dividers.
+        outline: map.get($foreground, divider),
+        outline-variant: map.get($foreground, disabled),
+
+        // Tooltip and snack bar, which invert against the page surface.
+        inverse-surface: map.get($background, tooltip),
+        inverse-on-surface: if($is-dark, treo-color('cool-gray', 900), white)
+    );
+}
+
+///
 /// Modify the Angular Material theme object to soften foreground colors
 /// on light themes and increase contrast on dark themes
 ///
@@ -130,22 +171,26 @@
         tooltip: if($is-dark, treo-color('cool-gray', 500), treo-color('cool-gray', 800)),
     );
 
-    // Store the modified theme.
+    // Merge the modified palettes into the theme rather than rebuilding it.
     //
-    // Since modifications only being done on 'foreground'
-    // and 'background' palettes, add them from above but
-    // keep everything else original
-    $modified-theme: (
-        primary: map.get($theme, primary),
-        accent: map.get($theme, accent),
-        warn: map.get($theme, warn),
-        is-dark: map.get($theme, is-dark),
+    // The theme map carries '_mat-system', the flat system map that every
+    // Angular Material component token function reads through
+    // 'm2-utils.get-system()', along with the internal typography and density
+    // configs. Returning a freshly built map drops all of them, 'get-system()'
+    // then returns an empty map, and every color token resolves to null, so the
+    // generated theme emits no color custom properties at all.
+    //
+    // '_mat-system' is derived from the palettes and 'is-dark' alone, so the
+    // modified 'foreground' and 'background' palettes above have to be restated
+    // against the system keys to take effect on components.
+    @return map.merge($theme, (
         foreground: $foreground,
-        background: $background
-    );
-
-    // Return the modified theme
-    @return $modified-theme;
+        background: $background,
+        _mat-system: map.merge(
+            map.get($theme, _mat-system),
+            _treo-system-color-overrides($is-dark, $foreground, $background)
+        )
+    ));
 }
 
 ///

--- a/webapp/frontend/src/styles/styles.scss
+++ b/webapp/frontend/src/styles/styles.scss
@@ -5,51 +5,17 @@
 //  modifications of third party libraries.
 // -----------------------------------------------------------------------------------------------------
 
+// Overlay, dialog, select, option, expansion and form field colors are emitted by
+// the generated Angular Material theme. See '_treo-system-color-overrides' in
+// '@treo/styles/utilities/_colors.scss'. Do not reintroduce per-component
+// '--mat-*' overrides here; fix the theme adapter instead.
+
 .treo-theme-dark {
-    --mat-select-panel-background-color: #1e293b;
-    --mat-menu-container-color: #1e293b;
-    --mat-autocomplete-background-color: #1e293b;
 
-    // The legacy Treo theme (pre-MDC) does not emit M3 component tokens for
-    // overlay-rendered components, so dialogs, selects and form fields fall back
-    // to Material's light defaults. Patch the dark tokens here so the Settings
-    // dialog and its dropdowns honor dark mode.
-
-    // Dialog surface + text (Settings dialog)
-    --mat-dialog-container-color: #1e293b;
-    --mat-dialog-subhead-color: #f8fafc;
-    --mat-dialog-supporting-text-color: #e2e8f0;
-
-    // Select dropdown option text (was dark-on-dark, unreadable)
-    --mat-option-label-text-color: #e2e8f0;
-    --mat-option-selected-state-label-text-color: #ffffff;
-    --mat-select-enabled-trigger-text-color: #f1f5f9;
-    --mat-select-placeholder-text-color: #94a3b8;
-    --mat-select-enabled-arrow-color: #cbd5e1;
-    --mat-select-focused-arrow-color: #38bdf8;
-
-    // Expansion panels (Scheduled Reports, SMART Overrides, Notifications, Navigation)
-    --mat-expansion-container-background-color: #243044;
-    --mat-expansion-container-text-color: #e2e8f0;
-    --mat-expansion-header-text-color: #f8fafc;
-    --mat-expansion-header-description-color: #cbd5e1;
-    --mat-expansion-header-indicator-color: #cbd5e1;
-    --mat-expansion-actions-divider-color: rgba(148, 163, 184, 0.2);
-
-    // Filled form fields (inputs, labels, hints) inside the dialog
-    --mat-form-field-filled-container-color: rgba(255, 255, 255, 0.06);
-    --mat-form-field-filled-input-text-color: #f1f5f9;
-    --mat-form-field-filled-input-text-placeholder-color: #94a3b8;
-    --mat-form-field-filled-label-text-color: #cbd5e1;
-    --mat-form-field-filled-focus-label-text-color: #38bdf8;
-    --mat-form-field-filled-caret-color: #38bdf8;
-    --mat-form-field-filled-active-indicator-color: rgba(148, 163, 184, 0.5);
-    --mat-form-field-filled-hover-active-indicator-color: #cbd5e1;
-    --mat-form-field-filled-focus-active-indicator-color: #38bdf8;
-
-    // mat-hint / subscript text has no dedicated color token; force it readable
+    // 'mat-hint' and subscript text have font tokens but no color token, so this
+    // stays a direct rule. The value matches the theme's 'on-surface-variant'.
     .mat-mdc-form-field-subscript-wrapper {
-        color: #94a3b8;
+        color: #97a6ba;
     }
 
     .yellow-50 {
@@ -65,11 +31,9 @@
         }
     }
 
+    // The table sits on an already-themed card, so its own surface is cleared.
     .scrutiny-dark-table {
         --mat-table-background-color: transparent;
-        --mat-table-header-headline-color: #f8fafc;
-        --mat-table-row-item-label-text-color: #e2e8f0;
-        --mat-table-row-item-outline-color: rgba(148, 163, 184, 0.16);
 
         .bg-blue-100 {
             color: #1e3a8a !important;
@@ -90,20 +54,6 @@
     // ID column uses text-secondary class
     .mat-mdc-cell .text-secondary {
         color: #CFD8E3 !important;
-    }
-
-    .mat-mdc-dialog-container .mat-mdc-dialog-actions .mat-mdc-button-base {
-        color: #e2e8f0;
-    }
-}
-
-.treo-theme-light {
-    --mat-select-panel-background-color: #ffffff;
-    --mat-menu-container-color: #ffffff;
-    --mat-autocomplete-background-color: #ffffff;
-
-    .mat-mdc-dialog-container .mat-mdc-dialog-actions .mat-mdc-button-base {
-        color: #0f172a;
     }
 }
 


### PR DESCRIPTION
Closes #543. Follow-up to the targeted patch for #541.

## The bug

`_treo-modify-angular-material-theme-colors` rebuilt the Angular Material theme
map from scratch rather than merging into it. That dropped `_mat-system`, the
flat system map every component token function reads through
`m2-utils.get-system()`, plus the internal typography and density configs.

With the key gone, `get-system()` returns an empty map and every color token
resolves to null, so the generated stylesheet emitted **no color custom
properties at all**. Measured on `develop`: 587 properties, every one of them an
elevation or shape base token.

Nothing reports this. Sass compiles, the build succeeds, and the tokens simply
do not exist. That is why the overlay backgrounds in #541 were transparent, and
why patching the variables by hand under `.treo-theme-dark` cleared the symptom
while leaving the adapter broken.

## The fix

Two parts, because merging alone is not enough. `_mat-system` is derived from
the palettes and `is-dark` alone, so Treo's customized `foreground` and
`background` palettes never reach it; a plain merge restores the tokens at
Angular Material's stock colors.

1. `_treo-modify-angular-material-theme-colors` now merges into the theme it was
   given instead of returning a new map.
2. `_treo-system-color-overrides` restates Treo's intent against the system keys
   the M2 path actually reads.

Nine keys, counted by direct reads across Angular Material excluding the `_m3-*`
files, which the theme-version-0 path never evaluates:

| System key | Reads | Treo source | Drives |
| --- | --- | --- | --- |
| `on-surface` | 135 | `foreground.text` | body and label text everywhere |
| `on-surface-variant` | 47 | `foreground.secondary-text` | placeholders, hints, select arrows, form field labels |
| `surface` | 28 | `background.card` | select panel, menu, autocomplete, dialog, expansion, table, card, tree, datepicker, timepicker, toolbar, stepper, paginator, bottom sheet, button toggle, sidenav |
| `outline` | 16 | `foreground.divider` | form field outlines, dividers |
| `inverse-surface` | 6 | `background.tooltip` | tooltip and snack bar containers |
| `background` | 4 | `background.background` | app background, sidenav, pseudo-checkbox |
| `surface-variant` | 3 | new value | filled form field container, slide toggle icons |
| `inverse-on-surface` | 3 | new value | tooltip and snack bar text |
| `outline-variant` | 1 | `foreground.disabled` | form field outline when disabled |

`primary`, `secondary`, `error` and the palette-derived `on-*` keys already
resolve correctly from the palettes passed to the theme and are not overridden.
`surface-container*` and `neutral*` are read on the M3 path only and are left
alone.

## Result

670 color tokens on each of the four theme classes, matching what an unmodified
Angular Material theme emits.

| Token | Before | Dark, after | Light, after |
| --- | --- | --- | --- |
| `--mat-select-panel-background-color` | absent | `#27303f` | `white` |
| `--mat-menu-container-color` | absent | `#27303f` | `white` |
| `--mat-autocomplete-background-color` | absent | `#27303f` | `white` |
| `--mat-dialog-container-color` | absent | `#27303f` | `white` |
| `--mat-expansion-container-background-color` | absent | `#27303f` | `white` |
| `--mat-table-background-color` | absent | `#27303f` | `white` |
| `--mat-option-label-text-color` | absent | `white` | `#27303f` |
| `--mat-select-placeholder-text-color` | absent | `#97a6ba` | `#64748b` |
| `--mat-form-field-filled-container-color` | absent | `rgba(255,255,255,0.06)` | `#f1f5f9` |
| `--mat-app-background-color` | absent | `#1a202e` | `#f1f5f9` |
| `--mat-tooltip-container-color` | absent | `#64748b` | `#27303f` |

## Visible colour changes

The hand-written overrides used values that are not in the Treo palette, so
removing them shifts a few surfaces onto palette colours:

- overlay and dialog surfaces: `#1e293b` to cool-gray 800 `#27303F`
- expansion panels: `#243044` to `#27303F`
- focus indicators, carets and focused arrows: `#38bdf8` to the theme's own
  primary, teal 500 `#0694A2`

Contrast was checked for every pair that changed. Dark secondary text on the
dialog surface is the largest move, 10.78:1 to 5.36:1, still above the 4.5:1
threshold for normal text. The focus indicator lands at 3.65:1, above the 3:1
threshold for non-text UI components.

## What stays in styles.scss

Three rules have no token behind them and are unchanged in substance:

- form field subscript text, which has `--mat-form-field-subscript-text-*` font
  tokens but no colour token
- the `.yellow-50` dark override
- the SMART table cell contrast rules from #165

`.scrutiny-dark-table` keeps only its transparent background, which is a
deliberate scoped override so the card behind shows through. Its other three
table variables are now emitted by the theme and were removed.

## Regression guard

`webapp/frontend/scripts/check-theme-tokens.mjs` compiles the real theme
entrypoint and asserts a representative token still lands on each theme class,
wired into CI as `npm run test:theme`. It runs after `Test Frontend` because
that target is what installs `node_modules`.

It was verified against the previous adapter: reintroducing the rebuilt map
fails the check with all 32 assertions, exit code 1.

## Verification

- `npm run build:prod` from a clean `dist`: passes. Bundle carries 966 unique
  `--mat-*` properties and no remaining `#1e293b`.
- `npm run lint`: passes.
- `npm run test:icons`: passes.
- `npm run test:theme`: passes.

Not covered here: a visual pass. 379 tokens per theme that never existed now
exist, so components that were falling back to Angular Material defaults change
appearance. All four theme classes are affected, not only the two named in the
issue.
