### PR TITLE
fix(docker): add a healthcheck so a dead web process is visible

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -118,4 +118,17 @@ RUN chmod 0644 /etc/cron.d/scrutiny && \
     chmod +x /etc/services.d/*/run && \
     chmod +x /etc/services.d/*/finish
 
+# The web process runs under s6 in this image, so a crash leaves s6 (PID 1) alive
+# and the container keeps reporting Up with RestartCount=0. docker-proxy also
+# binds the published port whether or not anything listens behind it, so neither
+# container state nor a port check can see a dead web process (#806). Request a
+# real endpoint instead.
+#
+# start-period is generous because InfluxDB startup and database migrations run
+# before the web server binds; a legitimate first start must not be marked
+# unhealthy. 8080 is the in-container listen port and is independent of whatever
+# the host publishes.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=90s --retries=3 \
+    CMD curl -fsS http://127.0.0.1:8080/api/health || exit 1
+
 ENTRYPOINT ["/init"]

--- a/docker/Dockerfile.web
+++ b/docker/Dockerfile.web
@@ -41,4 +41,10 @@ RUN mkdir -p /opt/scrutiny/web && \
     mkdir -p /opt/scrutiny/config && \
     chmod -R a+rX /opt/scrutiny && \
     chmod -R a+w /opt/scrutiny/config
+# A dead web process must not present as a healthy container. Request a real
+# endpoint rather than relying on container state or an open port, which stays
+# bound by docker-proxy regardless (#806). 8080 is the in-container listen port.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+    CMD curl -fsS http://127.0.0.1:8080/api/health || exit 1
+
 CMD ["/opt/scrutiny/bin/scrutiny", "start"]


### PR DESCRIPTION
Fixes #810.

Neither image declared a `HEALTHCHECK`, so Docker could not tell a working instance from a dead one.

In the omnibus image s6 is PID 1. When the web process died, s6 restarted the supervised child and the container never exited:

```
STATUS: Up 5 hours     RestartCount: 0     State.Running: true
```

while nothing was served and the log accumulated 48059 panics. A port check would not have caught it either, because docker-proxy binds the published port whether or not anything listens behind it. Every container-level signal describes s6, not the app. That is how #806 ran unnoticed for about six hours on production.

## Change

`HEALTHCHECK` on `docker/Dockerfile` (omnibus) and `docker/Dockerfile.web`, requesting `/api/health`. That endpoint is served by the web process, so it disappears when the process dies. `curl` was already in both runtime stages, so no new dependency.

## Verified

Ran the exact probe command inside a live container:

| condition | exit |
| --- | --- |
| app listening | 0 |
| nothing on the port | 7 |

The Dockerfile syntax itself is validated by `docker-permissions.yaml`, which builds on any PR touching `docker/**`.

## Choices worth noting

- **`/api/health`, not `/api/summary`.** A healthcheck should report whether the service runs, not whether every query succeeds. `/api/summary` was returning 500 on a live instance for reasons unrelated to process liveness.
- **90s start period on omnibus.** InfluxDB startup and migrations run before the web server binds; a legitimate first start must not flap unhealthy. The web-only image binds sooner and uses 30s.
- **In the image, not a compose file.** Every deployment inherits it, including the Unraid templates and hand-written compose files this project does not control.
- **Port 8080** is the in-container listen port, independent of what the host publishes.

This closes the class rather than the instance: any failure that kills the supervised web process while leaving s6 alive presented identically before this.