### PR TITLE
fix(database): tolerate summary records missing optional fields

### DIFF
--- a/webapp/backend/pkg/database/scrutiny_repository.go
+++ b/webapp/backend/pkg/database/scrutiny_repository.go
@@ -539,11 +539,11 @@ func summaryFluxQuery(bucketBaseName string) string {
 
 // applySummaryRecord parses a single summary query record and populates the matching device summary.
 func (sr *scrutinyRepository) applySummaryRecord(summaries map[string]*models.DeviceSummary, wwnToDeviceID map[string]string, values map[string]interface{}) {
-	deviceWWN, ok := values["device_wwn"]
+	deviceWWN, ok := values["device_wwn"].(string)
 	if !ok {
 		return
 	}
-	devID, hasDevID := wwnToDeviceID[deviceWWN.(string)]
+	devID, hasDevID := wwnToDeviceID[deviceWWN]
 	if !hasDevID {
 		return
 	}
@@ -553,10 +553,24 @@ func (sr *scrutinyRepository) applySummaryRecord(summaries map[string]*models.De
 		summaries[devID] = &models.DeviceSummary{}
 	}
 
+	// Every field here is optional. summaryFluxQuery unions the daily, weekly,
+	// monthly and yearly buckets and pivots with schema.fieldsAsCols(), so a
+	// device whose winning row never had one of these fields written yields a
+	// map with that key absent. An unchecked assertion on a nil value panics,
+	// and because this runs in the goroutine started by loadInitialMetrics it
+	// takes down the whole web process before it finishes binding.
+	temp, hasTemp := values["temp"].(int64)
+	powerOnHours, hasPowerOnHours := values["power_on_hours"].(int64)
+	collectorDate, hasCollectorDate := values["_time"].(time.Time)
+
+	if missing := missingSummaryFields(hasTemp, hasPowerOnHours, hasCollectorDate); len(missing) > 0 {
+		sr.logger.Debugf("summary record for device %s is missing %s; using zero values", deviceWWN, strings.Join(missing, ", "))
+	}
+
 	smartSummary := &models.SmartSummary{
-		Temp:          values["temp"].(int64),
-		PowerOnHours:  values["power_on_hours"].(int64),
-		CollectorDate: values["_time"].(time.Time),
+		Temp:          temp,
+		PowerOnHours:  powerOnHours,
+		CollectorDate: collectorDate,
 	}
 	smartSummary.PercentageUsed = extractPercentageUsed(values)
 	smartSummary.WearoutValue = extractWearoutValue(values)
@@ -568,6 +582,22 @@ func (sr *scrutinyRepository) applySummaryRecord(summaries map[string]*models.De
 	smartSummary.RiskCategory = string(riskCategory)
 
 	summaries[devID].SmartResults = smartSummary
+}
+
+// missingSummaryFields names the summary fields that were absent from a record,
+// for the diagnostic log in applySummaryRecord.
+func missingSummaryFields(hasTemp, hasPowerOnHours, hasCollectorDate bool) []string {
+	missing := []string{}
+	if !hasTemp {
+		missing = append(missing, "temp")
+	}
+	if !hasPowerOnHours {
+		missing = append(missing, "power_on_hours")
+	}
+	if !hasCollectorDate {
+		missing = append(missing, "_time")
+	}
+	return missing
 }
 
 // extractPercentageUsed returns the "percentage used" wear metric from NVMe (percentage_used) or

--- a/webapp/backend/pkg/database/scrutiny_repository_summary_record_test.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_summary_record_test.go
@@ -1,0 +1,159 @@
+package database
+
+import (
+	"testing"
+	"time"
+
+	"github.com/analogj/scrutiny/webapp/backend/pkg/models"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+// summaryRecordRepository builds the minimum repository needed to exercise
+// applySummaryRecord, which reads only the logger.
+func summaryRecordRepository() *scrutinyRepository {
+	logger := logrus.New()
+	logger.SetLevel(logrus.PanicLevel)
+
+	return &scrutinyRepository{logger: logger}
+}
+
+func summaryRecordFixture() (map[string]*models.DeviceSummary, map[string]string) {
+	summaries := map[string]*models.DeviceSummary{
+		"dev-1": {Device: models.Device{DeviceID: "dev-1", WWN: "wwn-1"}},
+	}
+
+	return summaries, map[string]string{"wwn-1": "dev-1"}
+}
+
+// A record missing temp or power_on_hours used to panic with
+// "interface conversion: interface {} is nil, not int64". applySummaryRecord
+// runs in the goroutine started by loadInitialMetrics, so the panic killed the
+// web process before it finished binding and s6 restart-looped it.
+func TestApplySummaryRecordToleratesMissingFields(t *testing.T) {
+	collected := time.Date(2026, 9, 6, 12, 0, 0, 0, time.UTC)
+
+	cases := []struct {
+		name                 string
+		values               map[string]interface{}
+		expectedTemp         int64
+		expectedPowerOnHours int64
+		expectedDate         time.Time
+	}{
+		{
+			name: "all fields present",
+			values: map[string]interface{}{
+				"device_wwn":     "wwn-1",
+				"temp":           int64(35),
+				"power_on_hours": int64(1200),
+				"_time":          collected,
+			},
+			expectedTemp:         35,
+			expectedPowerOnHours: 1200,
+			expectedDate:         collected,
+		},
+		{
+			name: "temp absent",
+			values: map[string]interface{}{
+				"device_wwn":     "wwn-1",
+				"power_on_hours": int64(1200),
+				"_time":          collected,
+			},
+			expectedPowerOnHours: 1200,
+			expectedDate:         collected,
+		},
+		{
+			name: "temp explicitly nil",
+			values: map[string]interface{}{
+				"device_wwn":     "wwn-1",
+				"temp":           nil,
+				"power_on_hours": int64(1200),
+				"_time":          collected,
+			},
+			expectedPowerOnHours: 1200,
+			expectedDate:         collected,
+		},
+		{
+			name: "power_on_hours absent",
+			values: map[string]interface{}{
+				"device_wwn": "wwn-1",
+				"temp":       int64(35),
+				"_time":      collected,
+			},
+			expectedTemp: 35,
+			expectedDate: collected,
+		},
+		{
+			name: "time absent",
+			values: map[string]interface{}{
+				"device_wwn":     "wwn-1",
+				"temp":           int64(35),
+				"power_on_hours": int64(1200),
+			},
+			expectedTemp:         35,
+			expectedPowerOnHours: 1200,
+		},
+		{
+			name:   "every optional field absent",
+			values: map[string]interface{}{"device_wwn": "wwn-1"},
+		},
+		{
+			name: "wrong type is treated as absent",
+			values: map[string]interface{}{
+				"device_wwn":     "wwn-1",
+				"temp":           "35",
+				"power_on_hours": float64(1200),
+				"_time":          "2026-09-06",
+			},
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			summaries, wwnToDeviceID := summaryRecordFixture()
+
+			require.NotPanics(t, func() {
+				summaryRecordRepository().applySummaryRecord(summaries, wwnToDeviceID, testCase.values)
+			})
+
+			results := summaries["dev-1"].SmartResults
+			require.NotNil(t, results, "a partial record must still produce a summary")
+			require.Equal(t, testCase.expectedTemp, results.Temp)
+			require.Equal(t, testCase.expectedPowerOnHours, results.PowerOnHours)
+			require.Equal(t, testCase.expectedDate, results.CollectorDate)
+		})
+	}
+}
+
+// A non-string device_wwn reached wwnToDeviceID[deviceWWN.(string)] unguarded.
+func TestApplySummaryRecordIgnoresUnusableDeviceWWN(t *testing.T) {
+	cases := map[string]map[string]interface{}{
+		"missing":    {"temp": int64(35)},
+		"nil":        {"device_wwn": nil},
+		"non-string": {"device_wwn": int64(7)},
+		"unknown":    {"device_wwn": "wwn-unknown"},
+	}
+
+	for name, values := range cases {
+		t.Run(name, func(t *testing.T) {
+			summaries, wwnToDeviceID := summaryRecordFixture()
+
+			require.NotPanics(t, func() {
+				summaryRecordRepository().applySummaryRecord(summaries, wwnToDeviceID, values)
+			})
+
+			require.Nil(t, summaries["dev-1"].SmartResults)
+		})
+	}
+}
+
+func TestMissingSummaryFieldsNamesEveryAbsentField(t *testing.T) {
+	require.Empty(t, missingSummaryFields(true, true, true))
+	require.Equal(t, []string{"temp"}, missingSummaryFields(false, true, true))
+	require.Equal(t, []string{"power_on_hours"}, missingSummaryFields(true, false, true))
+	require.Equal(t, []string{"_time"}, missingSummaryFields(true, true, false))
+	require.Equal(t,
+		[]string{"temp", "power_on_hours", "_time"},
+		missingSummaryFields(false, false, false),
+	)
+}


### PR DESCRIPTION
Fixes #806.

## The bug

`applySummaryRecord` built `models.SmartSummary` with unchecked type assertions:

```go
smartSummary := &models.SmartSummary{
    Temp:          values["temp"].(int64),
    PowerOnHours:  values["power_on_hours"].(int64),
    CollectorDate: values["_time"].(time.Time),
}
```

`summaryFluxQuery` unions the daily, weekly, monthly and yearly buckets and
pivots with `schema.fieldsAsCols()`. A device whose winning row never had one of
those fields written yields a map with the key absent, the lookup returns nil,
and the assertion panics. `wwnToDeviceID[deviceWWN.(string)]` on the line above
was unchecked in the same way.

```
panic: interface conversion: interface {} is nil, not int64
  database.applySummaryRecord        scrutiny_repository.go:557
  database.getSummary                scrutiny_repository.go:461
  metrics.Collector.LoadInitialData  collector.go:145
  web.loadInitialMetrics             server.go:445
```

## Why it is worse than a panic

It runs in the goroutine started by `loadInitialMetrics`, so it kills the
process before the HTTP server finishes binding. Under the omnibus image s6
restarts the supervised child immediately, so the container never exits and
Docker keeps reporting it healthy.

A production instance was found serving nothing on its published port for five
hours while `docker ps` showed `Up 5 hours` and `RestartCount=0`. The container
log held 48059 panics. Nothing external caught it: the port is bound by
`docker-proxy` whether or not the app is listening, so even a TCP check passes.

One device with a partial summary row stops disk health alerting for every
device.

## The fix

Read each field with comma-ok. Keep the record rather than dropping it, so
partial data still reaches the dashboard, and let absent fields fall back to
their zero values. That is already how the model represents them: `Temp` and
`PowerOnHours` are plain `int64`, not pointers, unlike the neighbouring
`PercentageUsed` and `WearoutValue`. A debug log names the device and the
missing fields so the underlying data gap stays diagnosable.

This is the pattern the rest of the function already uses.
`extractPercentageUsed`, `extractWearoutValue` and `asInt64Ptr` are all
comma-ok; only this literal and the WWN lookup were unchecked. Both predate the
cognitive-complexity refactor in #621 and come from upstream.

## Tests

`scrutiny_repository_summary_record_test.go` covers 12 cases: every field
present, each field individually absent, an explicit nil, all optional fields
absent at once, wrong types treated as absent, and four unusable `device_wwn`
shapes.

Verified the tests fail against the previous code: restoring the unchecked
assertion turns `temp absent` red with the original panic.

- `go build ./webapp/backend/...` passes
- `go vet ./webapp/backend/pkg/database/` passes
- `go test ./webapp/backend/pkg/database/...` passes

## Not covered here

Why a device started returning a summary row without `temp` is a separate
question. This change stops one malformed row taking down the process; it does
not explain the data gap, which the new debug log is there to surface.

Worth considering separately: the container reports healthy while the supervised
web process is dead. A healthcheck that actually probes the app would have
caught this in minutes rather than hours.
