### PR TITLE
fix(release): join wrapped prose in release note summaries

### DIFF
--- a/.github/scripts/generate-release-notes.sh
+++ b/.github/scripts/generate-release-notes.sh
@@ -89,12 +89,28 @@ extract_summary_items() {
     [ -z "$summary_block" ] && return
 
     local prose_lines bullet_lines
+    # Join wrapped prose into one item per paragraph. A summary written as
+    # hard-wrapped paragraphs used to emit one bullet per physical line, which
+    # split sentences mid-way in the published notes. Blank lines separate
+    # paragraphs; bullets are collected separately below and are unaffected.
     prose_lines=$(
         echo "$summary_block" \
-            | grep -v '^[[:space:]]*$' \
             | grep -v '^[[:space:]]*[-*] ' \
             | grep -v '^#' \
             | grep -vE '^(Closes|Fixes|Resolves) #[0-9]+$' \
+            | awk '
+                /^[[:space:]]*$/ {
+                    if (para != "") { print para; para = "" }
+                    next
+                }
+                {
+                    line = $0
+                    gsub(/^[[:space:]]+|[[:space:]]+$/, "", line)
+                    if (line == "") next
+                    para = (para == "") ? line : para " " line
+                }
+                END { if (para != "") print para }
+            ' \
             | clean_text || true
     )
     bullet_lines=$(

--- a/scripts/tests/generate-release-notes_test.sh
+++ b/scripts/tests/generate-release-notes_test.sh
@@ -18,6 +18,8 @@ case "$1" in
         ;;
     rev-list)
         echo "released-commit"
+        echo "wrapped-commit"
+        echo "wrapped-merge"
         echo "released-merge"
         echo "stale-commit"
         echo "operational-commit"
@@ -30,6 +32,11 @@ EOF
 cat > "$MOCK_BIN/gh" <<'EOF'
 #!/bin/bash
 case "${!#}" in
+    */wrapped-commit/pulls)
+        cat <<'JSON'
+[{"number":45,"title":"fix: wrapped prose summary","merged_at":"2026-09-05T00:00:00Z","merge_commit_sha":"wrapped-merge","body":"## Product changes\n\n## Summary\n\nTen commits: two features, one documentation change and six\nfixes. Two of them are the reason to promote now.\n\nA second paragraph that also\nwraps across lines.\n\n- A real bullet\n\n## Test plan\n\n- test","base":{"ref":"master"},"head":{"ref":"develop"}}]
+JSON
+        ;;
     */released-commit/pulls)
         cat <<'JSON'
 [{"number":42,"title":"feat: release change","merged_at":"2026-09-05T00:00:00Z","merge_commit_sha":"released-merge","body":"## Product changes\n\n## Summary\n\n- Visible change\n\nCloses #41\n\n## Test plan\n\n- test","base":{"ref":"master"},"head":{"ref":"develop"}}]
@@ -64,3 +71,12 @@ grep -Fq "Visible change" <<< "$NOTES"
 ! grep -Fq "#44" <<< "$NOTES"
 ! grep -Fq "#99" <<< "$NOTES"
 ! grep -Fq "Stale change" <<< "$NOTES"
+
+# Wrapped prose must join into one item per paragraph. Emitting one bullet per
+# physical line split sentences mid-way in the published v1.72.0 notes.
+grep -Fq "Ten commits: two features, one documentation change and six fixes. Two of them are the reason to promote now." <<< "$NOTES"
+grep -Fq "A second paragraph that also wraps across lines." <<< "$NOTES"
+# the fragment must not survive as its own item
+! grep -qE '^[[:space:]]*-[[:space:]]+fixes\. Two of them' <<< "$NOTES"
+# bullets alongside prose are still collected
+grep -Fq "A real bullet" <<< "$NOTES"


### PR DESCRIPTION
Fixes #819.

## The bug

`extract_summary_items` collected every non-blank, non-bullet line from a PR's `## Summary` block and the caller emitted each as its own bullet. A summary written as bullets rendered fine; one written as hard-wrapped paragraphs rendered as a bullet per physical line.

The v1.72.0 notes shipped like this:

```
  - Ten commits: two features, one documentation change, one dependency bump and six
  - fixes. Two of the fixes are the reason to promote now.
```

## Change

Consecutive non-blank prose lines join into a single item, with blank lines separating paragraphs. Bullets are still collected separately and are unaffected, as is `MAX_SUMMARY_BULLETS`.

Both authoring styles are reasonable and nothing in the PR template signals which the generator expects, so this makes the generator accept either rather than asking authors to avoid one.

## Tests

The case mixes two wrapped paragraphs with a bullet and asserts the joined sentences appear, the fragment does not survive as its own item, and the bullet is still collected.

Verified it distinguishes the two implementations: old generator exits 1, new exits 0.

Note the mock requires a PR's `merge_commit_sha` to appear in the `rev-list` output as well as its commit, or completeness validation silently drops the PR. Cost me a confusing pass where the new case simply was not in the output.

## Related, not fixed here

Two authoring traps the same release exposed, better addressed in the PR template than in code:

- `Closes #1, #2, #3` links only the first. `extract_closes` requires a keyword per issue, matching GitHub's own behaviour.
- Content under `## Product changes` is discarded; that heading is only an opt-in marker and `## Summary` is what reaches the notes. The script header says so, but the section name reads like it holds the user-facing content.