### PR TITLE
fix(zfs): raise contrast on the raw capacity line

### DIFF
--- a/webapp/frontend/src/app/layout/common/zfs-pool-card/zfs-pool-card.component.html
+++ b/webapp/frontend/src/app/layout/common/zfs-pool-card/zfs-pool-card.component.html
@@ -103,7 +103,7 @@
             <div class="mt-2 font-medium text-3xl leading-none">
                 {{ usableSize(poolSummary) | fileSize : $safeNavigationMigration(config?.file_size_si_units) }}
             </div>
-            <div class="mt-1 text-xs text-hint">{{ poolSummary.size | fileSize : $safeNavigationMigration(config?.file_size_si_units) }} raw</div>
+            <div class="mt-1 text-sm text-secondary">{{ poolSummary.size | fileSize : $safeNavigationMigration(config?.file_size_si_units) }} raw</div>
             } @else {
             <div class="mt-2 font-medium text-3xl leading-none">
                 {{ poolSummary.size | fileSize : $safeNavigationMigration(config?.file_size_si_units) }}

--- a/webapp/frontend/src/app/modules/zfs-pool-detail/zfs-pool-detail.component.html
+++ b/webapp/frontend/src/app/modules/zfs-pool-detail/zfs-pool-detail.component.html
@@ -48,11 +48,11 @@
                 ></div>
             </div>
             @if (usableSize(pool) > 0) {
-            <div class="text-sm text-hint mt-2">
+            <div class="text-sm text-secondary mt-2">
                 {{ pool.usable_used | fileSize : $safeNavigationMigration(config?.file_size_si_units) }} /
                 {{ usableSize(pool) | fileSize : $safeNavigationMigration(config?.file_size_si_units) }} usable
             </div>
-            <div class="text-xs text-hint mt-1">
+            <div class="text-xs text-secondary mt-1">
                 {{ pool.allocated | fileSize : $safeNavigationMigration(config?.file_size_si_units) }} /
                 {{ pool.size | fileSize : $safeNavigationMigration(config?.file_size_si_units) }} raw
             </div>


### PR DESCRIPTION
Follow-up to #801, which added the raw capacity line beneath the usable size.

## Problem

The raw line was `text-xs text-hint`. Against the card background that is close to unreadable in both light and dark themes, which defeats the point of keeping the raw figure visible.

## Change

- Pool card: `text-xs text-hint` becomes `text-sm text-secondary`. The value it sits under is `text-3xl`, so there is room for the larger size without competing with it.
- Pool detail Capacity card: the raw line becomes `text-xs text-secondary`, and the usable line above it moves from `text-hint` to `text-secondary` as well. The pair now keeps its hierarchy through size rather than through one line being fainter than the line it qualifies.

The fallback branch shown for pools with no usable figure is untouched.

## Validation

- `ng build` clean
- `ng test`: 195 of 195 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
