### PR TITLE
fix(ci): publish bare version tags and stop latest racing the release

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -2,8 +2,11 @@ name: Docker
 
 on:
   push:
+    # master is deliberately absent. Every tag this workflow publishes for a
+    # release is now enabled on the tag ref alone, so a master push would build
+    # and then push an empty tag list. Releases arrive here through the v*.*.*
+    # tag that semantic-release creates.
     branches:
-      - master
       - beta
       - develop
     paths:
@@ -72,7 +75,7 @@ jobs:
             # Manual trigger
             type=raw,value=${{ inputs.tag_suffix }}-collector,enable=${{ github.event_name == 'workflow_dispatch' }}
             # Branch builds
-            type=raw,value=latest-collector,enable=${{ (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')) && github.event_name != 'workflow_dispatch' }}
+            type=raw,value=latest-collector,enable=${{ startsWith(github.ref, 'refs/tags/v') && github.event_name != 'workflow_dispatch' }}
             type=raw,value=beta-collector,enable=${{ github.ref == 'refs/heads/beta' && github.event_name != 'workflow_dispatch' }}
             type=raw,value=develop-collector,enable=${{ github.ref == 'refs/heads/develop' && github.event_name != 'workflow_dispatch' }}
             # Version tags
@@ -132,7 +135,7 @@ jobs:
             # Manual trigger
             type=raw,value=${{ inputs.tag_suffix }}-collector-omnibus,enable=${{ github.event_name == 'workflow_dispatch' }}
             # Branch builds
-            type=raw,value=latest-collector-omnibus,enable=${{ (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')) && github.event_name != 'workflow_dispatch' }}
+            type=raw,value=latest-collector-omnibus,enable=${{ startsWith(github.ref, 'refs/tags/v') && github.event_name != 'workflow_dispatch' }}
             type=raw,value=beta-collector-omnibus,enable=${{ github.ref == 'refs/heads/beta' && github.event_name != 'workflow_dispatch' }}
             type=raw,value=develop-collector-omnibus,enable=${{ github.ref == 'refs/heads/develop' && github.event_name != 'workflow_dispatch' }}
             # Version tags
@@ -192,7 +195,7 @@ jobs:
             # Manual trigger
             type=raw,value=${{ inputs.tag_suffix }}-collector-zfs,enable=${{ github.event_name == 'workflow_dispatch' }}
             # Branch builds
-            type=raw,value=latest-collector-zfs,enable=${{ (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')) && github.event_name != 'workflow_dispatch' }}
+            type=raw,value=latest-collector-zfs,enable=${{ startsWith(github.ref, 'refs/tags/v') && github.event_name != 'workflow_dispatch' }}
             type=raw,value=beta-collector-zfs,enable=${{ github.ref == 'refs/heads/beta' && github.event_name != 'workflow_dispatch' }}
             type=raw,value=develop-collector-zfs,enable=${{ github.ref == 'refs/heads/develop' && github.event_name != 'workflow_dispatch' }}
             # Version tags
@@ -252,7 +255,7 @@ jobs:
             # Manual trigger
             type=raw,value=${{ inputs.tag_suffix }}-collector-mdadm,enable=${{ github.event_name == 'workflow_dispatch' }}
             # Branch builds
-            type=raw,value=latest-collector-mdadm,enable=${{ (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')) && github.event_name != 'workflow_dispatch' }}
+            type=raw,value=latest-collector-mdadm,enable=${{ startsWith(github.ref, 'refs/tags/v') && github.event_name != 'workflow_dispatch' }}
             type=raw,value=beta-collector-mdadm,enable=${{ github.ref == 'refs/heads/beta' && github.event_name != 'workflow_dispatch' }}
             type=raw,value=develop-collector-mdadm,enable=${{ github.ref == 'refs/heads/develop' && github.event_name != 'workflow_dispatch' }}
             # Version tags
@@ -312,7 +315,7 @@ jobs:
             # Manual trigger
             type=raw,value=${{ inputs.tag_suffix }}-collector-btrfs,enable=${{ github.event_name == 'workflow_dispatch' }}
             # Branch builds
-            type=raw,value=latest-collector-btrfs,enable=${{ (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')) && github.event_name != 'workflow_dispatch' }}
+            type=raw,value=latest-collector-btrfs,enable=${{ startsWith(github.ref, 'refs/tags/v') && github.event_name != 'workflow_dispatch' }}
             type=raw,value=beta-collector-btrfs,enable=${{ github.ref == 'refs/heads/beta' && github.event_name != 'workflow_dispatch' }}
             type=raw,value=develop-collector-btrfs,enable=${{ github.ref == 'refs/heads/develop' && github.event_name != 'workflow_dispatch' }}
             # Version tags
@@ -372,7 +375,7 @@ jobs:
             # Manual trigger
             type=raw,value=${{ inputs.tag_suffix }}-collector-performance,enable=${{ github.event_name == 'workflow_dispatch' }}
             # Branch builds
-            type=raw,value=latest-collector-performance,enable=${{ (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')) && github.event_name != 'workflow_dispatch' }}
+            type=raw,value=latest-collector-performance,enable=${{ startsWith(github.ref, 'refs/tags/v') && github.event_name != 'workflow_dispatch' }}
             type=raw,value=beta-collector-performance,enable=${{ github.ref == 'refs/heads/beta' && github.event_name != 'workflow_dispatch' }}
             type=raw,value=develop-collector-performance,enable=${{ github.ref == 'refs/heads/develop' && github.event_name != 'workflow_dispatch' }}
             # Version tags
@@ -433,7 +436,7 @@ jobs:
             # Manual trigger
             type=raw,value=${{ inputs.tag_suffix }}-web,enable=${{ github.event_name == 'workflow_dispatch' }}
             # Branch builds
-            type=raw,value=latest-web,enable=${{ (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')) && github.event_name != 'workflow_dispatch' }}
+            type=raw,value=latest-web,enable=${{ startsWith(github.ref, 'refs/tags/v') && github.event_name != 'workflow_dispatch' }}
             type=raw,value=beta-web,enable=${{ github.ref == 'refs/heads/beta' && github.event_name != 'workflow_dispatch' }}
             type=raw,value=develop-web,enable=${{ github.ref == 'refs/heads/develop' && github.event_name != 'workflow_dispatch' }}
             # Version tags
@@ -495,7 +498,7 @@ jobs:
             type=raw,value=${{ inputs.tag_suffix }}-omnibus,enable=${{ github.event_name == 'workflow_dispatch' }}
             type=raw,value=${{ inputs.tag_suffix }},enable=${{ github.event_name == 'workflow_dispatch' && inputs.tag_suffix == 'latest' }}
             # Branch builds
-            type=raw,value=latest-omnibus,enable=${{ (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')) && github.event_name != 'workflow_dispatch' }}
+            type=raw,value=latest-omnibus,enable=${{ startsWith(github.ref, 'refs/tags/v') && github.event_name != 'workflow_dispatch' }}
             type=raw,value=beta-omnibus,enable=${{ github.ref == 'refs/heads/beta' && github.event_name != 'workflow_dispatch' }}
             type=raw,value=beta,enable=${{ github.ref == 'refs/heads/beta' && github.event_name != 'workflow_dispatch' }}
             type=raw,value=develop-omnibus,enable=${{ github.ref == 'refs/heads/develop' && github.event_name != 'workflow_dispatch' }}
@@ -504,8 +507,18 @@ jobs:
             type=semver,pattern={{version}}-omnibus
             type=semver,pattern={{major}}.{{minor}}-omnibus
             type=semver,pattern={{major}}-omnibus,enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
-            # Default latest tag (omnibus is the default)
-            type=raw,value=latest,enable=${{ (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')) && github.event_name != 'workflow_dispatch' }}
+            # Bare version tags. Omnibus is the default image, so it owns the
+            # unsuffixed names. Without these the default image can only be
+            # tracked as a moving latest and cannot be pinned to a release.
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
+            # Default latest tag (omnibus is the default). Tag refs only: a
+            # release pushes chore(release) to master and creates the tag, and
+            # those runs are in different concurrency groups, so enabling both
+            # let whichever finished last win latest. For v1.72.0 the master
+            # build won and latest did not point at the released image.
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && github.event_name != 'workflow_dispatch' }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v7


### PR DESCRIPTION
Fixes #818. Both defects found while deploying v1.72.0.

## A. The default image had no bare version tag

Every job publishes `latest-<variant>` alongside `{{version}}-<variant>`. The `omnibus` job is the exception: it also publishes the bare `latest` every deployment uses, but all its semver patterns carried the `-omnibus` suffix.

Against the registry after v1.72.0:

| tag | resolved |
| --- | --- |
| `latest`, `1.72.0-omnibus`, `1.72-omnibus`, `1-omnibus` | yes |
| `1.72.0`, `1.72`, `1` | **no** |

So the default image could only be tracked as a moving tag, never pinned to a release. The bare `latest` line exists precisely because omnibus is the default image; the bare version tags are its missing counterpart.

## B. `latest` was a race, and the release lost it

`latest` was enabled for both a master push and a tag ref. A release produces both: semantic-release pushes `chore(release): X.Y.Z` to master and creates the tag. `concurrency.group` keys on `github.ref`, so the two runs are in different groups and run concurrently. Last omnibus job to finish wins.

For v1.72.0 the master build won:

| tag | image created | source revision |
| --- | --- | --- |
| `1.72.0-omnibus` | 03:47:11Z | `c2e2df83` (`chore(release): 1.72.0`) |
| `latest` | 03:59:54Z | merge commit, no revision label |

`latest` did not point at the released image.

## Change

- Bare `{{version}}`, `{{major}}.{{minor}}` and `{{major}}` added to the `omnibus` job.
- **All nine** `latest*` tags restricted to tag refs, not just the two observed. The same race applied to every one, and fixing only the observed pair would leave seven behind with no way to tell which build answered.
- `master` removed from the push trigger, because no tag is enabled on it any more and the job would build then push an empty tag list. Releases arrive via the `v*.*.*` tag, so nothing is lost and a redundant full matrix per release is no longer built.

## Verified

- `actionlint` clean, YAML parses.
- Every one of the 8 jobs still publishes on both a develop and a beta push; omnibus additionally carries the bare pair.

## Worth a second opinion

Dropping master from `latest` is a behaviour change, not a pure bug fix: a direct push to master no longer republishes `latest`. That looks right, since master is reached only through a promotion that a release follows, but it is the part to disagree with if you see a case I have not.