### PR TITLE
fix(ci): let a release commit match the docker build path filter

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -3,9 +3,10 @@ name: Docker
 on:
   push:
     # master is deliberately absent. Every tag this workflow publishes for a
-    # release is now enabled on the tag ref alone, so a master push would build
-    # and then push an empty tag list. Releases arrive here through the v*.*.*
-    # tag that semantic-release creates.
+    # release is enabled on the tag ref alone, so a master push resolves to zero
+    # tags and buildx fails outright with "tag is needed when pushing to
+    # registry". Releases arrive here through the v*.*.* tag that
+    # semantic-release creates.
     branches:
       - beta
       - develop
@@ -17,6 +18,15 @@ on:
       - 'Makefile'
       - 'go.mod'
       - 'go.sum'
+      # CHANGELOG.md is here so a release commit matches this filter on its own
+      # terms. semantic-release tags a chore(release) commit touching only
+      # CHANGELOG.md and version.go, and version.go is excluded above, so
+      # otherwise a release commit matches nothing and the tag build runs only
+      # because path filters have not gated tag pushes in practice. The tag build
+      # is the sole publisher of release images, and a silent miss would leave a
+      # published GitHub release with no image, so the filter should not be the
+      # thing standing between a tag and its images.
+      - 'CHANGELOG.md'
     tags:
       - 'v*.*.*'
   workflow_dispatch:


### PR DESCRIPTION
Fixes #822. Hardening, not a repair.

## What rests on what

Since the tag build became the only publisher of release images, that path has depended on `paths` filters not gating tag pushes. semantic-release tags a `chore(release)` commit touching exactly two files:

| file | in `paths`? |
| --- | --- |
| `CHANGELOG.md` | no |
| `webapp/backend/pkg/version/version.go` | **explicitly excluded** |

So under the filter alone a release commit matched nothing.

## It has never actually failed

| tag | release commit touches | tag build |
| --- | --- | --- |
| v1.72.0 | CHANGELOG.md, version.go | success |
| v1.71.0 | same | success |
| v1.70.0 | same | success |
| v1.69.2 | same | success |
| v1.69.1 | same | success |

Five for five. This removes a dependency on undeclared behaviour rather than fixing a break.

## Change

`CHANGELOG.md` added to `paths`, so a release commit matches on its own terms. Cost is that a CHANGELOG-only push to develop or beta now builds images — rare, and cheap against a release that publishes nothing. `release.yaml` builds binaries only, so a silent miss leaves a git tag and a GitHub release with no image behind them.

Also corrects the trigger comment I wrote in #820, which claimed a master push "would build and then push an empty tag list". It fails outright:

```
ERROR: failed to build: tag is needed when pushing to registry
```

Verified directly against buildx.

## Rejected

A second `on.push` entry carrying `tags` without `paths`, which is the option the issue listed first. YAML has no duplicate keys, so the second `push:` silently replaces the first — `branches` and `paths` vanish and tag builds become the only trigger. I wrote it, parsed the result, and found develop and beta builds gone. Worth recording so nobody reaches for it again.