### PR TITLE
ci: build every published image on pull requests

### DIFF
--- a/.github/workflows/docker-permissions.yaml
+++ b/.github/workflows/docker-permissions.yaml
@@ -22,6 +22,52 @@ jobs:
       - name: Test Docker frontend permissions
         run: bash docker/tests/frontend-permissions_test.sh
 
+  # Every Dockerfile this repository publishes is built here, so a broken image
+  # is caught on the pull request rather than by the tag build. That matters
+  # because release.yaml publishes the GitHub release before docker-build.yaml
+  # runs on the resulting tag: a failure there leaves a published release with
+  # no image behind it.
+  #
+  # The AppArmor matrix below is not the right place for this. It carries a
+  # "kind" that selects an AppArmor test, and half these images have nothing
+  # meaningful to assert under it.
+  #
+  # amd64 only, deliberately. The publish path builds linux/amd64 and
+  # linux/arm64 through QEMU, so an arm64-only failure still reaches the tag
+  # build first. Emulated arm64 builds of eight images on every pull request is
+  # a large standing cost for a narrower class of failure; see #824 for that
+  # half.
+  build-images:
+    name: Build (${{ matrix.image }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: web
+            dockerfile: docker/Dockerfile.web
+          - image: collector-zfs
+            dockerfile: docker/Dockerfile.collector-zfs
+          - image: collector-mdadm
+            dockerfile: docker/Dockerfile.collector-mdadm
+          - image: collector-btrfs
+            dockerfile: docker/Dockerfile.collector-btrfs
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7.0.1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+      - name: Build image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64
+          push: false
+          cache-from: type=gha,scope=prbuild-${{ matrix.image }}
+          cache-to: type=gha,mode=max,scope=prbuild-${{ matrix.image }}
+
   apparmor:
     name: AppArmor (${{ matrix.image }})
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Refs #824. Closes the coverage half; the architecture half stays open deliberately.

## Gap

Four of eight published Dockerfiles were never built before a release:

| Dockerfile | was built pre-release |
| --- | --- |
| `Dockerfile` (omnibus), `Dockerfile.collector`, `Dockerfile.collector-omnibus`, `Dockerfile.collector-performance` | yes |
| `Dockerfile.web`, `Dockerfile.collector-zfs`, `Dockerfile.collector-mdadm`, `Dockerfile.collector-btrfs` | **no** |

The covered four are the ones the AppArmor matrix happens to need, so coverage was a side effect of a different test rather than a choice.

## Why the timing matters

`release.yaml` publishes the GitHub release, *then* `docker-build.yaml` runs on the resulting tag. A failure in an uncovered image was first visible after the tag and release already existed — a published release with nothing to pull.

## Change

A separate `build-images` job covering the missing four. Deliberately **not** an extension of the AppArmor matrix: that matrix carries a `kind` selecting an AppArmor test, and these images have nothing meaningful to assert under it.

Verified all 8 Dockerfiles are now reachable pre-release by cross-checking both matrices against `docker/Dockerfile*`:

```
total Dockerfiles: 8
covered pre-release: 8
MISSING: none
```

actionlint clean.

## Left open on purpose

amd64 only. The publish path builds `linux/amd64,linux/arm64` through QEMU, so an arm64-only failure — the realistic case for CGO, arch-specific packages, or a base image without an arm64 variant — still reaches the tag build first.

Emulated arm64 builds of eight images on every PR is a large standing CI cost against a narrower failure class. That is a budget decision rather than a correctness one, so I have not taken it here. #824 stays open with the reasoning.