### PR TITLE
fix(models): make a missing temperature distinguishable from 0C

### DIFF
--- a/webapp/backend/pkg/database/scrutiny_repository.go
+++ b/webapp/backend/pkg/database/scrutiny_repository.go
@@ -568,9 +568,11 @@ func (sr *scrutinyRepository) applySummaryRecord(summaries map[string]*models.De
 	}
 
 	smartSummary := &models.SmartSummary{
-		Temp:          temp,
 		PowerOnHours:  powerOnHours,
 		CollectorDate: collectorDate,
+	}
+	if hasTemp {
+		smartSummary.Temp = &temp
 	}
 	smartSummary.PercentageUsed = extractPercentageUsed(values)
 	smartSummary.WearoutValue = extractWearoutValue(values)

--- a/webapp/backend/pkg/database/scrutiny_repository_summary_page.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_summary_page.go
@@ -213,10 +213,10 @@ func summaryPowerOnHours(summary *models.DeviceSummary) int64 {
 }
 
 func summaryTemperature(summary *models.DeviceSummary) int64 {
-	if summary.SmartResults == nil {
+	if summary.SmartResults == nil || summary.SmartResults.Temp == nil {
 		return int64(^uint64(0) >> 1)
 	}
-	return summary.SmartResults.Temp
+	return *summary.SmartResults.Temp
 }
 
 func compareInt64(left, right int64) int {

--- a/webapp/backend/pkg/database/scrutiny_repository_summary_record_test.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_summary_record_test.go
@@ -11,6 +11,12 @@ import (
 
 // summaryRecordRepository builds the minimum repository needed to exercise
 // applySummaryRecord, which reads only the logger.
+// tempPtr returns a pointer to v. SmartSummary.Temp is a pointer so that an
+// absent reading and a genuine 0C are distinguishable.
+func tempPtr(v int64) *int64 {
+	return &v
+}
+
 func summaryRecordRepository() *scrutinyRepository {
 	logger := logrus.New()
 	logger.SetLevel(logrus.PanicLevel)
@@ -36,7 +42,7 @@ func TestApplySummaryRecordToleratesMissingFields(t *testing.T) {
 	cases := []struct {
 		name                 string
 		values               map[string]interface{}
-		expectedTemp         int64
+		expectedTemp         *int64
 		expectedPowerOnHours int64
 		expectedDate         time.Time
 	}{
@@ -48,7 +54,7 @@ func TestApplySummaryRecordToleratesMissingFields(t *testing.T) {
 				"power_on_hours": int64(1200),
 				"_time":          collected,
 			},
-			expectedTemp:         35,
+			expectedTemp:         tempPtr(35),
 			expectedPowerOnHours: 1200,
 			expectedDate:         collected,
 		},
@@ -80,7 +86,7 @@ func TestApplySummaryRecordToleratesMissingFields(t *testing.T) {
 				"temp":       int64(35),
 				"_time":      collected,
 			},
-			expectedTemp: 35,
+			expectedTemp: tempPtr(35),
 			expectedDate: collected,
 		},
 		{
@@ -90,7 +96,7 @@ func TestApplySummaryRecordToleratesMissingFields(t *testing.T) {
 				"temp":           int64(35),
 				"power_on_hours": int64(1200),
 			},
-			expectedTemp:         35,
+			expectedTemp:         tempPtr(35),
 			expectedPowerOnHours: 1200,
 		},
 		{
@@ -118,7 +124,12 @@ func TestApplySummaryRecordToleratesMissingFields(t *testing.T) {
 
 			results := summaries["dev-1"].SmartResults
 			require.NotNil(t, results, "a partial record must still produce a summary")
-			require.Equal(t, testCase.expectedTemp, results.Temp)
+			if testCase.expectedTemp == nil {
+				require.Nil(t, results.Temp, "an absent temperature must stay absent, not become 0")
+			} else {
+				require.NotNil(t, results.Temp)
+				require.Equal(t, *testCase.expectedTemp, *results.Temp)
+			}
 			require.Equal(t, testCase.expectedPowerOnHours, results.PowerOnHours)
 			require.Equal(t, testCase.expectedDate, results.CollectorDate)
 		})

--- a/webapp/backend/pkg/models/device_summary.go
+++ b/webapp/backend/pkg/models/device_summary.go
@@ -57,6 +57,10 @@ type SmartSummary struct {
 	WearoutValue   *int64    `json:"wearout_value,omitempty"`
 	RiskScore      *int      `json:"risk_score,omitempty"`
 	RiskCategory   string    `json:"risk_category,omitempty"`
-	Temp           int64     `json:"temp"`
-	PowerOnHours   int64     `json:"power_on_hours,omitempty"`
+	// Temp is a pointer because a device with no temperature reading and one
+	// reading 0C are different facts, same as PercentageUsed and WearoutValue
+	// above. omitempty on a pointer omits only nil, so a genuine 0 still
+	// serializes and the frontend renders it rather than "--".
+	Temp         *int64 `json:"temp,omitempty"`
+	PowerOnHours int64  `json:"power_on_hours,omitempty"`
 }

--- a/webapp/backend/pkg/models/device_summary_test.go
+++ b/webapp/backend/pkg/models/device_summary_test.go
@@ -7,9 +7,24 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func tempPtr(v int64) *int64 {
+	return &v
+}
+
+// A genuine 0C reading must still serialize. omitempty on a pointer omits only
+// nil, so this survives Temp becoming *int64.
 func TestSmartSummaryJSONIncludesZeroTemperature(t *testing.T) {
-	payload, err := json.Marshal(SmartSummary{Temp: 0})
+	payload, err := json.Marshal(SmartSummary{Temp: tempPtr(0)})
 
 	require.NoError(t, err)
 	require.Contains(t, string(payload), `"temp":0`)
+}
+
+// A device that reported no temperature must omit the field entirely, so the
+// frontend renders "--" rather than 0C.
+func TestSmartSummaryJSONOmitsAbsentTemperature(t *testing.T) {
+	payload, err := json.Marshal(SmartSummary{})
+
+	require.NoError(t, err)
+	require.NotContains(t, string(payload), `"temp"`)
 }

--- a/webapp/backend/pkg/reports/formatter_html.go
+++ b/webapp/backend/pkg/reports/formatter_html.go
@@ -151,10 +151,10 @@ func writeDeviceHTMLTable(b *strings.Builder, report *ReportData) {
 		fmt.Fprintf(b, `<tr>
 <td style="padding:5px 6px;border:1px solid #dee2e6;color:%s;">%s</td>
 <td align="center" style="padding:5px 6px;border:1px solid #dee2e6;color:%s;">%s</td>
-<td align="center" style="padding:5px 6px;border:1px solid #dee2e6;">%dC</td>
+<td align="center" style="padding:5px 6px;border:1px solid #dee2e6;">%sC</td>
 <td align="center" style="padding:5px 6px;border:1px solid #dee2e6;">%d</td>
 <td align="center" style="padding:5px 6px;border:1px solid #dee2e6;">%d</td>
-</tr>`, rowColor, escapeHTML(name), rowColor, d.StatusString(), d.TempCurrent, d.PowerOnHours, alertCount)
+</tr>`, rowColor, escapeHTML(name), rowColor, d.StatusString(), formatTemp(d.TempCurrent), d.PowerOnHours, alertCount)
 	}
 
 	b.WriteString(`</table></td></tr>`)
@@ -173,12 +173,12 @@ func writeTempHTMLSummary(b *strings.Builder, devices []DeviceReport) {
 <h3 style="margin:0 0 8px;color:#212529;font-size:14px;">Temperature Summary</h3>
 <table cellpadding="3" cellspacing="0" style="font-size:12px;">`)
 
-	fmt.Fprintf(b, `<tr><td style="color:#6c757d;">Highest:</td><td><strong>%s</strong> at %dC (avg %.0fC)</td></tr>`,
-		escapeHTML(hottest.DisplayName()), hottest.TempCurrent, hottest.TempAvg)
+	fmt.Fprintf(b, `<tr><td style="color:#6c757d;">Highest:</td><td><strong>%s</strong> at %sC (avg %.0fC)</td></tr>`,
+		escapeHTML(hottest.DisplayName()), formatTemp(hottest.TempCurrent), hottest.TempAvg)
 
-	if coldest != nil && coldest.TempCurrent != hottest.TempCurrent {
-		fmt.Fprintf(b, `<tr><td style="color:#6c757d;">Lowest:</td><td><strong>%s</strong> at %dC (avg %.0fC)</td></tr>`,
-			escapeHTML(coldest.DisplayName()), coldest.TempCurrent, coldest.TempAvg)
+	if coldest != nil && coldest != hottest {
+		fmt.Fprintf(b, `<tr><td style="color:#6c757d;">Lowest:</td><td><strong>%s</strong> at %sC (avg %.0fC)</td></tr>`,
+			escapeHTML(coldest.DisplayName()), formatTemp(coldest.TempCurrent), coldest.TempAvg)
 	}
 
 	b.WriteString(`</table></td></tr>`)

--- a/webapp/backend/pkg/reports/formatter_pdf.go
+++ b/webapp/backend/pkg/reports/formatter_pdf.go
@@ -150,7 +150,7 @@ func writeDeviceTable(pdf *fpdf.Fpdf, report *ReportData) {
 		pdf.CellFormat(colWidths[0], 6, name, "1", 0, "L", false, 0, "")
 		pdf.CellFormat(colWidths[1], 6, d.StatusString(), "1", 0, "C", false, 0, "")
 		pdf.SetTextColor(33, 37, 41)
-		pdf.CellFormat(colWidths[2], 6, fmt.Sprintf("%d", d.TempCurrent), "1", 0, "C", false, 0, "")
+		pdf.CellFormat(colWidths[2], 6, formatTemp(d.TempCurrent), "1", 0, "C", false, 0, "")
 		pdf.CellFormat(colWidths[3], 6, fmt.Sprintf("%d", d.TempMin), "1", 0, "C", false, 0, "")
 		pdf.CellFormat(colWidths[4], 6, fmt.Sprintf("%d", d.TempMax), "1", 0, "C", false, 0, "")
 		pdf.CellFormat(colWidths[5], 6, fmt.Sprintf("%d", d.PowerOnHours), "1", 0, "C", false, 0, "")
@@ -201,8 +201,8 @@ func writeDeviceDetail(pdf *fpdf.Fpdf, device *DeviceReport) {
 
 	pdf.SetFont("Helvetica", "", 9)
 	pdf.CellFormat(0, 5, fmt.Sprintf("Model: %s | Serial: %s | Protocol: %s", device.Model, device.Serial, device.Protocol), "", 1, "L", false, 0, "")
-	pdf.CellFormat(0, 5, fmt.Sprintf("Status: %s | Power-On Hours: %d | Temperature: %dC (min: %d, max: %d, avg: %.0f)",
-		device.StatusString(), device.PowerOnHours, device.TempCurrent, device.TempMin, device.TempMax, device.TempAvg), "", 1, "L", false, 0, "")
+	pdf.CellFormat(0, 5, fmt.Sprintf("Status: %s | Power-On Hours: %d | Temperature: %sC (min: %d, max: %d, avg: %.0f)",
+		device.StatusString(), device.PowerOnHours, formatTemp(device.TempCurrent), device.TempMin, device.TempMax, device.TempAvg), "", 1, "L", false, 0, "")
 
 	if device.HostID != "" {
 		pdf.CellFormat(0, 5, fmt.Sprintf("Host: %s", device.HostID), "", 1, "L", false, 0, "")

--- a/webapp/backend/pkg/reports/formatter_pdf_test.go
+++ b/webapp/backend/pkg/reports/formatter_pdf_test.go
@@ -23,16 +23,16 @@ func TestGeneratePDF_CreatesFile(t *testing.T) {
 			{
 				WWN: "0x5000cca264eb01d7", Name: "/dev/sda", Model: "WDC WD40EFRX",
 				Serial: "WD-12345", Protocol: "ATA", Status: 0,
-				TempCurrent: 35, TempMin: 30, TempMax: 40, TempAvg: 35.0,
+				TempCurrent: tempPtr(35), TempMin: 30, TempMax: 40, TempAvg: 35.0,
 				PowerOnHours: 25000, PowerCycleCount: 150,
 				NewAlerts: []AlertEntry{}, ActiveFailures: []AlertEntry{},
 			},
 			{
 				WWN: "0x5002538e40a22954", Name: "/dev/nvme0", Model: "Samsung 970 EVO",
 				Serial: "S4EWNF0M", Protocol: "NVMe", Status: 1,
-				TempCurrent: 45, TempMin: 40, TempMax: 50, TempAvg: 44.5,
+				TempCurrent: tempPtr(45), TempMin: 40, TempMax: 50, TempAvg: 44.5,
 				PowerOnHours: 8000,
-				NewAlerts: []AlertEntry{},
+				NewAlerts:    []AlertEntry{},
 				ActiveFailures: []AlertEntry{
 					{AttributeID: "media_errors", AttributeName: "Media Errors", Status: "failed", Value: 3},
 				},

--- a/webapp/backend/pkg/reports/formatter_temp_absent_test.go
+++ b/webapp/backend/pkg/reports/formatter_temp_absent_test.go
@@ -1,0 +1,89 @@
+package reports
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// A device that reported no temperature must never be rendered as 0C, and must
+// never be selected as the coldest device. Before TempCurrent became a pointer
+// the two cases were indistinguishable, and tempExtremes carried a
+// "TempCurrent == 0" workaround that made any device without a reading the
+// coldest one.
+func TestTempExtremesSkipsDevicesWithoutAReading(t *testing.T) {
+	devices := []DeviceReport{
+		{Name: "/dev/sda", TempCurrent: nil},
+		{Name: "/dev/sdb", TempCurrent: tempPtr(41)},
+		{Name: "/dev/sdc", TempCurrent: tempPtr(33)},
+	}
+
+	hottest, coldest := tempExtremes(devices)
+
+	require.NotNil(t, hottest)
+	require.NotNil(t, coldest)
+	require.Equal(t, "/dev/sdb", hottest.Name)
+	require.Equal(t, "/dev/sdc", coldest.Name, "a device with no reading must not be the coldest")
+}
+
+// A device genuinely reading 0C is a real measurement and must still win.
+func TestTempExtremesKeepsAGenuineZeroReading(t *testing.T) {
+	devices := []DeviceReport{
+		{Name: "/dev/sda", TempCurrent: tempPtr(20)},
+		{Name: "/dev/sdb", TempCurrent: tempPtr(0)},
+	}
+
+	hottest, coldest := tempExtremes(devices)
+
+	require.Equal(t, "/dev/sda", hottest.Name)
+	require.Equal(t, "/dev/sdb", coldest.Name)
+}
+
+func TestTempExtremesReturnsNilWhenNoDeviceReported(t *testing.T) {
+	hottest, coldest := tempExtremes([]DeviceReport{{Name: "/dev/sda"}, {Name: "/dev/sdb"}})
+
+	require.Nil(t, hottest)
+	require.Nil(t, coldest)
+}
+
+func TestFormatTempRendersPlaceholderOnlyForAbsent(t *testing.T) {
+	require.Equal(t, "--", formatTemp(nil))
+	require.Equal(t, "0", formatTemp(tempPtr(0)))
+	require.Equal(t, "37", formatTemp(tempPtr(37)))
+	require.Equal(t, "-5", formatTemp(tempPtr(-5)))
+}
+
+// The rendered output is what the operator actually reads, so assert on it
+// rather than only on the helper.
+func TestHTMLDeviceTableRendersPlaceholderForAbsentReading(t *testing.T) {
+	report := &ReportData{
+		Devices: []DeviceReport{
+			{Name: "/dev/sda", Model: "WDC WD40EFRX", TempCurrent: nil},
+			{Name: "/dev/sdb", Model: "Samsung 860", TempCurrent: tempPtr(31)},
+		},
+	}
+
+	var b strings.Builder
+	writeDeviceHTMLTable(&b, report)
+	html := b.String()
+
+	require.Contains(t, html, ">--C<", "a device with no reading must not render as a number")
+	require.Contains(t, html, ">31C<")
+	require.NotContains(t, html, ">0C<")
+}
+
+// The text summary must not name a device that never reported a temperature.
+func TestTextTempSummarySkipsDevicesWithoutAReading(t *testing.T) {
+	devices := []DeviceReport{
+		{Name: "/dev/sda", TempCurrent: nil},
+		{Name: "/dev/sdb", TempCurrent: tempPtr(41), TempAvg: 40},
+		{Name: "/dev/sdc", TempCurrent: tempPtr(33), TempAvg: 33},
+	}
+
+	text := strings.Join(appendTempSummary(nil, devices), "\n")
+
+	require.Contains(t, text, "/dev/sdb")
+	require.Contains(t, text, "/dev/sdc")
+	require.NotContains(t, text, "/dev/sda")
+}

--- a/webapp/backend/pkg/reports/formatter_text.go
+++ b/webapp/backend/pkg/reports/formatter_text.go
@@ -2,6 +2,7 @@ package reports
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -95,10 +96,10 @@ func appendTempSummary(parts []string, devices []DeviceReport) []string {
 	parts = append(parts,
 		"",
 		"Temperature Summary:",
-		fmt.Sprintf("  Highest: %s at %dC (avg %.0fC)", hottest.DisplayName(), hottest.TempCurrent, hottest.TempAvg),
+		fmt.Sprintf("  Highest: %s at %sC (avg %.0fC)", hottest.DisplayName(), formatTemp(hottest.TempCurrent), hottest.TempAvg),
 	)
-	if coldest != nil && coldest.TempCurrent != hottest.TempCurrent {
-		parts = append(parts, fmt.Sprintf("  Lowest: %s at %dC (avg %.0fC)", coldest.DisplayName(), coldest.TempCurrent, coldest.TempAvg))
+	if coldest != nil && coldest != hottest {
+		parts = append(parts, fmt.Sprintf("  Lowest: %s at %sC (avg %.0fC)", coldest.DisplayName(), formatTemp(coldest.TempCurrent), coldest.TempAvg))
 	}
 	return parts
 }
@@ -149,17 +150,30 @@ func collectAlerts(report *ReportData, status string) []alertLine {
 	return results
 }
 
-func tempExtremes(devices []DeviceReport) (*DeviceReport, *DeviceReport) {
-	if len(devices) == 0 {
-		return nil, nil
+// formatTemp renders a temperature, or a placeholder when the device reported
+// none. A device with no reading must not print as 0C.
+const tempPlaceholder = "--"
+
+func formatTemp(temp *int64) string {
+	if temp == nil {
+		return tempPlaceholder
 	}
-	hottest := &devices[0]
-	coldest := &devices[0]
+	return strconv.FormatInt(*temp, 10)
+}
+
+// tempExtremes returns the hottest and coldest device that actually reported a
+// temperature. Devices without a reading are skipped rather than counted as 0C,
+// which previously made any of them the coldest device.
+func tempExtremes(devices []DeviceReport) (*DeviceReport, *DeviceReport) {
+	var hottest, coldest *DeviceReport
 	for i := range devices {
-		if devices[i].TempCurrent > hottest.TempCurrent {
+		if devices[i].TempCurrent == nil {
+			continue
+		}
+		if hottest == nil || *devices[i].TempCurrent > *hottest.TempCurrent {
 			hottest = &devices[i]
 		}
-		if devices[i].TempCurrent < coldest.TempCurrent || coldest.TempCurrent == 0 {
+		if coldest == nil || *devices[i].TempCurrent < *coldest.TempCurrent {
 			coldest = &devices[i]
 		}
 	}

--- a/webapp/backend/pkg/reports/formatter_text_test.go
+++ b/webapp/backend/pkg/reports/formatter_text_test.go
@@ -9,6 +9,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// tempPtr returns a pointer to v, for the pointer-valued temperature fields.
+func tempPtr(v int64) *int64 {
+	return &v
+}
+
 func TestFormatTextReport_HealthyDevices(t *testing.T) {
 	report := &ReportData{
 		GeneratedAt:   time.Date(2026, 2, 17, 8, 0, 0, 0, time.UTC),
@@ -16,9 +21,9 @@ func TestFormatTextReport_HealthyDevices(t *testing.T) {
 		TotalDevices:  3,
 		PassedDevices: 3,
 		Devices: []DeviceReport{
-			{Name: "/dev/sda", Model: "WDC WD40EFRX", Status: 0, TempCurrent: 35, TempMin: 30, TempMax: 40, TempAvg: 35.0},
-			{Name: "/dev/sdb", Model: "Samsung 860", Status: 0, TempCurrent: 32, TempMin: 28, TempMax: 36, TempAvg: 32.0},
-			{Name: "/dev/nvme0", Model: "Samsung 970", Status: 0, TempCurrent: 45, TempMin: 40, TempMax: 50, TempAvg: 45.0},
+			{Name: "/dev/sda", Model: "WDC WD40EFRX", Status: 0, TempCurrent: tempPtr(35), TempMin: 30, TempMax: 40, TempAvg: 35.0},
+			{Name: "/dev/sdb", Model: "Samsung 860", Status: 0, TempCurrent: tempPtr(32), TempMin: 28, TempMax: 36, TempAvg: 32.0},
+			{Name: "/dev/nvme0", Model: "Samsung 970", Status: 0, TempCurrent: tempPtr(45), TempMin: 40, TempMax: 50, TempAvg: 45.0},
 		},
 	}
 
@@ -41,15 +46,15 @@ func TestFormatTextReport_WithFailures(t *testing.T) {
 		WarningDevices: 1,
 		FailedDevices:  1,
 		Devices: []DeviceReport{
-			{Name: "/dev/sda", Model: "WDC WD40EFRX", Status: 0, TempCurrent: 35},
+			{Name: "/dev/sda", Model: "WDC WD40EFRX", Status: 0, TempCurrent: tempPtr(35)},
 			{
-				Name: "/dev/sdb", Model: "Samsung 860", Status: 2, TempCurrent: 32,
+				Name: "/dev/sdb", Model: "Samsung 860", Status: 2, TempCurrent: tempPtr(32),
 				ActiveFailures: []AlertEntry{
 					{AttributeID: "5", AttributeName: "Reallocated Sectors", Status: "failed", Value: 10, Threshold: 5, StatusReason: "scrutiny"},
 				},
 			},
 			{
-				Name: "/dev/nvme0", Model: "Samsung 970", Status: 1, TempCurrent: 45,
+				Name: "/dev/nvme0", Model: "Samsung 970", Status: 1, TempCurrent: tempPtr(45),
 				ActiveFailures: []AlertEntry{
 					{AttributeID: "percentage_used", AttributeName: "Percentage Used", Status: "warning", Value: 95, StatusReason: "smart"},
 				},
@@ -117,8 +122,8 @@ func TestFormatTextReport_TemperatureSummary(t *testing.T) {
 		TotalDevices:  2,
 		PassedDevices: 2,
 		Devices: []DeviceReport{
-			{Name: "/dev/sda", TempCurrent: 52, TempAvg: 45.0, Status: 0},
-			{Name: "/dev/nvme0", TempCurrent: 28, TempAvg: 31.0, Status: 0},
+			{Name: "/dev/sda", TempCurrent: tempPtr(52), TempAvg: 45.0, Status: 0},
+			{Name: "/dev/nvme0", TempCurrent: tempPtr(28), TempAvg: 31.0, Status: 0},
 		},
 	}
 

--- a/webapp/backend/pkg/reports/generator.go
+++ b/webapp/backend/pkg/reports/generator.go
@@ -160,7 +160,10 @@ func buildDeviceReport(summary *models.DeviceSummary, temps []measurements.Smart
 	}
 
 	if summary.SmartResults != nil {
-		dr.TempCurrent = summary.SmartResults.Temp
+		if summary.SmartResults.Temp != nil {
+			val := *summary.SmartResults.Temp
+			dr.TempCurrent = &val
+		}
 		dr.PowerOnHours = summary.SmartResults.PowerOnHours
 
 		if summary.SmartResults.PercentageUsed != nil {
@@ -175,10 +178,10 @@ func buildDeviceReport(summary *models.DeviceSummary, temps []measurements.Smart
 
 	if len(temps) > 0 {
 		dr.TempMin, dr.TempMax, dr.TempAvg = aggregateTemps(temps)
-	} else {
-		dr.TempMin = dr.TempCurrent
-		dr.TempMax = dr.TempCurrent
-		dr.TempAvg = float64(dr.TempCurrent)
+	} else if dr.TempCurrent != nil {
+		dr.TempMin = *dr.TempCurrent
+		dr.TempMax = *dr.TempCurrent
+		dr.TempAvg = float64(*dr.TempCurrent)
 	}
 
 	return dr

--- a/webapp/backend/pkg/reports/generator_test.go
+++ b/webapp/backend/pkg/reports/generator_test.go
@@ -59,7 +59,7 @@ func TestGenerateReport_BasicSummary(t *testing.T) {
 					DeviceStatus:   pkg.DeviceStatusPassed,
 				},
 				SmartResults: &models.SmartSummary{
-					Temp:         35,
+					Temp:         tempPtr(35),
 					PowerOnHours: 25000,
 				},
 			},
@@ -74,7 +74,7 @@ func TestGenerateReport_BasicSummary(t *testing.T) {
 					DeviceStatus:   pkg.DeviceStatusFailedSmart,
 				},
 				SmartResults: &models.SmartSummary{
-					Temp:         45,
+					Temp:         tempPtr(45),
 					PowerOnHours: 8000,
 				},
 			},
@@ -114,7 +114,7 @@ func TestGenerateReport_TempAggregation(t *testing.T) {
 					DeviceName:   "/dev/sda",
 					DeviceStatus: pkg.DeviceStatusPassed,
 				},
-				SmartResults: &models.SmartSummary{Temp: 35, PowerOnHours: 100},
+				SmartResults: &models.SmartSummary{Temp: tempPtr(35), PowerOnHours: 100},
 			},
 		},
 		tempHistory: map[string][]measurements.SmartTemperature{
@@ -146,14 +146,14 @@ func TestGenerateReport_ArchivedDevicesExcluded(t *testing.T) {
 					DeviceID: "devid-active", WWN: "wwn1", DeviceName: "/dev/sda", Archived: false,
 					DeviceStatus: pkg.DeviceStatusPassed,
 				},
-				SmartResults: &models.SmartSummary{Temp: 35},
+				SmartResults: &models.SmartSummary{Temp: tempPtr(35)},
 			},
 			"devid-archived": {
 				Device: models.Device{
 					DeviceID: "devid-archived", WWN: "wwn2", DeviceName: "/dev/sdb", Archived: true,
 					DeviceStatus: pkg.DeviceStatusPassed,
 				},
-				SmartResults: &models.SmartSummary{Temp: 30},
+				SmartResults: &models.SmartSummary{Temp: tempPtr(30)},
 			},
 		},
 		tempHistory: map[string][]measurements.SmartTemperature{},

--- a/webapp/backend/pkg/reports/models.go
+++ b/webapp/backend/pkg/reports/models.go
@@ -69,7 +69,7 @@ type DeviceReport struct {
 	ActiveFailures []AlertEntry `json:"active_failures"`
 
 	TempAvg         float64 `json:"temp_avg"`
-	TempCurrent     int64   `json:"temp_current"`
+	TempCurrent     *int64  `json:"temp_current,omitempty"`
 	TempMin         int64   `json:"temp_min"`
 	TempMax         int64   `json:"temp_max"`
 	PowerOnHours    int64   `json:"power_on_hours"`

--- a/webapp/backend/pkg/reports/scheduler.go
+++ b/webapp/backend/pkg/reports/scheduler.go
@@ -27,12 +27,12 @@ const (
 
 // Scheduler runs report generation on configured schedules
 type Scheduler struct {
-	appConfig  config.Interface
-	logger     logrus.FieldLogger
-	deviceRepo database.DeviceRepo
-	ctx        context.Context
-	cancel     context.CancelFunc
-	stopCh     chan struct{}
+	appConfig   config.Interface
+	logger      logrus.FieldLogger
+	deviceRepo  database.DeviceRepo
+	ctx         context.Context
+	cancel      context.CancelFunc
+	stopCh      chan struct{}
 	repoFactory func() (database.DeviceRepo, error)
 
 	lastDailyRun   time.Time


### PR DESCRIPTION
Fixes #809. Follow-up to #807.

## The bug

`models.SmartSummary.Temp` was a plain `int64`, so a device that reported no
temperature was indistinguishable from one reading 0C. The dashboard rendered it
as `0°C`.

It surfaced after #807, which stopped `applySummaryRecord` panicking on a record
missing `temp` or `power_on_hours` and let absent fields fall back to their zero
value. Measured against a live fleet: of 48 devices, 17 had a summary and 1 of
those had no temperature, so it displayed 0C.

## The same ambiguity had already reached the reports

`DeviceReport.TempCurrent` was also `int64`, and `tempExtremes` carried a
workaround for it:

```go
if devices[i].TempCurrent < coldest.TempCurrent || coldest.TempCurrent == 0 {
```

That `== 0` test existed because a device with no reading sorted as the coldest
one. It caught genuine 0C readings with it, and the HTML and PDF formatters
printed `0C` for a device that never reported.

## Change

- `SmartSummary.Temp` becomes `*int64` with `omitempty`, matching
  `PercentageUsed` and `WearoutValue` on the same struct, which are already
  pointers for exactly this reason. `omitempty` on a pointer omits only nil, so a
  genuine 0 still serializes.
- `DeviceReport.TempCurrent` becomes `*int64`.
- `tempExtremes` skips devices with no reading; the `== 0` workaround is gone.
- Text, HTML and PDF render a placeholder through a shared `formatTemp` helper.
- `summaryTemperature` returns the existing max-int sentinel for a nil
  temperature, so devices without a reading keep sorting last exactly as a device
  with no summary already did.

## The frontend needed no changes

It was already written for a nullable temperature, which is what made this worth
doing rather than papering over:

| site | already handles absent |
| --- | --- |
| `TemperaturePipe.formatTemperature` | returns `--` for `temp == null` |
| `DeviceSummaryModel.temp` | declared `temp?: number` |
| `device-sort.pipe.ts` | `a.smart?.temp ?? Number.MAX_SAFE_INTEGER` |
| `mobile-home.component.html` | `@if (item.temperature !== null && item.temperature !== undefined)` |

Only the backend type was holding it back.

## Tests

`formatter_temp_absent_test.go` covers `tempExtremes` skipping devices with no
reading, keeping a genuine 0C, returning nil when nothing reported, `formatTemp`
across nil/0/positive/negative, and the rendered HTML table and text summary.
`device_summary_test.go` keeps the existing guarantee that a real 0 serializes
and adds that nil is omitted. The #807 test was updated for the pointer.

Verified the new tests fail against the old behaviour: making `formatTemp`
return `"0"` for nil turns them red, with the HTML assertion showing the exact
`>0C<` cell this fixes.

- `go build ./webapp/backend/...` passes
- `go vet ./webapp/backend/...` passes
- `go test ./webapp/backend/...` passes

## Note on the diff

`reports/scheduler.go` carries a 6-line whitespace realignment. That file was
already unformatted on `develop`; the repo's own `.githooks/pre-commit` runs
`gofmt -w` on staged files, so it is reformatted automatically. No behaviour
change.
