### PR TITLE
feat: add sustained drive temperature notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -650,6 +650,8 @@ Check the `notify.urls` section of [example.scrutiny.yaml](example.scrutiny.yaml
 
 For more information and troubleshooting, see the [TROUBLESHOOTING_NOTIFICATIONS.md](./docs/TROUBLESHOOTING_NOTIFICATIONS.md) file
 
+Quiet-hours digests are delivered on the next background check after quiet hours end, even when missed-ping alerts are disabled. Failed or rate-limited digests remain queued for retry. The check uses **Missed Ping Check Interval** (default: 5 minutes).
+
 ### Drive Temperature Notifications
 
 Enable **Temperature Notifications** in **Display & Notifications** to alert when any unmuted drive stays at or above a global threshold (default: **55°C for 30 minutes**). The UI uses your selected Celsius/Fahrenheit unit; the backend stores whole degrees Celsius. A duration of **0** alerts on the first hot reading. Each excursion alerts once and re-arms after a valid reading below the threshold. Unknown readings (0 or lower) are ignored.

--- a/README.md
+++ b/README.md
@@ -658,6 +658,8 @@ Checks run on collector uploads, so delivery can be delayed until the next uploa
 
 Changing the threshold/duration or receiving an upload while notifications are disabled or the device is muted resets its timer. On resuming, the next hot reading starts a new timer. See [temperature notification troubleshooting](docs/TROUBLESHOOTING_NOTIFICATIONS.md#drive-temperature-notifications) for details.
 
+Temperature alerts ignore **Repeat Notifications**: each sustained hot excursion sends one alert, and cooling below the threshold re-arms silently. There is no recovery notification or hysteresis margin.
+
 ### Heartbeat Notifications
 
 Scrutiny can send periodic "all clear" heartbeat notifications to confirm the monitoring system is running and all drives are healthy. This is useful for integration with uptime monitoring tools like Uptime Kuma. When delivered through SMTP or HTML-capable Apprise targets, heartbeat messages use the same HTML-plus-plain-text pattern as the other email notifications.

--- a/README.md
+++ b/README.md
@@ -650,6 +650,14 @@ Check the `notify.urls` section of [example.scrutiny.yaml](example.scrutiny.yaml
 
 For more information and troubleshooting, see the [TROUBLESHOOTING_NOTIFICATIONS.md](./docs/TROUBLESHOOTING_NOTIFICATIONS.md) file
 
+### Drive Temperature Notifications
+
+Enable **Temperature Notifications** in **Display & Notifications** to alert when any unmuted drive stays at or above a global threshold (default: **55°C for 30 minutes**). The UI uses your selected Celsius/Fahrenheit unit; the backend stores whole degrees Celsius. A duration of **0** alerts on the first hot reading. Each excursion alerts once and re-arms after a valid reading below the threshold. Unknown readings (0 or lower) are ignored.
+
+Checks run on collector uploads, so delivery can be delayed until the next upload. After a server restart, Scrutiny can seed the timer from up to 24 hours of raw temperature history when storage is enabled and the history includes the current upload. Otherwise timing starts with that upload. Longer durations may need additional time after restarting, and an ongoing excursion may notify again after each restart. Quiet hours and rate limits apply.
+
+Changing the threshold/duration or receiving an upload while notifications are disabled or the device is muted resets its timer. On resuming, the next hot reading starts a new timer. See [temperature notification troubleshooting](docs/TROUBLESHOOTING_NOTIFICATIONS.md#drive-temperature-notifications) for details.
+
 ### Heartbeat Notifications
 
 Scrutiny can send periodic "all clear" heartbeat notifications to confirm the monitoring system is running and all drives are healthy. This is useful for integration with uptime monitoring tools like Uptime Kuma. When delivered through SMTP or HTML-capable Apprise targets, heartbeat messages use the same HTML-plus-plain-text pattern as the other email notifications.

--- a/docs/TROUBLESHOOTING_NOTIFICATIONS.md
+++ b/docs/TROUBLESHOOTING_NOTIFICATIONS.md
@@ -30,7 +30,7 @@ Enable this feature in **Display & Notifications**. The global defaults are 55°
 
 - Evaluation happens only on successful collector uploads. A collector interval longer than the configured duration delays the alert until the next upload. Fatal smartctl uploads never evaluate temperature.
 - Readings of 0 or lower are unknown: they neither start nor reset a streak and do not trigger an alert. A valid reading below the threshold re-arms the device.
-- After restarting the server, seeding uses up to 24 hours of raw history and requires **Store Temperature History** to be enabled and the current upload to appear in the query. Empty, stale, or failed queries fall back to timing from the current upload. Keep collector clocks synchronized with the server.
+- After restarting the server, seeding uses up to 24 hours of raw history tagged with the exact device ID and requires **Store Temperature History** to be enabled and the current upload to appear in the query. History from another device sharing a WWN cannot seed an alert. Empty, stale, or failed queries fall back to timing from the current upload. Keep collector clocks synchronized with the server.
 - Missing readings do not prove continuous heat; elapsed time spans gaps between valid observations. Durations longer than 24 hours may need additional time after a restart. Notification state is held in memory, so an ongoing excursion can notify once again after each restart.
 - An upload while muted/disabled resets that device's timer. Changes to the threshold or duration reset it on the next evaluated upload. Resuming starts a fresh timer without reusing old history.
 - Quiet hours queue one alert for the digest described above. Rate-limited or failed direct dispatches retry on the next hot upload. As with other notifications, partial delivery failures can repeat a message to targets that already succeeded.
@@ -43,6 +43,10 @@ To test restart seeding, use a nonzero duration and a hot history older than tha
 Omitting the threshold or duration in a Settings API request applies 55°C or 30 minutes respectively. An explicit duration of 0 means immediate delivery. The API rejects out-of-range values, including a threshold of 0, even when alerts are disabled. The UI preserves input while typing and rounds to whole Celsius on blur or save. When saving with alerts disabled, invalid hidden temperature values use the defaults; valid values are preserved.
 
 ## Upgrade note: temperature history storage
+
+Device-ID tagging first shipped in v1.39.0. Older history and history affected by the AnalogJ identity repair may lack the current device-ID tag and cannot seed temperature notifications. The repair does not add or correct that tag. With new tagged uploads, affected old points age out of the 24-hour seeding window. There is no 24-hour wait for alerts: fresh hot readings start the normal duration timer immediately.
+
+This identity fix applies to notification seeding. Dashboard temperature charts (`GET /api/summary/temp`) still group history by WWN and can mix devices with shared WWNs; correcting raw and downsampled chart history is separate follow-up work.
 
 The temperature notification release also repairs the legacy database key `store_temperature_history`, migrating it to `collector.store_temperature_history`. Affected installations could show history storage enabled while uploads did not store history. The migration preserves the existing preference (and prefers the canonical key if both exist), so enabled storage resumes on subsequent uploads. Existing history is retained; missing past readings cannot be reconstructed.
 

--- a/docs/TROUBLESHOOTING_NOTIFICATIONS.md
+++ b/docs/TROUBLESHOOTING_NOTIFICATIONS.md
@@ -22,9 +22,11 @@ If you are troubleshooting an Apprise target, use the Apprise documentation: htt
 
 Queued alerts are sent as a digest after quiet hours end. The background check runs at **Missed Ping Check Interval** (default: 5 minutes), even when missed-ping alerts are disabled. Failed or rate-limited digests stay queued for the next check. The queue is held in memory and is lost on server restart. Partial delivery failures can repeat a digest to targets that already succeeded.
 
+Quiet-hours digests combine alert categories and retain the legacy failure type `MissedPing` in scripts and webhooks, including digests containing temperature alerts. The subject and message identify the queued alerts.
+
 # Drive Temperature Notifications
 
-Enable this feature in **Display & Notifications**. The global defaults are 55°C for 30 minutes; equality counts as hot. A duration of 0 alerts on the first hot upload. Configure targets as for other notifications. Scripts and webhooks receive failure type `Temperature`.
+Enable this feature in **Display & Notifications**. The global defaults are 55°C for 30 minutes; equality counts as hot. A duration of 0 alerts on the first hot upload. Configure targets as for other notifications. Direct deliveries to scripts and webhooks receive failure type `Temperature`; quiet-hours digests use `MissedPing` as described above.
 
 - Evaluation happens only on successful collector uploads. A collector interval longer than the configured duration delays the alert until the next upload. Fatal smartctl uploads never evaluate temperature.
 - Readings of 0 or lower are unknown: they neither start nor reset a streak and do not trigger an alert. A valid reading below the threshold re-arms the device.
@@ -32,12 +34,13 @@ Enable this feature in **Display & Notifications**. The global defaults are 55°
 - Missing readings do not prove continuous heat; elapsed time spans gaps between valid observations. Durations longer than 24 hours may need additional time after a restart. Notification state is held in memory, so an ongoing excursion can notify once again after each restart.
 - An upload while muted/disabled resets that device's timer. Changes to the threshold or duration reset it on the next evaluated upload. Resuming starts a fresh timer without reusing old history.
 - Quiet hours queue one alert for the digest described above. Rate-limited or failed direct dispatches retry on the next hot upload. As with other notifications, partial delivery failures can repeat a message to targets that already succeeded.
+- If no targets are configured, alerts remain eligible for retry so adding a target can deliver an ongoing excursion. The notification gate logs the missing-target warning once across devices and digest retries, until a delivery succeeds or the server restarts. Target settings are still checked on each retry.
 - **Repeat Notifications** does not apply to temperature alerts. A sustained hot excursion sends one alert; cooling below the threshold re-arms silently, without a recovery notification or hysteresis margin.
 - History seeding queries time out after 10 seconds. Debug logging explains when seeding is skipped because the upload timestamp is missing/ahead of the server or the current point is not yet visible in InfluxDB. The timer then starts with the current upload.
 
 To test restart seeding, use a nonzero duration and a hot history older than that duration, then restart the web app and upload another hot reading. Using duration 0 only verifies immediate delivery, not seeding. These settings live under `metrics` in the Settings API: `notify_on_temperature`, `temperature_threshold_celsius` (1–150), and `temperature_duration_minutes` (whole minutes, 0–153722867).
 
-Omitting the threshold or duration in a Settings API request applies 55°C or 30 minutes respectively. An explicit duration of 0 means immediate delivery; an explicit threshold of 0 is rejected when alerts are enabled. The UI preserves input while typing and rounds to whole Celsius on blur or save.
+Omitting the threshold or duration in a Settings API request applies 55°C or 30 minutes respectively. An explicit duration of 0 means immediate delivery. The API rejects out-of-range values, including a threshold of 0, even when alerts are disabled. The UI preserves input while typing and rounds to whole Celsius on blur or save. When saving with alerts disabled, invalid hidden temperature values use the defaults; valid values are preserved.
 
 ## Upgrade note: temperature history storage
 

--- a/docs/TROUBLESHOOTING_NOTIFICATIONS.md
+++ b/docs/TROUBLESHOOTING_NOTIFICATIONS.md
@@ -50,6 +50,10 @@ This identity fix applies to notification seeding. Dashboard temperature charts 
 
 The temperature notification release also repairs the legacy database key `store_temperature_history`, migrating it to `collector.store_temperature_history`. Affected installations could show history storage enabled while uploads did not store history. The migration preserves the existing preference (and prefers the canonical key if both exist), so enabled storage resumes on subsequent uploads. Existing history is retained; missing past readings cannot be reconstructed.
 
+# SMTP Notifications
+
+The SMTP `timeout` URL parameter must be positive and defaults to `10s`. It now covers connection establishment and the entire SMTP conversation, including TLS, all recipients, and message submission. Slow but working servers may exhaust this shared budget; increase it (for example, `timeout=30s`) when needed. Zero and negative values are rejected before dialing. Timeout failures remain eligible for the normal notification retry behavior.
+
 # Webhook Notifications
 
 Raw HTTP/HTTPS webhook requests time out after 10 seconds. Only HTTP 2xx responses count as successful delivery; other statuses and timeouts are failures. Direct temperature alerts retry failed dispatches on the next hot upload.
@@ -58,6 +62,8 @@ Raw HTTP/HTTPS webhook requests time out after 10 seconds. Only HTTP 2xx respons
 
 While the Shoutrrr library supports many popular providers for sending notifications Scrutiny also supports a "script" based
 notification system, allowing you to execute a custom script whenever a notification needs to be sent. 
+Scripts have a 30-second execution timeout and a further 1-second allowance for closing inherited output pipes. A timeout is a delivery failure; direct temperature alerts retry on the next hot upload. The direct process is terminated on timeout, but this does not guarantee termination of every descendant. Both stdout and stderr continue streaming to raw process stdout with the existing prefix and stream labels, independently of the application logger.
+
 Data is provided to this script using the following environmental variables:
 
 ```
@@ -86,6 +92,12 @@ Then your `shoutrrr` url will look something like:
 # Apprise Targets
 
 Apprise targets must be explicit and prefixed with `apprise+` so Scrutiny can route them through the Apprise CLI without changing the existing `notify.urls` contract.
+
+Apprise has a 30-second execution timeout and a further 1-second allowance for closing inherited pipes. Its output remains buffered for failure diagnostics.
+
+Notification targets execute in parallel, so delivery waits for the slowest complete target operation. These transport budgets are not upload deadlines: history seeding, database work, and waiting behind another upload can add time.
+
+For the audited Shoutrrr v0.17.0 Matrix password-login path, sender construction can make two sequential HTTP requests with 10-second deadlines, followed by the router's 10-second send wait: approximately 30 seconds of transport execution. This is not a total device-lock or upload deadline.
 
 Examples:
 

--- a/docs/TROUBLESHOOTING_NOTIFICATIONS.md
+++ b/docs/TROUBLESHOOTING_NOTIFICATIONS.md
@@ -18,6 +18,10 @@ If you are troubleshooting a Shoutrrr target, use their documentation: https://n
 If you are troubleshooting an Apprise target, use the Apprise documentation: https://appriseit.com/
 
 
+# Quiet Hours
+
+Queued alerts are sent as a digest after quiet hours end. The background check runs at **Missed Ping Check Interval** (default: 5 minutes), even when missed-ping alerts are disabled. Failed or rate-limited digests stay queued for the next check. The queue is held in memory and is lost on server restart. Partial delivery failures can repeat a digest to targets that already succeeded.
+
 # Drive Temperature Notifications
 
 Enable this feature in **Display & Notifications**. The global defaults are 55°C for 30 minutes; equality counts as hot. A duration of 0 alerts on the first hot upload. Configure targets as for other notifications. Scripts and webhooks receive failure type `Temperature`.
@@ -27,7 +31,7 @@ Enable this feature in **Display & Notifications**. The global defaults are 55°
 - After restarting the server, seeding uses up to 24 hours of raw history and requires **Store Temperature History** to be enabled and the current upload to appear in the query. Empty, stale, or failed queries fall back to timing from the current upload. Keep collector clocks synchronized with the server.
 - Missing readings do not prove continuous heat; elapsed time spans gaps between valid observations. Durations longer than 24 hours may need additional time after a restart. Notification state is held in memory, so an ongoing excursion can notify once again after each restart.
 - An upload while muted/disabled resets that device's timer. Changes to the threshold or duration reset it on the next evaluated upload. Resuming starts a fresh timer without reusing old history.
-- Quiet hours queue one alert for the digest. Rate-limited or failed direct dispatches retry on the next hot upload. As with other notifications, partial delivery failures can repeat a message to targets that already succeeded.
+- Quiet hours queue one alert for the digest described above. Rate-limited or failed direct dispatches retry on the next hot upload. As with other notifications, partial delivery failures can repeat a message to targets that already succeeded.
 - **Repeat Notifications** does not apply to temperature alerts. A sustained hot excursion sends one alert; cooling below the threshold re-arms silently, without a recovery notification or hysteresis margin.
 - History seeding queries time out after 10 seconds. Debug logging explains when seeding is skipped because the upload timestamp is missing/ahead of the server or the current point is not yet visible in InfluxDB. The timer then starts with the current upload.
 

--- a/docs/TROUBLESHOOTING_NOTIFICATIONS.md
+++ b/docs/TROUBLESHOOTING_NOTIFICATIONS.md
@@ -18,6 +18,19 @@ If you are troubleshooting a Shoutrrr target, use their documentation: https://n
 If you are troubleshooting an Apprise target, use the Apprise documentation: https://appriseit.com/
 
 
+# Drive Temperature Notifications
+
+Enable this feature in **Display & Notifications**. The global defaults are 55°C for 30 minutes; equality counts as hot. A duration of 0 alerts on the first hot upload. Configure targets as for other notifications. Scripts and webhooks receive failure type `Temperature`.
+
+- Evaluation happens only on successful collector uploads. A collector interval longer than the configured duration delays the alert until the next upload. Fatal smartctl uploads never evaluate temperature.
+- Readings of 0 or lower are unknown: they neither start nor reset a streak and do not trigger an alert. A valid reading below the threshold re-arms the device.
+- After restarting the server, seeding uses up to 24 hours of raw history and requires **Store Temperature History** to be enabled and the current upload to appear in the query. Empty, stale, or failed queries fall back to timing from the current upload. Keep collector clocks synchronized with the server.
+- Missing readings do not prove continuous heat; elapsed time spans gaps between valid observations. Durations longer than 24 hours may need additional time after a restart. Notification state is held in memory, so an ongoing excursion can notify once again after each restart.
+- An upload while muted/disabled resets that device's timer. Changes to the threshold or duration reset it on the next evaluated upload. Resuming starts a fresh timer without reusing old history.
+- Quiet hours queue one alert for the digest. Rate-limited or failed dispatches retry on the next hot upload. As with other notifications, partial delivery failures can repeat a message to targets that already succeeded.
+
+To test restart seeding, use a nonzero duration and a hot history older than that duration, then restart the web app and upload another hot reading. Using duration 0 only verifies immediate delivery, not seeding. These settings live under `metrics` in the Settings API: `notify_on_temperature`, `temperature_threshold_celsius` (1–150), and `temperature_duration_minutes` (whole minutes, 0–153722867).
+
 # Script Notifications
 
 While the Shoutrrr library supports many popular providers for sending notifications Scrutiny also supports a "script" based
@@ -27,7 +40,7 @@ Data is provided to this script using the following environmental variables:
 ```
 SCRUTINY_SUBJECT - 	eg. "Scrutiny SMART error (%s) detected on device: %s"
 SCRUTINY_DATE 
-SCRUTINY_FAILURE_TYPE - EmailTest, SmartFail, ScrutinyFail, MissedPing, Heartbeat
+SCRUTINY_FAILURE_TYPE - EmailTest, SmartFail, ScrutinyFail, MissedPing, Heartbeat, Temperature
 SCRUTINY_DEVICE_NAME - eg. /dev/sda
 SCRUTINY_DEVICE_TYPE - ATA/SCSI/NVMe
 SCRUTINY_DEVICE_SERIAL - eg. WDDJ324KSO

--- a/docs/TROUBLESHOOTING_NOTIFICATIONS.md
+++ b/docs/TROUBLESHOOTING_NOTIFICATIONS.md
@@ -27,9 +27,21 @@ Enable this feature in **Display & Notifications**. The global defaults are 55°
 - After restarting the server, seeding uses up to 24 hours of raw history and requires **Store Temperature History** to be enabled and the current upload to appear in the query. Empty, stale, or failed queries fall back to timing from the current upload. Keep collector clocks synchronized with the server.
 - Missing readings do not prove continuous heat; elapsed time spans gaps between valid observations. Durations longer than 24 hours may need additional time after a restart. Notification state is held in memory, so an ongoing excursion can notify once again after each restart.
 - An upload while muted/disabled resets that device's timer. Changes to the threshold or duration reset it on the next evaluated upload. Resuming starts a fresh timer without reusing old history.
-- Quiet hours queue one alert for the digest. Rate-limited or failed dispatches retry on the next hot upload. As with other notifications, partial delivery failures can repeat a message to targets that already succeeded.
+- Quiet hours queue one alert for the digest. Rate-limited or failed direct dispatches retry on the next hot upload. As with other notifications, partial delivery failures can repeat a message to targets that already succeeded.
+- **Repeat Notifications** does not apply to temperature alerts. A sustained hot excursion sends one alert; cooling below the threshold re-arms silently, without a recovery notification or hysteresis margin.
+- History seeding queries time out after 10 seconds. Debug logging explains when seeding is skipped because the upload timestamp is missing/ahead of the server or the current point is not yet visible in InfluxDB. The timer then starts with the current upload.
 
 To test restart seeding, use a nonzero duration and a hot history older than that duration, then restart the web app and upload another hot reading. Using duration 0 only verifies immediate delivery, not seeding. These settings live under `metrics` in the Settings API: `notify_on_temperature`, `temperature_threshold_celsius` (1–150), and `temperature_duration_minutes` (whole minutes, 0–153722867).
+
+Omitting the threshold or duration in a Settings API request applies 55°C or 30 minutes respectively. An explicit duration of 0 means immediate delivery; an explicit threshold of 0 is rejected when alerts are enabled. The UI preserves input while typing and rounds to whole Celsius on blur or save.
+
+## Upgrade note: temperature history storage
+
+The temperature notification release also repairs the legacy database key `store_temperature_history`, migrating it to `collector.store_temperature_history`. Affected installations could show history storage enabled while uploads did not store history. The migration preserves the existing preference (and prefers the canonical key if both exist), so enabled storage resumes on subsequent uploads. Existing history is retained; missing past readings cannot be reconstructed.
+
+# Webhook Notifications
+
+Raw HTTP/HTTPS webhook requests time out after 10 seconds. Only HTTP 2xx responses count as successful delivery; other statuses and timeouts are failures. Direct temperature alerts retry failed dispatches on the next hot upload.
 
 # Script Notifications
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2126,19 +2126,19 @@ components:
             notify_on_temperature:
               type: boolean
               default: false
-              description: Notify once per sustained hot excursion, evaluated on collector uploads. Muted devices are skipped.
+              description: Notify once per sustained hot excursion, evaluated on collector uploads. Muted devices are skipped. Ignores repeat_notifications; cooling re-arms silently without a recovery notification.
             temperature_threshold_celsius:
               type: integer
               minimum: 1
               maximum: 150
               default: 55
-              description: Inclusive Celsius threshold; validated when temperature notifications are enabled.
+              description: Inclusive Celsius threshold; defaults to 55 when omitted. Explicit zero is rejected when temperature notifications are enabled.
             temperature_duration_minutes:
               type: integer
               minimum: 0
               maximum: 153722867
               default: 30
-              description: Sustained hot duration in whole minutes; 0 alerts on the first hot reading. Validated when enabled. Restart history seeding is limited to 24 hours.
+              description: Sustained hot duration in whole minutes; defaults to 30 when omitted. Explicit 0 alerts on the first hot reading. Validated when enabled. Restart history seeding is limited to 24 hours.
             notify_on_replacement_risk:
               type: boolean
             replacement_risk_notify_category:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2123,6 +2123,22 @@ components:
               type: boolean
             notify_on_missed_ping:
               type: boolean
+            notify_on_temperature:
+              type: boolean
+              default: false
+              description: Notify once per sustained hot excursion, evaluated on collector uploads. Muted devices are skipped.
+            temperature_threshold_celsius:
+              type: integer
+              minimum: 1
+              maximum: 150
+              default: 55
+              description: Inclusive Celsius threshold; validated when temperature notifications are enabled.
+            temperature_duration_minutes:
+              type: integer
+              minimum: 0
+              maximum: 153722867
+              default: 30
+              description: Sustained hot duration in whole minutes; 0 alerts on the first hot reading. Validated when enabled. Restart history seeding is limited to 24 hours.
             notify_on_replacement_risk:
               type: boolean
             replacement_risk_notify_category:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2132,13 +2132,13 @@ components:
               minimum: 1
               maximum: 150
               default: 55
-              description: Inclusive Celsius threshold; defaults to 55 when omitted. Explicit zero is rejected when temperature notifications are enabled.
+              description: Inclusive Celsius threshold; defaults to 55 when omitted. Range is validated even when temperature notifications are disabled; explicit zero is rejected.
             temperature_duration_minutes:
               type: integer
               minimum: 0
               maximum: 153722867
               default: 30
-              description: Sustained hot duration in whole minutes; defaults to 30 when omitted. Explicit 0 alerts on the first hot reading. Validated when enabled. Restart history seeding is limited to 24 hours.
+              description: Sustained hot duration in whole minutes; defaults to 30 when omitted. Explicit 0 alerts on the first hot reading. Range is validated even when notifications are disabled. Restart history seeding is limited to 24 hours.
             notify_on_replacement_risk:
               type: boolean
             replacement_risk_notify_category:

--- a/example.scrutiny.yaml
+++ b/example.scrutiny.yaml
@@ -383,6 +383,19 @@ failures:
 #     -d '{"metrics": {"notify_on_missed_ping": true, "missed_ping_timeout_minutes": 60}}'
 
 ######################################################################
+# Drive Temperature Notifications (API-only settings)
+#
+# Configure in Display & Notifications or through /api/settings, not this file:
+#   metrics.notify_on_temperature: false
+#   metrics.temperature_threshold_celsius: 55   # Inclusive; 1..150 Celsius
+#   metrics.temperature_duration_minutes: 30    # Whole minutes; 0 = immediate
+#
+# Alerts once per hot excursion, evaluated on collector uploads. Restart seeding
+# uses up to 24 hours of raw history when storage is enabled. An ongoing hot
+# excursion may notify again after restarting. Quiet hours and rate limits apply.
+# Threshold/duration changes and uploads while muted/disabled reset the timer.
+#
+######################################################################
 # Scheduled Reports [WIP]
 #
 # Scrutiny can generate and email periodic health reports summarizing

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/influxdata/influxdb-client-go/v2 v2.14.0
 	github.com/jaypipes/ghw v0.25.0
+	github.com/kvz/logstreamer v0.0.0-20201023134116-02d20f4338f5
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/nicholas-fedor/shoutrrr v0.17.0
 	github.com/prometheus/client_golang v1.24.1
@@ -61,7 +62,6 @@ require (
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
-	github.com/kvz/logstreamer v0.0.0-20201023134116-02d20f4338f5 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/mattn/go-colorable v0.1.15 // indirect
 	github.com/mattn/go-isatty v0.0.24 // indirect

--- a/webapp/backend/pkg/database/interface.go
+++ b/webapp/backend/pkg/database/interface.go
@@ -72,6 +72,7 @@ type DeviceRepo interface {
 	GetSummaryPage(ctx context.Context, options models.DeviceSummaryPageOptions) (*models.DeviceSummaryPage, error)
 	GetSmartTemperatureHistory(ctx context.Context, durationKey string) (map[string][]measurements.SmartTemperature, error)
 	GetSmartTemperatureHistoryForDevices(ctx context.Context, durationKey string, deviceIDs []string) (map[string][]measurements.SmartTemperature, error)
+	GetTemperatureNotificationHistory(ctx context.Context, deviceID string) ([]measurements.SmartTemperature, error)
 	SaveFilesystemSummary(ctx context.Context, payload models.FilesystemSummaryUpload) error
 	GetFilesystemSummary(ctx context.Context) (map[string][]models.FilesystemCapacity, map[string]*models.FilesystemHostStatus, error)
 

--- a/webapp/backend/pkg/database/mock/mock_database.go
+++ b/webapp/backend/pkg/database/mock/mock_database.go
@@ -649,6 +649,21 @@ func (mr *MockDeviceRepoMockRecorder) GetSummaryPage(ctx, options interface{}) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSummaryPage", reflect.TypeOf((*MockDeviceRepo)(nil).GetSummaryPage), ctx, options)
 }
 
+// GetTemperatureNotificationHistory mocks base method.
+func (m *MockDeviceRepo) GetTemperatureNotificationHistory(ctx context.Context, deviceID string) ([]measurements.SmartTemperature, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTemperatureNotificationHistory", ctx, deviceID)
+	ret0, _ := ret[0].([]measurements.SmartTemperature)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetTemperatureNotificationHistory indicates an expected call of GetTemperatureNotificationHistory.
+func (mr *MockDeviceRepoMockRecorder) GetTemperatureNotificationHistory(ctx, deviceID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTemperatureNotificationHistory", reflect.TypeOf((*MockDeviceRepo)(nil).GetTemperatureNotificationHistory), ctx, deviceID)
+}
+
 // GetWorkloadInsights mocks base method.
 func (m *MockDeviceRepo) GetWorkloadInsights(ctx context.Context, durationKey string) (map[string]*models.WorkloadInsight, error) {
 	m.ctrl.T.Helper()

--- a/webapp/backend/pkg/database/scrutiny_repository_migrations.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_migrations.go
@@ -1663,14 +1663,8 @@ func migrateTemperatureNotificationSettings(tx *gorm.DB) error {
 		{SettingKeyName: "metrics.temperature_duration_minutes", SettingKeyDescription: "Sustained hot duration in minutes (0 = immediate)", SettingDataType: "numeric", SettingValueNumeric: models.DefaultTemperatureDurationMinutes},
 	}
 	for _, entry := range entries {
-		var count int64
-		if err := tx.Model(&models.SettingEntry{}).Where("setting_key_name = ?", entry.SettingKeyName).Count(&count).Error; err != nil {
+		if err := tx.Where("setting_key_name = ?", entry.SettingKeyName).FirstOrCreate(&entry).Error; err != nil {
 			return err
-		}
-		if count == 0 {
-			if err := tx.Create(&entry).Error; err != nil {
-				return err
-			}
 		}
 	}
 	return nil

--- a/webapp/backend/pkg/database/scrutiny_repository_migrations.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_migrations.go
@@ -677,6 +677,8 @@ func (sr *scrutinyRepository) Migrate(ctx context.Context) error {
 			ID:      "m20260907000000", // add usable capacity columns to zfs_pools table (#754)
 			Migrate: m20260907000000.Migrate,
 		},
+		{ID: "m20260908000000", Migrate: migrateTemperatureStorageKey},
+		{ID: "m20260908000001", Migrate: migrateTemperatureNotificationSettings},
 	})
 
 	if err := m.Migrate(); err != nil {
@@ -1638,4 +1640,38 @@ func migrateSelfTestChronology(tx *gorm.DB) error {
 		return err
 	}
 	return tx.AutoMigrate(&models.DeviceSelfTest{})
+}
+
+// Keep an existing canonical value if an installation already repaired the key.
+func migrateTemperatureStorageKey(tx *gorm.DB) error {
+	const legacyKey = "store_temperature_history"
+	const canonicalKey = "collector.store_temperature_history"
+	var count int64
+	if err := tx.Model(&models.SettingEntry{}).Where("setting_key_name = ?", canonicalKey).Count(&count).Error; err != nil {
+		return err
+	}
+	if count > 0 {
+		return tx.Unscoped().Where("setting_key_name = ?", legacyKey).Delete(&models.SettingEntry{}).Error
+	}
+	return tx.Model(&models.SettingEntry{}).Where("setting_key_name = ?", legacyKey).Update("setting_key_name", canonicalKey).Error
+}
+
+func migrateTemperatureNotificationSettings(tx *gorm.DB) error {
+	entries := []models.SettingEntry{
+		{SettingKeyName: "metrics.notify_on_temperature", SettingKeyDescription: "Notify when drive temperature stays at or above the threshold", SettingDataType: "bool", SettingValueBool: false},
+		{SettingKeyName: "metrics.temperature_threshold_celsius", SettingKeyDescription: "Temperature notification threshold in Celsius", SettingDataType: "numeric", SettingValueNumeric: models.DefaultTemperatureThresholdCelsius},
+		{SettingKeyName: "metrics.temperature_duration_minutes", SettingKeyDescription: "Sustained hot duration in minutes (0 = immediate)", SettingDataType: "numeric", SettingValueNumeric: models.DefaultTemperatureDurationMinutes},
+	}
+	for _, entry := range entries {
+		var count int64
+		if err := tx.Model(&models.SettingEntry{}).Where("setting_key_name = ?", entry.SettingKeyName).Count(&count).Error; err != nil {
+			return err
+		}
+		if count == 0 {
+			if err := tx.Create(&entry).Error; err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }

--- a/webapp/backend/pkg/database/scrutiny_repository_migrations_test.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_migrations_test.go
@@ -24,6 +24,9 @@ func createMigrationTestRepositoryWithAppliedMigrations(t *testing.T, appliedMig
 	dbPath := filepath.Join(tempDir, "scrutiny.db")
 	db, err := gorm.Open(sqlite.Open(dbPath), &gorm.Config{})
 	require.NoError(t, err)
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, sqlDB.Close()) })
 
 	require.NoError(t, db.AutoMigrate(
 		&m20260301000000.Device{},
@@ -618,6 +621,8 @@ func TestTemperatureMigrationsPreserveExistingCanonicalSettings(t *testing.T) {
 		{SettingKeyName: "store_temperature_history", SettingDataType: "bool", SettingValueBool: true},
 		{SettingKeyName: "collector.store_temperature_history", SettingDataType: "bool", SettingValueBool: false},
 		{SettingKeyName: "metrics.temperature_duration_minutes", SettingDataType: "numeric", SettingValueNumeric: 0},
+		{SettingKeyName: "metrics.notify_on_temperature", SettingDataType: "bool", SettingValueBool: true},
+		{SettingKeyName: "metrics.temperature_threshold_celsius", SettingDataType: "numeric", SettingValueNumeric: 65},
 	}
 	require.NoError(t, repo.gormClient.Create(&entries).Error)
 	for range 2 {
@@ -630,6 +635,11 @@ func TestTemperatureMigrationsPreserveExistingCanonicalSettings(t *testing.T) {
 	var duration models.SettingEntry
 	require.NoError(t, repo.gormClient.First(&duration, entries[2].ID).Error)
 	require.Zero(t, duration.SettingValueNumeric)
+	var enabled, threshold models.SettingEntry
+	require.NoError(t, repo.gormClient.First(&enabled, entries[3].ID).Error)
+	require.True(t, enabled.SettingValueBool)
+	require.NoError(t, repo.gormClient.First(&threshold, entries[4].ID).Error)
+	require.Equal(t, 65, threshold.SettingValueNumeric)
 	var count int64
 	require.NoError(t, repo.gormClient.Model(&models.SettingEntry{}).Count(&count).Error)
 	require.EqualValues(t, 4, count)

--- a/webapp/backend/pkg/database/scrutiny_repository_migrations_test.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_migrations_test.go
@@ -2,6 +2,8 @@ package database
 
 import (
 	"context"
+	"fmt"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/config"
 	"path/filepath"
 	"testing"
 
@@ -559,9 +561,78 @@ func TestMigrateEnablesTemperatureHistoryStorage(t *testing.T) {
 	require.NoError(t, repo.Migrate(context.Background()))
 
 	var setting models.SettingEntry
-	require.NoError(t, repo.gormClient.Where("setting_key_name = ?", "store_temperature_history").First(&setting).Error)
+	require.NoError(t, repo.gormClient.Where("setting_key_name = ?", "collector.store_temperature_history").First(&setting).Error)
 	require.Equal(t, "bool", setting.SettingDataType)
 	require.True(t, setting.SettingValueBool)
+}
+
+func TestTemperatureSettingsPersistAcrossConfigReload(t *testing.T) {
+	repo := createMigrationTestRepository(t)
+	require.NoError(t, repo.Migrate(context.Background()))
+	var err error
+	repo.appConfig, err = config.Create()
+	require.NoError(t, err)
+	settings, err := repo.LoadSettings(context.Background())
+	require.NoError(t, err)
+	require.True(t, settings.Collector.StoreTempHistory)
+	require.False(t, settings.Metrics.NotifyOnTemperature)
+	require.Equal(t, models.DefaultTemperatureThresholdCelsius, settings.Metrics.TemperatureThresholdCelsius)
+	require.Equal(t, models.DefaultTemperatureDurationMinutes, settings.Metrics.TemperatureDurationMinutes)
+	for _, store := range []bool{false, true} {
+		settings.Collector.StoreTempHistory = store
+		settings.Metrics.NotifyOnTemperature = true
+		settings.Metrics.TemperatureThresholdCelsius = 65
+		settings.Metrics.TemperatureDurationMinutes = 0
+		require.NoError(t, repo.SaveSettings(context.Background(), *settings))
+		repo.appConfig, err = config.Create()
+		require.NoError(t, err)
+		settings, err = repo.LoadSettings(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, store, settings.Collector.StoreTempHistory)
+		require.Equal(t, store, repo.appConfig.GetBool("user.collector.store_temperature_history"))
+		require.True(t, settings.Metrics.NotifyOnTemperature)
+		require.Equal(t, 65, settings.Metrics.TemperatureThresholdCelsius)
+		require.Zero(t, settings.Metrics.TemperatureDurationMinutes)
+	}
+}
+
+func TestTemperatureStorageMigrationPreservesValues(t *testing.T) {
+	for _, value := range []bool{false, true} {
+		t.Run(fmt.Sprint(value), func(t *testing.T) {
+			repo := createMigrationTestRepository(t)
+			legacy := models.SettingEntry{SettingKeyName: "store_temperature_history", SettingDataType: "bool", SettingValueBool: value}
+			require.NoError(t, repo.gormClient.Create(&legacy).Error)
+			require.NoError(t, migrateTemperatureStorageKey(repo.gormClient))
+			require.NoError(t, migrateTemperatureStorageKey(repo.gormClient))
+			var saved models.SettingEntry
+			require.NoError(t, repo.gormClient.First(&saved, legacy.ID).Error)
+			require.Equal(t, "collector.store_temperature_history", saved.SettingKeyName)
+			require.Equal(t, value, saved.SettingValueBool)
+		})
+	}
+}
+
+func TestTemperatureMigrationsPreserveExistingCanonicalSettings(t *testing.T) {
+	repo := createMigrationTestRepository(t)
+	entries := []models.SettingEntry{
+		{SettingKeyName: "store_temperature_history", SettingDataType: "bool", SettingValueBool: true},
+		{SettingKeyName: "collector.store_temperature_history", SettingDataType: "bool", SettingValueBool: false},
+		{SettingKeyName: "metrics.temperature_duration_minutes", SettingDataType: "numeric", SettingValueNumeric: 0},
+	}
+	require.NoError(t, repo.gormClient.Create(&entries).Error)
+	for range 2 {
+		require.NoError(t, migrateTemperatureStorageKey(repo.gormClient))
+		require.NoError(t, migrateTemperatureNotificationSettings(repo.gormClient))
+	}
+	var saved models.SettingEntry
+	require.NoError(t, repo.gormClient.First(&saved, entries[1].ID).Error)
+	require.False(t, saved.SettingValueBool)
+	var duration models.SettingEntry
+	require.NoError(t, repo.gormClient.First(&duration, entries[2].ID).Error)
+	require.Zero(t, duration.SettingValueNumeric)
+	var count int64
+	require.NoError(t, repo.gormClient.Model(&models.SettingEntry{}).Count(&count).Error)
+	require.EqualValues(t, 4, count)
 }
 
 func TestMigrateSelfTestChronologyPreservesLegacyHistory(t *testing.T) {

--- a/webapp/backend/pkg/database/scrutiny_repository_temperature.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_temperature.go
@@ -73,6 +73,38 @@ func (sr *scrutinyRepository) GetSmartTemperatureHistoryForDevices(ctx context.C
 	return sr.getSmartTemperatureHistory(ctx, durationKey, deviceIDs)
 }
 
+// GetTemperatureNotificationHistory uses only raw points tagged with the current
+// device ID. WWNs and legacy untagged points cannot safely establish an excursion.
+func (sr *scrutinyRepository) GetTemperatureNotificationHistory(ctx context.Context, deviceID string) ([]measurements.SmartTemperature, error) {
+	if deviceID == "" {
+		return nil, fmt.Errorf("temperature notification history requires a device ID")
+	}
+	query := fmt.Sprintf(`from(bucket: %s)
+|> range(start: %s, stop: %s)
+|> filter(fn: (r) => r["_measurement"] == "temp" and r["_field"] == "temp")
+|> filter(fn: (r) => exists r["device_id"] and r["device_id"] == %s)`,
+		strconv.Quote(sr.lookupBucketName(DURATION_KEY_DAY)), INFLUX_DURATION_1_DAY, INFLUX_NOW, strconv.Quote(deviceID))
+	result, err := sr.influxQueryApi.Query(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	defer result.Close()
+	var history []measurements.SmartTemperature
+	for result.Next() {
+		record := result.Record()
+		if record.ValueByKey("device_id") != deviceID || record.Time().IsZero() {
+			continue
+		}
+		point := measurements.SmartTemperature{Date: record.Time()}
+		point.Inflate("temp", record.Value())
+		history = append(history, point)
+	}
+	if err := result.Err(); err != nil {
+		return nil, fmt.Errorf("temperature notification history query failed: %w", err)
+	}
+	return history, nil
+}
+
 func (sr *scrutinyRepository) getSmartTemperatureHistory(ctx context.Context, durationKey string, deviceIDs []string) (map[string][]measurements.SmartTemperature, error) {
 	//we can get temp history for "week", "month", DURATION_KEY_YEAR, "forever"
 

--- a/webapp/backend/pkg/database/scrutiny_repository_temperature.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_temperature.go
@@ -116,7 +116,7 @@ func (sr *scrutinyRepository) getSmartTemperatureHistory(ctx context.Context, du
 		appendTempRecord(deviceTempHistory, result.Record().Values(), wwnToDeviceID)
 	}
 	if result.Err() != nil {
-		sr.logger.Errorf("Query error: %s", result.Err().Error())
+		return nil, fmt.Errorf("temperature history query failed: %w", result.Err())
 	}
 	return deviceTempHistory, nil
 }

--- a/webapp/backend/pkg/database/scrutiny_repository_temperature_test.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_temperature_test.go
@@ -5,11 +5,27 @@ import (
 	mock_config "github.com/analogj/scrutiny/webapp/backend/pkg/config/mock"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/models/collector"
 	"github.com/golang/mock/gomock"
+	influxapi "github.com/influxdata/influxdb-client-go/v2/api"
 	"github.com/influxdata/influxdb-client-go/v2/api/write"
 	"github.com/stretchr/testify/require"
+	"io"
 	"strings"
 	"testing"
 )
+
+type temperatureErrorQuery struct{ stubQueryAPI }
+
+func (s *temperatureErrorQuery) Query(_ context.Context, _ string) (*influxapi.QueryTableResult, error) {
+	return influxapi.NewQueryTableResult(io.NopCloser(strings.NewReader("invalid,csv\n"))), nil
+}
+
+func TestTemperatureHistoryPropagatesStreamErrors(t *testing.T) {
+	repo := createDeviceSelfTestRepository(t)
+	repo.influxQueryApi = &temperatureErrorQuery{}
+	history, err := repo.GetSmartTemperatureHistory(context.Background(), DURATION_KEY_DAY)
+	require.Error(t, err)
+	require.Nil(t, history)
+}
 
 type countingWriteAPI struct {
 	stubWriteAPI

--- a/webapp/backend/pkg/database/temperature_notification_history_test.go
+++ b/webapp/backend/pkg/database/temperature_notification_history_test.go
@@ -1,0 +1,113 @@
+package database
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	mock_config "github.com/analogj/scrutiny/webapp/backend/pkg/config/mock"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/models/measurements"
+	"github.com/golang/mock/gomock"
+	influxapi "github.com/influxdata/influxdb-client-go/v2/api"
+	"github.com/stretchr/testify/require"
+)
+
+const notificationHistoryCSV = `#datatype,string,long,dateTime:RFC3339,long,string,string
+#group,false,false,false,false,true,true
+#default,_result,,,,,
+,result,table,_time,_value,device_id,device_wwn
+`
+
+type notificationHistoryQuery struct {
+	stubQueryAPI
+	response string
+	query    string
+	err      error
+}
+
+func (q *notificationHistoryQuery) Query(ctx context.Context, query string) (*influxapi.QueryTableResult, error) {
+	q.query = query
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if q.err != nil {
+		return nil, q.err
+	}
+	return influxapi.NewQueryTableResult(io.NopCloser(strings.NewReader(q.response))), nil
+}
+
+func TestTemperatureNotificationHistoryUsesDeviceIdentity(t *testing.T) {
+	for _, wwn := range []string{"shared", ""} {
+		t.Run("wwn="+wwn, func(t *testing.T) {
+			query := &notificationHistoryQuery{response: notificationHistoryCSV + fmt.Sprintf(`,,0,2026-09-07T11:00:00Z,60,neighbor,%s
+,,0,2026-09-07T11:10:00Z,60,,%s
+,,0,2026-09-07T11:20:00Z,60,obsolete-id,%s
+,,0,2026-09-07T12:00:00Z,60,drive,%s
+,,0,2026-09-07T12:00:00Z,60,neighbor,%s
+,,0,2026-09-07T11:50:00Z,40,neighbor,%s
+,,0,2026-09-07T11:40:00Z,55,drive,%s
+`, wwn, wwn, wwn, wwn, wwn, wwn, wwn)}
+			cfg := mock_config.NewMockInterface(gomock.NewController(t))
+			cfg.EXPECT().GetString("web.influxdb.bucket").Return("metrics")
+			repo := scrutinyRepository{appConfig: cfg, influxQueryApi: query}
+			points, err := repo.GetTemperatureNotificationHistory(context.Background(), "drive")
+			require.NoError(t, err)
+			require.Equal(t, []measurements.SmartTemperature{
+				{Date: time.Date(2026, 9, 7, 12, 0, 0, 0, time.UTC), Temp: 60},
+				{Date: time.Date(2026, 9, 7, 11, 40, 0, 0, time.UTC), Temp: 55},
+			}, points)
+			require.Contains(t, query.query, `exists r["device_id"] and r["device_id"] == "drive"`)
+			require.Contains(t, query.query, `range(start: -1d, stop: now())`)
+			require.Contains(t, query.query, `r["_field"] == "temp"`)
+			require.NotContains(t, query.query, "device_wwn")
+			require.NotContains(t, query.query, "aggregateWindow")
+		})
+	}
+}
+
+func TestTemperatureNotificationHistoryErrorsAndEscaping(t *testing.T) {
+	const escapedID = `drive-"\\id`
+	for _, scenario := range []string{"escaped", "empty result", "missing tag", "empty id", "query error", "stream error", "canceled"} {
+		t.Run(scenario, func(t *testing.T) {
+			query := &notificationHistoryQuery{response: notificationHistoryCSV}
+			deviceID := escapedID
+			ctx := context.Background()
+			switch scenario {
+			case "missing tag":
+				query.response = "#datatype,string,long,dateTime:RFC3339,long\n#group,false,false,false,false\n#default,_result,,,\n,result,table,_time,_value\n,,0,2026-09-07T12:00:00Z,60\n"
+			case "empty id":
+				deviceID = ""
+			case "query error":
+				query.err = errors.New("unavailable")
+			case "stream error":
+				query.response += ",,0,invalid-date,60,drive,shared\n"
+			case "canceled":
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithCancel(ctx)
+				cancel()
+			}
+			cfg := mock_config.NewMockInterface(gomock.NewController(t))
+			if deviceID != "" {
+				cfg.EXPECT().GetString("web.influxdb.bucket").Return("metrics")
+			}
+			repo := scrutinyRepository{appConfig: cfg, influxQueryApi: query}
+			points, err := repo.GetTemperatureNotificationHistory(ctx, deviceID)
+			if scenario == "empty id" || scenario == "query error" || scenario == "stream error" || scenario == "canceled" {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Empty(t, points)
+			if deviceID == "" {
+				require.Empty(t, query.query)
+			} else {
+				require.Contains(t, query.query, `r["device_id"] == `+strconv.Quote(deviceID))
+			}
+		})
+	}
+}

--- a/webapp/backend/pkg/models/settings.go
+++ b/webapp/backend/pkg/models/settings.go
@@ -1,5 +1,18 @@
 package models
 
+import (
+	"math"
+	"time"
+)
+
+const (
+	DefaultTemperatureThresholdCelsius = 55
+	DefaultTemperatureDurationMinutes  = 30
+	MinTemperatureThresholdCelsius     = 1
+	MaxTemperatureThresholdCelsius     = 150
+	MaxTemperatureDurationMinutes      = int(math.MaxInt64 / int64(time.Minute))
+)
+
 // Settings is made up of parsed SettingEntry objects retrieved from the database
 //type Settings struct {
 //	MetricsNotifyLevel            pkg.MetricsNotifyLevel            `json:"metrics.notify.level" mapstructure:"metrics.notify.level"`
@@ -9,6 +22,9 @@ package models
 
 type Settings struct {
 	Metrics struct {
+		NotifyOnTemperature           bool   `json:"notify_on_temperature" mapstructure:"notify_on_temperature"`
+		TemperatureThresholdCelsius   int    `json:"temperature_threshold_celsius" mapstructure:"temperature_threshold_celsius"`
+		TemperatureDurationMinutes    int    `json:"temperature_duration_minutes" mapstructure:"temperature_duration_minutes"`
 		NotificationQuietStart        string `json:"notification_quiet_start" mapstructure:"notification_quiet_start"`
 		ReportPDFPath                 string `json:"report_pdf_path" mapstructure:"report_pdf_path"`
 		ReportMonthlyTime             string `json:"report_monthly_time" mapstructure:"report_monthly_time"`
@@ -110,6 +126,7 @@ func (s *Settings) ApplyDefaults() {
 	defaultInt(&s.DashboardHostPageSize, 10)
 
 	// Metrics: numeric fields where 0 is not a valid value.
+	defaultInt(&s.Metrics.TemperatureThresholdCelsius, DefaultTemperatureThresholdCelsius)
 	// Note: StatusFilterAttributes defaults to 0 (All), which is the zero value, so no check needed.
 	defaultInt(&s.Metrics.NotifyLevel, 2)     // MetricsNotifyLevelFail
 	defaultInt(&s.Metrics.StatusThreshold, 3) // MetricsStatusThresholdBoth

--- a/webapp/backend/pkg/models/settings_test.go
+++ b/webapp/backend/pkg/models/settings_test.go
@@ -29,6 +29,9 @@ func TestApplyDefaults_AllZeroValues(t *testing.T) {
 	require.Equal(t, 60, s.Metrics.MissedPingTimeoutMinutes)
 	require.Equal(t, 5, s.Metrics.MissedPingCheckIntervalMins)
 	require.Equal(t, 24, s.Metrics.HeartbeatIntervalHours)
+	require.Equal(t, DefaultTemperatureThresholdCelsius, s.Metrics.TemperatureThresholdCelsius)
+	require.Zero(t, s.Metrics.TemperatureDurationMinutes)
+	require.False(t, s.Metrics.NotifyOnTemperature)
 
 	// Metrics scheduled report defaults
 	require.Equal(t, "08:00", s.Metrics.ReportDailyTime)
@@ -71,6 +74,8 @@ func TestApplyDefaults_PreservesExistingValues(t *testing.T) {
 	s.Metrics.MissedPingTimeoutMinutes = 30
 	s.Metrics.MissedPingCheckIntervalMins = 10
 	s.Metrics.HeartbeatIntervalHours = 12
+	s.Metrics.TemperatureThresholdCelsius = 65
+	s.Metrics.TemperatureDurationMinutes = 0
 	s.Metrics.ReportDailyTime = "03:00"
 	s.Metrics.ReportWeeklyDay = 5
 	s.Metrics.ReportWeeklyTime = "09:00"
@@ -95,6 +100,8 @@ func TestApplyDefaults_PreservesExistingValues(t *testing.T) {
 	require.Equal(t, 30, s.Metrics.MissedPingTimeoutMinutes)
 	require.Equal(t, 10, s.Metrics.MissedPingCheckIntervalMins)
 	require.Equal(t, 12, s.Metrics.HeartbeatIntervalHours)
+	require.Equal(t, 65, s.Metrics.TemperatureThresholdCelsius)
+	require.Zero(t, s.Metrics.TemperatureDurationMinutes)
 	require.Equal(t, "03:00", s.Metrics.ReportDailyTime)
 	require.Equal(t, 5, s.Metrics.ReportWeeklyDay)
 	require.Equal(t, "09:00", s.Metrics.ReportWeeklyTime)

--- a/webapp/backend/pkg/notify/command_sender_test.go
+++ b/webapp/backend/pkg/notify/command_sender_test.go
@@ -1,0 +1,172 @@
+package notify
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+const commandHelperMode = "SCRUTINY_TEST_COMMAND_MODE"
+const commandHelperSafety = 10 * time.Second
+const commandTestPoll = 10 * time.Millisecond
+
+// Running the test executable as a script avoids platform-specific shell fixtures.
+func TestMain(m *testing.M) {
+	mode := os.Getenv(commandHelperMode)
+	if mode == "" {
+		os.Exit(m.Run())
+	}
+	switch mode {
+	case "output":
+		for _, key := range []string{"SUBJECT", "DATE", "FAILURE_TYPE", "DEVICE_NAME", "DEVICE_TYPE", "DEVICE_SERIAL", "MESSAGE", "HOST_ID"} {
+			fmt.Println(key + "=" + os.Getenv("SCRUTINY_"+key))
+		}
+		fmt.Println("ready")
+		fmt.Fprint(os.Stderr, "trailing stderr")
+		deadline := time.Now().Add(commandHelperSafety)
+		for time.Now().Before(deadline) {
+			if _, err := os.Stat(os.Getenv("SCRUTINY_TEST_RELEASE")); err == nil {
+				os.Exit(0)
+			}
+			time.Sleep(commandTestPoll)
+		}
+	case "block":
+		fmt.Println("ready")
+		time.Sleep(commandHelperSafety)
+	case "descendant":
+		cmd := exec.Command(os.Args[0])
+		cmd.Env = append(os.Environ(), commandHelperMode+"=block")
+		cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
+		if err := cmd.Start(); err != nil {
+			panic(err)
+		}
+		if err := os.WriteFile(os.Getenv("SCRUTINY_TEST_CHILD_PID"), []byte(strconv.Itoa(cmd.Process.Pid)), 0600); err != nil {
+			panic(err)
+		}
+		os.Exit(0)
+	case "failure":
+		fmt.Fprintln(os.Stderr, "controlled failure")
+		os.Exit(1)
+	}
+	os.Exit(1)
+}
+
+func TestScriptStreamsOutputAndPreservesEnvironment(t *testing.T) {
+	t.Setenv(commandHelperMode, "output")
+	release := filepath.Join(t.TempDir(), "release")
+	t.Setenv("SCRUTINY_TEST_RELEASE", release)
+	output, err := os.CreateTemp(t.TempDir(), "stdout")
+	require.NoError(t, err)
+	originalStdout := os.Stdout
+	os.Stdout = output
+	defer func() { os.Stdout = originalStdout; _ = output.Close() }()
+	logger := logrus.New()
+	logger.SetOutput(io.Discard)
+	n := Notify{Logger: logger, Payload: Payload{Subject: "subject", Date: "date", FailureType: "Temperature", DeviceName: "drive", DeviceType: "ATA", DeviceSerial: "serial", Message: "message", HostId: "host"}}
+	ctx, cancel := context.WithTimeout(context.Background(), commandHelperSafety)
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- n.sendScriptNotification(ctx, "script://"+os.Args[0]) }()
+	require.Eventually(t, func() bool {
+		data, _ := os.ReadFile(output.Name())
+		return strings.Contains(string(data), "stdout ready")
+	}, transportTestAllowance, commandTestPoll)
+	select {
+	case err := <-done:
+		t.Fatalf("script returned before release: %v", err)
+	default:
+	}
+	require.NoError(t, os.WriteFile(release, nil, 0600))
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(transportTestAllowance):
+		t.Fatal("script did not finish")
+	}
+	data, err := os.ReadFile(output.Name())
+	require.NoError(t, err)
+	for _, expected := range []string{" >> ", "stdout SUBJECT=subject", "DATE=date", "FAILURE_TYPE=Temperature", "DEVICE_NAME=drive", "DEVICE_TYPE=ATA", "DEVICE_SERIAL=serial", "MESSAGE=message", "HOST_ID=host", "stderr trailing stderr"} {
+		require.Contains(t, string(data), expected)
+	}
+}
+
+func TestScriptCancellationAndFailures(t *testing.T) {
+	for _, scenario := range []string{"timeout", "canceled", "failure", "missing"} {
+		t.Run(scenario, func(t *testing.T) {
+			t.Setenv(commandHelperMode, "block")
+			ctx, cancel := context.WithTimeout(context.Background(), smtpTestTimeout)
+			defer cancel()
+			path := os.Args[0]
+			switch scenario {
+			case "canceled":
+				cancel()
+			case "failure":
+				t.Setenv(commandHelperMode, "failure")
+			case "missing":
+				path = filepath.Join(t.TempDir(), "missing")
+			}
+			n := Notify{Logger: logrus.New()}
+			start := time.Now()
+			err := n.sendScriptNotification(ctx, "script://"+path)
+			require.Error(t, err)
+			require.Less(t, time.Since(start), notificationCommandWaitDelay+transportTestAllowance)
+			if scenario == "timeout" {
+				require.ErrorIs(t, err, context.DeadlineExceeded)
+			}
+			if scenario == "canceled" {
+				require.ErrorIs(t, err, context.Canceled)
+			}
+		})
+	}
+}
+
+func TestNotificationCommandsBoundInheritedPipes(t *testing.T) {
+	for _, transport := range []string{"script", "apprise"} {
+		t.Run(transport, func(t *testing.T) {
+			t.Setenv(commandHelperMode, "descendant")
+			pidFile := filepath.Join(t.TempDir(), "child.pid")
+			t.Setenv("SCRUTINY_TEST_CHILD_PID", pidFile)
+			t.Cleanup(func() {
+				data, err := os.ReadFile(pidFile)
+				if err != nil {
+					return
+				}
+				pid, err := strconv.Atoi(string(data))
+				if err != nil {
+					return
+				}
+				child, err := os.FindProcess(pid)
+				if err == nil {
+					_ = child.Kill()
+					_, _ = child.Wait()
+				}
+			})
+			n := Notify{Logger: logrus.New()}
+			var err error
+			start := time.Now()
+			if transport == "script" {
+				err = n.SendScriptNotification("script://" + os.Args[0])
+			} else {
+				original := execCommandContext
+				execCommandContext = func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
+					return exec.CommandContext(ctx, os.Args[0])
+				}
+				t.Cleanup(func() { execCommandContext = original })
+				err = n.SendAppriseNotification("apprise+logger://")
+			}
+			require.True(t, errors.Is(err, exec.ErrWaitDelay), "expected pipe cleanup failure, got %v", err)
+			require.Less(t, time.Since(start), notificationCommandWaitDelay+transportTestAllowance)
+		})
+	}
+}

--- a/webapp/backend/pkg/notify/gate.go
+++ b/webapp/backend/pkg/notify/gate.go
@@ -20,6 +20,7 @@ type NotificationGate struct {
 	collectorError map[string]time.Time // dedupe map for collector-side errors
 	mu             sync.Mutex
 	temperature    *TemperatureTracker
+	flushMu        sync.Mutex // Serializes digest flushes without blocking notification enqueue.
 }
 
 // QueuedNotification holds a notification that was deferred during quiet hours.
@@ -116,9 +117,12 @@ func (g *NotificationGate) ClearCollectorErrorState(identity string) {
 }
 
 // FlushQuietQueue checks if quiet hours have ended and sends a digest of all
-// queued notifications. Should be called periodically (e.g., at the start of
-// each missed ping check cycle).
+// queued notifications. Failed or rate-limited digests remain queued for the
+// next periodic check, regardless of whether missed ping alerts are enabled.
 func (g *NotificationGate) FlushQuietQueue(n *Notify, settings *models.Settings) {
+	g.flushMu.Lock()
+	defer g.flushMu.Unlock()
+
 	if g.isQuietHours(settings) {
 		return
 	}
@@ -130,7 +134,6 @@ func (g *NotificationGate) FlushQuietQueue(n *Notify, settings *models.Settings)
 	}
 	queued := make([]QueuedNotification, len(g.quietQueue))
 	copy(queued, g.quietQueue)
-	g.quietQueue = nil
 	g.mu.Unlock()
 
 	subject := fmt.Sprintf("Scrutiny: %d notification(s) during quiet hours", len(queued))
@@ -156,7 +159,7 @@ func (g *NotificationGate) FlushQuietQueue(n *Notify, settings *models.Settings)
 	}
 
 	if g.isRateLimited(settings) {
-		g.logger.Warnf("Quiet hours digest dropped due to rate limit")
+		g.logger.Warnf("Quiet hours digest deferred due to rate limit")
 		return
 	}
 
@@ -164,6 +167,11 @@ func (g *NotificationGate) FlushQuietQueue(n *Notify, settings *models.Settings)
 		g.logger.Warnf("Failed to send quiet hours digest: %v", err)
 		return
 	}
+	// Only remove the delivered batch; new notifications may have been queued
+	// while Send was running. flushMu prevents another flush removing it first.
+	g.mu.Lock()
+	g.quietQueue = append([]QueuedNotification(nil), g.quietQueue[len(queued):]...)
+	g.mu.Unlock()
 	g.recordSent()
 	g.logger.Infof("Sent quiet hours digest with %d queued notification(s)", len(queued))
 }

--- a/webapp/backend/pkg/notify/gate.go
+++ b/webapp/backend/pkg/notify/gate.go
@@ -19,6 +19,7 @@ type NotificationGate struct {
 	quietQueue     []QueuedNotification // queued during quiet hours
 	collectorError map[string]time.Time // dedupe map for collector-side errors
 	mu             sync.Mutex
+	temperature    *TemperatureTracker
 }
 
 // QueuedNotification holds a notification that was deferred during quiet hours.
@@ -34,8 +35,11 @@ func NewNotificationGate(logger logrus.FieldLogger) *NotificationGate {
 	return &NotificationGate{
 		logger:         logger,
 		collectorError: map[string]time.Time{},
+		temperature:    NewTemperatureTracker(),
 	}
 }
+
+func (g *NotificationGate) Temperature() *TemperatureTracker { return g.temperature }
 
 // TrySend checks rate limiting and quiet hours before dispatching a notification.
 // If quiet hours are active, the notification summary is queued for digest delivery.

--- a/webapp/backend/pkg/notify/gate.go
+++ b/webapp/backend/pkg/notify/gate.go
@@ -1,6 +1,7 @@
 package notify
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -14,13 +15,14 @@ import (
 // All notification dispatch should pass through Gate.TrySend() instead of
 // directly calling Notify.Send().
 type NotificationGate struct {
-	logger         logrus.FieldLogger
-	sentTimestamps []time.Time          // sliding window for rate limiting
-	quietQueue     []QueuedNotification // queued during quiet hours
-	collectorError map[string]time.Time // dedupe map for collector-side errors
-	mu             sync.Mutex
-	temperature    *TemperatureTracker
-	flushMu        sync.Mutex // Serializes digest flushes without blocking notification enqueue.
+	logger            logrus.FieldLogger
+	sentTimestamps    []time.Time          // sliding window for rate limiting
+	quietQueue        []QueuedNotification // queued during quiet hours
+	collectorError    map[string]time.Time // dedupe map for collector-side errors
+	mu                sync.Mutex
+	temperature       *TemperatureTracker
+	flushMu           sync.Mutex // Serializes digest flushes without blocking notification enqueue.
+	noEndpointsWarned bool       // Reset after successful delivery; retries remain enabled.
 }
 
 // QueuedNotification holds a notification that was deferred during quiet hours.
@@ -69,7 +71,7 @@ func (g *NotificationGate) TrySend(n *Notify, settings *models.Settings, bypassQ
 	}
 
 	if err := n.Send(); err != nil {
-		g.logger.Warnf("Failed to send notification: %v", err)
+		g.logSendError(n.Payload.Subject, err)
 		return false
 	}
 
@@ -164,7 +166,7 @@ func (g *NotificationGate) FlushQuietQueue(n *Notify, settings *models.Settings)
 	}
 
 	if err := n.Send(); err != nil {
-		g.logger.Warnf("Failed to send quiet hours digest: %v", err)
+		g.logSendError(n.Payload.Subject, err)
 		return
 	}
 	// Only remove the delivered batch; new notifications may have been queued
@@ -228,6 +230,22 @@ func (g *NotificationGate) recordSent() {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	g.sentTimestamps = append(g.sentTimestamps, time.Now())
+	g.noEndpointsWarned = false
+}
+
+// logSendError warns once about missing endpoints across all devices and digests.
+// Other delivery failures are always logged, and no retry state is changed.
+func (g *NotificationGate) logSendError(subject string, err error) {
+	if errors.Is(err, errNoNotificationEndpoints) {
+		g.mu.Lock()
+		alreadyWarned := g.noEndpointsWarned
+		g.noEndpointsWarned = true
+		g.mu.Unlock()
+		if alreadyWarned {
+			return
+		}
+	}
+	g.logger.Warnf("Failed to send notification %q: %v", subject, err)
 }
 
 // pruneOldTimestamps removes entries older than 1 hour from the sliding window.

--- a/webapp/backend/pkg/notify/gate_flush_test.go
+++ b/webapp/backend/pkg/notify/gate_flush_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/analogj/scrutiny/webapp/backend/pkg/models"
 	"github.com/golang/mock/gomock"
 	"github.com/sirupsen/logrus"
+	logrustest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/require"
 )
 
@@ -23,6 +24,49 @@ func newQuietFlushNotify(t *testing.T, urls ...string) *Notify {
 	cfg.EXPECT().GetStringSlice("notify.urls").Return(nil).AnyTimes()
 	cfg.EXPECT().GetString("notify.urls").Return("").AnyTimes()
 	return &Notify{Logger: logrus.New(), Config: cfg, DatabaseUrls: urls}
+}
+
+func TestGateMissingEndpointsWarnsOnceAndKeepsRetrying(t *testing.T) {
+	n := newQuietFlushNotify(t)
+	logger, hook := logrustest.NewNullLogger()
+	logger.SetLevel(logrus.WarnLevel)
+	n.Logger = logger
+	gate := NewNotificationGate(logger)
+	settings := &models.Settings{}
+	const attempts = 20
+	var workers sync.WaitGroup
+	var accepted atomic.Int32
+	for range attempts {
+		workers.Go(func() {
+			if gate.TrySend(n, settings, false) {
+				accepted.Add(1)
+			}
+		})
+	}
+	workers.Wait()
+	require.Zero(t, accepted.Load())
+	require.Len(t, hook.AllEntries(), 1, "all devices share one missing-endpoint warning")
+	require.Contains(t, hook.LastEntry().Message, "no notification endpoints configured")
+
+	require.True(t, gate.TrySend(&Notify{Payload: Payload{Subject: "Hot drive"}}, activeQuietSettings(), false))
+	gate.FlushQuietQueue(n, settings)
+	gate.FlushQuietQueue(n, settings)
+	require.Len(t, hook.AllEntries(), 1, "digest retries must share the warning suppression")
+	require.Equal(t, 1, gate.QueueLength())
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+	n.DatabaseUrls = []string{server.URL}
+	gate.FlushQuietQueue(n, settings)
+	require.Zero(t, gate.QueueLength(), "adding an endpoint must deliver the pending digest")
+	require.True(t, gate.TrySend(n, settings, false))
+
+	n.DatabaseUrls = nil
+	require.False(t, gate.TrySend(n, settings, false))
+	require.False(t, gate.TrySend(n, settings, false))
+	require.Len(t, hook.AllEntries(), 2, "successful delivery re-arms the warning")
 }
 
 func activeQuietSettings() *models.Settings {

--- a/webapp/backend/pkg/notify/gate_flush_test.go
+++ b/webapp/backend/pkg/notify/gate_flush_test.go
@@ -1,0 +1,164 @@
+package notify
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	mock_config "github.com/analogj/scrutiny/webapp/backend/pkg/config/mock"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/models"
+	"github.com/golang/mock/gomock"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+const quietFlushTestTimeout = 5 * time.Second
+
+func newQuietFlushNotify(t *testing.T, urls ...string) *Notify {
+	t.Helper()
+	cfg := mock_config.NewMockInterface(gomock.NewController(t))
+	cfg.EXPECT().GetStringSlice("notify.urls").Return(nil).AnyTimes()
+	cfg.EXPECT().GetString("notify.urls").Return("").AnyTimes()
+	return &Notify{Logger: logrus.New(), Config: cfg, DatabaseUrls: urls}
+}
+
+func activeQuietSettings() *models.Settings {
+	now := time.Now()
+	settings := &models.Settings{}
+	settings.Metrics.NotificationQuietStart = now.Add(-time.Hour).Format("15:04")
+	settings.Metrics.NotificationQuietEnd = now.Add(time.Hour).Format("15:04")
+	return settings
+}
+
+func TestFlushQuietQueueRetainsUntilDelivered(t *testing.T) {
+	for _, scenario := range []string{"quiet hours", "rate limited", "send failure", "no endpoints"} {
+		t.Run(scenario, func(t *testing.T) {
+			var calls atomic.Int32
+			var status atomic.Int32
+			status.Store(http.StatusNoContent)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				calls.Add(1)
+				w.WriteHeader(int(status.Load()))
+			}))
+			defer server.Close()
+			n := newQuietFlushNotify(t, server.URL)
+			gate := NewNotificationGate(n.Logger)
+			n.Payload = Payload{Subject: "Hot drive", Message: "First line\nSecond line"}
+			require.True(t, gate.TrySend(n, activeQuietSettings(), false))
+			settings := &models.Settings{}
+			var failedRequests int32
+			switch scenario {
+			case "quiet hours":
+				settings = activeQuietSettings()
+			case "rate limited":
+				settings.Metrics.NotificationRateLimit = 1
+				gate.recordSent()
+			case "send failure":
+				status.Store(http.StatusInternalServerError)
+				failedRequests = 1
+			case "no endpoints":
+				n.DatabaseUrls = nil
+			}
+
+			gate.FlushQuietQueue(n, settings)
+			require.Equal(t, 1, gate.QueueLength(), "undelivered alerts must remain queued")
+			require.Equal(t, failedRequests, calls.Load())
+
+			status.Store(http.StatusNoContent)
+			n.DatabaseUrls = []string{server.URL}
+			gate.FlushQuietQueue(n, &models.Settings{})
+			require.Zero(t, gate.QueueLength())
+			require.Equal(t, failedRequests+1, calls.Load())
+			require.Equal(t, "Scrutiny: 1 notification(s) during quiet hours", n.Payload.Subject)
+			require.Contains(t, n.Payload.Message, "Hot drive")
+			require.Contains(t, n.Payload.Message, "First line")
+			require.NotContains(t, n.Payload.Message, "Second line")
+
+			gate.FlushQuietQueue(n, &models.Settings{})
+			require.Equal(t, failedRequests+1, calls.Load(), "an empty queue must not resend")
+		})
+	}
+}
+
+func TestFlushQuietQueuePreservesConcurrentEnqueue(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var unblock sync.Once
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if calls.Add(1) == 1 {
+			close(started)
+			<-release
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+	defer unblock.Do(func() { close(release) })
+	n := newQuietFlushNotify(t, server.URL)
+	gate := NewNotificationGate(n.Logger)
+	require.True(t, gate.TrySend(&Notify{Payload: Payload{Subject: "First drive"}}, activeQuietSettings(), false))
+	done := make(chan struct{})
+	go func() {
+		gate.FlushQuietQueue(n, &models.Settings{})
+		close(done)
+	}()
+	select {
+	case <-started:
+	case <-time.After(quietFlushTestTimeout):
+		t.Fatal("digest delivery did not start")
+	}
+
+	enqueued := make(chan bool, 1)
+	go func() {
+		enqueued <- gate.TrySend(&Notify{Payload: Payload{Subject: "Second drive"}}, activeQuietSettings(), false)
+	}()
+	select {
+	case accepted := <-enqueued:
+		require.True(t, accepted)
+	case <-time.After(quietFlushTestTimeout):
+		t.Fatal("enqueue blocked behind delivery")
+	}
+	require.Equal(t, 2, gate.QueueLength(), "in-flight alerts remain queued until delivery succeeds")
+	unblock.Do(func() { close(release) })
+	select {
+	case <-done:
+	case <-time.After(quietFlushTestTimeout):
+		t.Fatal("digest delivery did not finish")
+	}
+	require.Equal(t, 1, gate.QueueLength())
+	require.Contains(t, n.Payload.Message, "First drive")
+	require.NotContains(t, n.Payload.Message, "Second drive")
+	gate.FlushQuietQueue(n, &models.Settings{})
+	require.Zero(t, gate.QueueLength())
+	require.EqualValues(t, 2, calls.Load())
+	require.Contains(t, n.Payload.Message, "Second drive")
+	require.NotContains(t, n.Payload.Message, "First drive")
+}
+
+func TestFlushQuietQueueConcurrentFlushesSendOnce(t *testing.T) {
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+	gate := NewNotificationGate(logrus.New())
+	require.True(t, gate.TrySend(&Notify{Payload: Payload{Subject: "Hot drive"}}, activeQuietSettings(), false))
+	const flushes = 20
+	var workers sync.WaitGroup
+	start := make(chan struct{})
+	for range flushes {
+		n := newQuietFlushNotify(t, server.URL)
+		workers.Go(func() {
+			<-start
+			gate.FlushQuietQueue(n, &models.Settings{})
+		})
+	}
+	close(start)
+	workers.Wait()
+	require.EqualValues(t, 1, calls.Load())
+	require.Zero(t, gate.QueueLength())
+}

--- a/webapp/backend/pkg/notify/notify.go
+++ b/webapp/backend/pkg/notify/notify.go
@@ -684,7 +684,13 @@ func (n *Notify) SendAppriseNotification(rawURL string) error {
 	return nil
 }
 
+const webhookRequestTimeout = 10 * time.Second
+
 func (n *Notify) SendWebhookNotification(webhookUrl string) error {
+	return n.sendWebhookNotification(webhookUrl, &http.Client{Timeout: webhookRequestTimeout})
+}
+
+func (n *Notify) sendWebhookNotification(webhookUrl string, client *http.Client) error {
 	n.Logger.Infof("Sending Webhook to %s", webhookUrl)
 	requestBody, err := json.Marshal(n.Payload)
 	if err != nil {
@@ -692,13 +698,15 @@ func (n *Notify) SendWebhookNotification(webhookUrl string) error {
 		return err
 	}
 
-	resp, err := http.Post(webhookUrl, "application/json", bytes.NewBuffer(requestBody))
+	resp, err := client.Post(webhookUrl, "application/json", bytes.NewBuffer(requestBody))
 	if err != nil {
 		n.Logger.Errorf("An error occurred while sending Webhook to %s: %v", webhookUrl, err)
 		return err
 	}
 	defer resp.Body.Close()
-	//we don't care about resp body content, but maybe we should log it?
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return fmt.Errorf("webhook returned HTTP %s", resp.Status)
+	}
 	return nil
 }
 

--- a/webapp/backend/pkg/notify/notify.go
+++ b/webapp/backend/pkg/notify/notify.go
@@ -61,6 +61,8 @@ const appriseCommandTimeout = 30 * time.Second
 
 var execCommandContext = exec.CommandContext
 
+var errNoNotificationEndpoints = errors.New("no notification endpoints configured")
+
 // requiredNotifyStatuses returns the device and attribute statuses that qualify for notification
 // given the configured status threshold and notify level.
 func requiredNotifyStatuses(statusThreshold pkg.MetricsStatusThreshold, notifyLevel pkg.MetricsNotifyLevel) (pkg.DeviceStatus, pkg.AttributeStatus) {
@@ -526,8 +528,7 @@ func (n *Notify) Send() error {
 		uniqueUrls, len(configUrls), len(uniqueUrls))
 
 	if len(uniqueUrls) == 0 {
-		n.Logger.Warnf("No notification endpoints configured. Cannot send notification.")
-		return errors.New("no notification endpoints configured")
+		return errNoNotificationEndpoints
 	}
 
 	return n.sendToUrls(uniqueUrls)

--- a/webapp/backend/pkg/notify/notify.go
+++ b/webapp/backend/pkg/notify/notify.go
@@ -48,6 +48,7 @@ const NotifyFailureTypeBothFailure = "SmartFailure" //SmartFailure always takes 
 const NotifyFailureTypeSmartFailure = "SmartFailure"
 const NotifyFailureTypeScrutinyFailure = "ScrutinyFailure"
 const NotifyFailureTypeMissedPing = "MissedPing"
+const NotifyFailureTypeTemperature = "Temperature"
 const NotifyFailureTypeHeartbeat = "Heartbeat"
 const NotifyFailureTypePerformanceDegradation = "PerformanceDegradation"
 const NotifyFailureTypeReport = "Report"

--- a/webapp/backend/pkg/notify/notify.go
+++ b/webapp/backend/pkg/notify/notify.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"html"
+	"log"
 	"net/http"
 	"net/url"
 	"os"
@@ -24,6 +25,7 @@ import (
 	"github.com/analogj/scrutiny/webapp/backend/pkg/overrides"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/thresholds"
 	"github.com/gin-gonic/gin"
+	"github.com/kvz/logstreamer"
 	"github.com/nicholas-fedor/shoutrrr"
 	shoutrrrTypes "github.com/nicholas-fedor/shoutrrr/pkg/types"
 	"github.com/sirupsen/logrus"
@@ -58,6 +60,9 @@ const AppriseURLPrefix = "apprise+"
 
 const appriseCommandName = "apprise"
 const appriseCommandTimeout = 30 * time.Second
+const scriptCommandTimeout = 30 * time.Second
+const notificationCommandWaitDelay = time.Second
+const scriptLogPrefix = " >> "
 
 var execCommandContext = exec.CommandContext
 
@@ -661,6 +666,7 @@ func (n *Notify) SendAppriseNotification(rawURL string) error {
 		targetURL,
 	}
 	cmd := execCommandContext(ctx, appriseCommandName, args...)
+	cmd.WaitDelay = notificationCommandWaitDelay
 	cmd.Stdin = strings.NewReader(body)
 
 	var stdout bytes.Buffer
@@ -712,13 +718,19 @@ func (n *Notify) sendWebhookNotification(webhookUrl string, client *http.Client)
 }
 
 func (n *Notify) SendScriptNotification(scriptUrl string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), scriptCommandTimeout)
+	defer cancel()
+	return n.sendScriptNotification(ctx, scriptUrl)
+}
+
+func (n *Notify) sendScriptNotification(ctx context.Context, scriptUrl string) error {
 	//check if the script exists.
 	scriptPath := strings.TrimPrefix(scriptUrl, "script://")
 	n.Logger.Infof("Executing Script %s", scriptPath)
 
 	if !utils.FileExists(scriptPath) {
 		n.Logger.Errorf("Script does not exist: %s", scriptPath)
-		return errors.New(fmt.Sprintf("custom script path does not exist: %s", scriptPath))
+		return fmt.Errorf("custom script path does not exist: %s", scriptPath)
 	}
 
 	copyEnv := os.Environ()
@@ -732,8 +744,22 @@ func (n *Notify) SendScriptNotification(scriptUrl string) error {
 	if len(n.Payload.HostId) > 0 {
 		copyEnv = append(copyEnv, fmt.Sprintf("SCRUTINY_HOST_ID=%s", n.Payload.HostId))
 	}
-	err := utils.CmdExec(scriptPath, []string{}, "", copyEnv, "")
+	// Preserve live script output on raw stdout, independent of the application
+	// logger. Separate streamers retain stream labels and flush trailing lines.
+	logger := log.New(os.Stdout, scriptLogPrefix, log.Ldate|log.Ltime)
+	stdout := logstreamer.NewLogstreamer(logger, "stdout", false)
+	stderr := logstreamer.NewLogstreamer(logger, "stderr", false)
+	defer stdout.Close()
+	defer stderr.Close()
+	cmd := exec.CommandContext(ctx, scriptPath)
+	cmd.Env = copyEnv
+	cmd.Stdout, cmd.Stderr = stdout, stderr
+	cmd.WaitDelay = notificationCommandWaitDelay
+	err := cmd.Run()
 	if err != nil {
+		if ctx.Err() != nil {
+			err = fmt.Errorf("script notification interrupted: %w", ctx.Err())
+		}
 		n.Logger.Errorf("An error occurred while executing script %s: %v", scriptPath, err)
 		return err
 	}
@@ -756,6 +782,11 @@ func (n *Notify) SendShoutrrrNotification(shoutrrrUrl string) error {
 		senderUrl = appendQueryParam(senderUrl, "usehtml=Yes")
 	}
 
+	// Audited with Shoutrrr v0.17.0: router sends time out after 10s. Sender
+	// construction is synchronous; only Matrix initializes over the network,
+	// using up to two HTTP requests with 10s deadlines. Re-audit initialization
+	// and send bounds on dependency upgrades (including the v0.19.0 update).
+	// Do not wrap construction in a timeout goroutine that abandons live work.
 	sender, err := shoutrrr.CreateSender(senderUrl)
 	if err != nil {
 		n.Logger.Errorf("An error occurred while sending notifications %v: %v", shoutrrrUrl, err)

--- a/webapp/backend/pkg/notify/smtp_sender.go
+++ b/webapp/backend/pkg/notify/smtp_sender.go
@@ -19,6 +19,8 @@ import (
 	shoutrrrsmtp "github.com/nicholas-fedor/shoutrrr/pkg/services/email/smtp"
 )
 
+const smtpDefaultTimeout = 10 * time.Second
+
 func (n *Notify) SendSMTPNotification(rawURL string) error {
 	serviceURL, err := url.Parse(rawURL)
 	if err != nil {
@@ -69,10 +71,13 @@ func (n *Notify) buildSMTPConfig(serviceURL *url.URL) (*shoutrrrsmtp.Config, err
 		UseHTML:     n.Payload.HTMLMessage != "",
 		Encryption:  shoutrrrsmtp.EncMethods.Auto,
 		ClientHost:  "localhost",
-		Timeout:     10 * time.Second,
+		Timeout:     smtpDefaultTimeout,
 	}
 	if err := config.SetURL(serviceURL); err != nil {
 		return nil, fmt.Errorf("failed to parse smtp config: %w", err)
+	}
+	if config.Timeout <= 0 {
+		return nil, fmt.Errorf("smtp timeout must be greater than zero")
 	}
 	if config.Auth == shoutrrrsmtp.AuthTypes.Unknown {
 		if config.Username != "" {
@@ -165,6 +170,14 @@ func openSMTPClient(ctx context.Context, config *shoutrrrsmtp.Config) (*smtp.Cli
 		return nil, fmt.Errorf("smtp connect failed: %w", err)
 	}
 
+	// The caller supplies one timeout for the entire conversation, including
+	// the greeting read by NewClient and any subsequent STARTTLS handshake.
+	if deadline, ok := ctx.Deadline(); ok {
+		if err = conn.SetDeadline(deadline); err != nil {
+			_ = conn.Close()
+			return nil, fmt.Errorf("smtp deadline failed: %w", err)
+		}
+	}
 	client, err := smtp.NewClient(conn, config.Host)
 	if err != nil {
 		_ = conn.Close()

--- a/webapp/backend/pkg/notify/smtp_sender_test.go
+++ b/webapp/backend/pkg/notify/smtp_sender_test.go
@@ -1,0 +1,103 @@
+package notify
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"net"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+const smtpTestTimeout = 100 * time.Millisecond
+const transportTestAllowance = 2 * time.Second
+
+func TestSMTPTimeoutConfiguration(t *testing.T) {
+	for _, tc := range []struct {
+		value   string
+		want    time.Duration
+		invalid bool
+	}{
+		{"", 10 * time.Second, false}, {"30s", 30 * time.Second, false},
+		{"0s", 0, true}, {"-1s", 0, true}, {"invalid", 0, true},
+	} {
+		t.Run(tc.value, func(t *testing.T) {
+			u, err := url.Parse("smtp://localhost/?fromaddress=sender@example.com&toaddresses=recipient@example.com")
+			require.NoError(t, err)
+			if tc.value != "" {
+				q := u.Query()
+				q.Set("timeout", tc.value)
+				u.RawQuery = q.Encode()
+			}
+			n := Notify{}
+			cfg, err := n.buildSMTPConfig(u)
+			if tc.invalid {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, cfg.Timeout)
+		})
+	}
+}
+
+func TestSMTPDeadlineBoundsConversation(t *testing.T) {
+	for _, phase := range []string{"greeting", "data"} {
+		t.Run(phase, func(t *testing.T) {
+			listener, err := net.Listen("tcp", "127.0.0.1:0")
+			require.NoError(t, err)
+			defer listener.Close()
+			stalled := make(chan struct{})
+			closed := make(chan struct{})
+			go func() {
+				defer close(closed)
+				conn, acceptErr := listener.Accept()
+				if acceptErr != nil {
+					return
+				}
+				defer conn.Close()
+				// Safety deadline makes a broken implementation fail instead of hanging the suite.
+				_ = conn.SetDeadline(time.Now().Add(2 * transportTestAllowance))
+				if phase == "greeting" {
+					close(stalled)
+					_, _ = io.Copy(io.Discard, conn)
+					return
+				}
+				_, _ = fmt.Fprint(conn, "220 test ESMTP\r\n")
+				reader := bufio.NewReader(conn)
+				for {
+					line, readErr := reader.ReadString('\n')
+					if readErr != nil {
+						return
+					}
+					if strings.HasPrefix(line, "DATA") {
+						close(stalled)
+						_, _ = io.Copy(io.Discard, conn)
+						return
+					}
+					_, _ = fmt.Fprint(conn, "250 OK\r\n")
+				}
+			}()
+			n := Notify{Logger: logrus.New(), Payload: Payload{Subject: "test", Message: "body"}}
+			start := time.Now()
+			err = n.SendSMTPNotification("smtp://" + listener.Addr().String() + "/?fromaddress=sender@example.com&toaddresses=recipient@example.com&usestarttls=No&auth=None&timeout=" + smtpTestTimeout.String())
+			require.Error(t, err)
+			require.Less(t, time.Since(start), smtpTestTimeout+transportTestAllowance)
+			select {
+			case <-stalled:
+			default:
+				t.Fatal("server never reached the intended stall")
+			}
+			select {
+			case <-closed:
+			case <-time.After(transportTestAllowance):
+				t.Fatal("SMTP connection was not closed")
+			}
+		})
+	}
+}

--- a/webapp/backend/pkg/notify/temperature.go
+++ b/webapp/backend/pkg/notify/temperature.go
@@ -17,18 +17,18 @@ import (
 // Each device has its own lock so history reads and delivery retries cannot race
 // with a reset or another upload, while unrelated drives proceed independently.
 type TemperatureTracker struct {
-	mu      sync.Mutex
 	devices map[string]*temperatureState
+	mu      sync.Mutex
 }
 
 type temperatureState struct {
-	mu         sync.Mutex
 	since      time.Time
+	mu         sync.Mutex
+	threshold  int
+	duration   time.Duration
 	notified   bool
 	canSeed    bool
 	configured bool
-	threshold  int
-	duration   time.Duration
 }
 
 func NewTemperatureTracker() *TemperatureTracker {

--- a/webapp/backend/pkg/notify/temperature.go
+++ b/webapp/backend/pkg/notify/temperature.go
@@ -142,7 +142,11 @@ func NewTemperatureNotify(logger logrus.FieldLogger, appconfig config.Interface,
 	if elapsed < 0 {
 		elapsed = 0
 	}
-	condition := fmt.Sprintf("%s >= %s for %s", formatTemperature(tempC, unit), formatTemperature(int64(thresholdC), unit), elapsed)
+	elapsedText := strings.TrimSuffix(elapsed.String(), "0s")
+	if elapsed == 0 {
+		elapsedText = "0m"
+	}
+	condition := fmt.Sprintf("%s >= %s for %s", formatTemperature(tempC, unit), formatTemperature(int64(thresholdC), unit), elapsedText)
 	payload.Subject = fmt.Sprintf("Scrutiny temperature alert (%s) on %s", condition, formatSubjectDevice(identifier, payload.HostId))
 	rows := [][2]string{
 		{notifyRowFailureType, NotifyFailureTypeTemperature},

--- a/webapp/backend/pkg/notify/temperature.go
+++ b/webapp/backend/pkg/notify/temperature.go
@@ -1,0 +1,189 @@
+package notify
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/analogj/scrutiny/webapp/backend/pkg/config"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/models"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/models/measurements"
+	"github.com/sirupsen/logrus"
+)
+
+// Each device has its own lock so history reads and delivery retries cannot race
+// with a reset or another upload, while unrelated drives proceed independently.
+type TemperatureTracker struct {
+	mu      sync.Mutex
+	devices map[string]*temperatureState
+}
+
+type temperatureState struct {
+	mu         sync.Mutex
+	since      time.Time
+	notified   bool
+	canSeed    bool
+	configured bool
+	threshold  int
+	duration   time.Duration
+}
+
+func NewTemperatureTracker() *TemperatureTracker {
+	return &TemperatureTracker{devices: make(map[string]*temperatureState)}
+}
+
+func (t *TemperatureTracker) state(deviceID string) *temperatureState {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	state, exists := t.devices[deviceID]
+	if !exists {
+		state = &temperatureState{canSeed: true}
+		t.devices[deviceID] = state
+	}
+	return state
+}
+
+func (t *TemperatureTracker) HasState(deviceID string) bool {
+	s := t.state(deviceID)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return !s.since.IsZero()
+}
+
+func (t *TemperatureTracker) Unmark(deviceID string) {
+	s := t.state(deviceID)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.notified = false
+}
+
+// Forget retains a tombstone: resuming must not revive an earlier hot history.
+func (t *TemperatureTracker) Forget(deviceID string) {
+	s := t.state(deviceID)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.reset()
+}
+
+func (s *temperatureState) reset() {
+	s.since = time.Time{}
+	s.notified = false
+	s.canSeed = false
+}
+
+func (t *TemperatureTracker) Observe(deviceID string, tempC int64, thresholdC int, minDuration time.Duration, now, firstSeen time.Time) (bool, time.Time) {
+	s := t.state(deviceID)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.observe(tempC, thresholdC, minDuration, now, firstSeen)
+}
+
+func (s *temperatureState) observe(tempC int64, thresholdC int, minDuration time.Duration, now, firstSeen time.Time) (bool, time.Time) {
+	if s.configured && (s.threshold != thresholdC || s.duration != minDuration) {
+		s.reset()
+	}
+	s.configured, s.threshold, s.duration = true, thresholdC, minDuration
+	if tempC <= 0 {
+		return false, s.since
+	}
+	if tempC < int64(thresholdC) {
+		s.reset()
+		return false, s.since
+	}
+	if s.since.IsZero() {
+		s.since = now
+		if s.canSeed && !firstSeen.IsZero() && !firstSeen.After(now) {
+			s.since = firstSeen
+		}
+	}
+	s.canSeed = false
+	if !s.notified && now.Sub(s.since) >= minDuration {
+		s.notified = true
+		return true, s.since
+	}
+	return false, s.since
+}
+
+// Evaluate serializes the entire observation/send transaction for one device.
+// A failed send preserves the streak and retries on the next hot upload.
+func (t *TemperatureTracker) Evaluate(deviceID string, enabled bool, tempC int64, thresholdC int, minDuration time.Duration, now time.Time, seed func() time.Time, send func(time.Time) bool) {
+	s := t.state(deviceID)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !enabled {
+		s.reset()
+		return
+	}
+	var firstSeen time.Time
+	if s.canSeed && tempC > 0 && tempC >= int64(thresholdC) && seed != nil {
+		firstSeen = seed()
+	}
+	if fire, since := s.observe(tempC, thresholdC, minDuration, now, firstSeen); fire {
+		s.notified = send(since)
+	}
+}
+
+// ExceededSince finds the current hot run without changing the caller's slice.
+// Unknown readings do not break a run. Invalid/future timestamps are ignored.
+func ExceededSince(history []measurements.SmartTemperature, thresholdC int, fallback time.Time) time.Time {
+	points := append([]measurements.SmartTemperature(nil), history...)
+	sort.SliceStable(points, func(i, j int) bool { return points[i].Date.Before(points[j].Date) })
+	since := fallback
+	for i := len(points) - 1; i >= 0; i-- {
+		point := points[i]
+		if point.Date.IsZero() || point.Date.After(fallback) || point.Temp <= 0 {
+			continue
+		}
+		if point.Temp < int64(thresholdC) {
+			break
+		}
+		since = point.Date
+	}
+	return since
+}
+
+func formatTemperature(c int64, unit string) string {
+	const fahrenheitScale = 9.0 / 5.0
+	const fahrenheitOffset = 32
+	const fahrenheitDecimalPlaces = 1 // Whole Celsius degrees convert to tenths of Fahrenheit.
+	if unit == "fahrenheit" {
+		value := strconv.FormatFloat(float64(c)*fahrenheitScale+fahrenheitOffset, 'f', fahrenheitDecimalPlaces, 64)
+		return strings.TrimSuffix(value, ".0") + "°F"
+	}
+	return fmt.Sprintf("%d°C", c)
+}
+
+func NewTemperatureNotify(logger logrus.FieldLogger, appconfig config.Interface, device *models.Device, tempC int64, thresholdC int, since, now time.Time, unit string) Notify {
+	payload := NewPayload(*device, false)
+	payload.FailureType = NotifyFailureTypeTemperature
+	identifier := device.DeviceName
+	if label := strings.TrimSpace(device.Label); label != "" {
+		identifier = fmt.Sprintf(fmtLabelWithName, label, identifier)
+	}
+	if host := strings.TrimSpace(device.HostId); host != "" {
+		identifier = fmt.Sprintf("[%s]%s", host, identifier)
+	}
+	elapsed := now.Sub(since).Truncate(time.Minute)
+	if elapsed < 0 {
+		elapsed = 0
+	}
+	condition := fmt.Sprintf("%s >= %s for %s", formatTemperature(tempC, unit), formatTemperature(int64(thresholdC), unit), elapsed)
+	payload.Subject = fmt.Sprintf("Scrutiny temperature alert (%s) on device: %s", condition, identifier)
+	rows := [][2]string{
+		{notifyRowFailureType, NotifyFailureTypeTemperature},
+		{"Temperature", condition}, {"Device", identifier},
+		{notifyRowDeviceSerial, device.SerialNumber}, {notifyRowDeviceType, device.DeviceType},
+		{"Exceeded Since", since.Format(time.RFC3339)}, {"Date", payload.Date},
+	}
+	parts := []string{payload.Subject}
+	for _, row := range rows {
+		parts = append(parts, row[0]+": "+row[1])
+	}
+	payload.Message = strings.Join(parts, "\n")
+	const temperatureBannerColor = "#f59e0b"
+	payload.HTMLMessage = formatNotificationHTML(payload.Subject, "Scrutiny temperature notification", "HIGH TEMPERATURE", temperatureBannerColor, rows, notifyFooterText)
+	return Notify{Logger: logger, Config: appconfig, Payload: payload}
+}

--- a/webapp/backend/pkg/notify/temperature.go
+++ b/webapp/backend/pkg/notify/temperature.go
@@ -138,15 +138,12 @@ func NewTemperatureNotify(logger logrus.FieldLogger, appconfig config.Interface,
 	if label := strings.TrimSpace(device.Label); label != "" {
 		identifier = fmt.Sprintf(fmtLabelWithName, label, identifier)
 	}
-	if host := strings.TrimSpace(device.HostId); host != "" {
-		identifier = fmt.Sprintf("[%s]%s", host, identifier)
-	}
 	elapsed := now.Sub(since).Truncate(time.Minute)
 	if elapsed < 0 {
 		elapsed = 0
 	}
 	condition := fmt.Sprintf("%s >= %s for %s", formatTemperature(tempC, unit), formatTemperature(int64(thresholdC), unit), elapsed)
-	payload.Subject = fmt.Sprintf("Scrutiny temperature alert (%s) on device: %s", condition, identifier)
+	payload.Subject = fmt.Sprintf("Scrutiny temperature alert (%s) on %s", condition, formatSubjectDevice(identifier, payload.HostId))
 	rows := [][2]string{
 		{notifyRowFailureType, NotifyFailureTypeTemperature},
 		{"Temperature", condition}, {"Device", identifier},

--- a/webapp/backend/pkg/notify/temperature.go
+++ b/webapp/backend/pkg/notify/temperature.go
@@ -46,20 +46,6 @@ func (t *TemperatureTracker) state(deviceID string) *temperatureState {
 	return state
 }
 
-func (t *TemperatureTracker) HasState(deviceID string) bool {
-	s := t.state(deviceID)
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return !s.since.IsZero()
-}
-
-func (t *TemperatureTracker) Unmark(deviceID string) {
-	s := t.state(deviceID)
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.notified = false
-}
-
 // Forget retains a tombstone: resuming must not revive an earlier hot history.
 func (t *TemperatureTracker) Forget(deviceID string) {
 	s := t.state(deviceID)
@@ -72,13 +58,6 @@ func (s *temperatureState) reset() {
 	s.since = time.Time{}
 	s.notified = false
 	s.canSeed = false
-}
-
-func (t *TemperatureTracker) Observe(deviceID string, tempC int64, thresholdC int, minDuration time.Duration, now, firstSeen time.Time) (bool, time.Time) {
-	s := t.state(deviceID)
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.observe(tempC, thresholdC, minDuration, now, firstSeen)
 }
 
 func (s *temperatureState) observe(tempC int64, thresholdC int, minDuration time.Duration, now, firstSeen time.Time) (bool, time.Time) {
@@ -109,14 +88,10 @@ func (s *temperatureState) observe(tempC int64, thresholdC int, minDuration time
 
 // Evaluate serializes the entire observation/send transaction for one device.
 // A failed send preserves the streak and retries on the next hot upload.
-func (t *TemperatureTracker) Evaluate(deviceID string, enabled bool, tempC int64, thresholdC int, minDuration time.Duration, now time.Time, seed func() time.Time, send func(time.Time) bool) {
+func (t *TemperatureTracker) Evaluate(deviceID string, tempC int64, thresholdC int, minDuration time.Duration, now time.Time, seed func() time.Time, send func(time.Time) bool) {
 	s := t.state(deviceID)
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if !enabled {
-		s.reset()
-		return
-	}
 	var firstSeen time.Time
 	if s.canSeed && tempC > 0 && tempC >= int64(thresholdC) && seed != nil {
 		firstSeen = seed()

--- a/webapp/backend/pkg/notify/temperature_test.go
+++ b/webapp/backend/pkg/notify/temperature_test.go
@@ -121,6 +121,82 @@ func TestTemperatureEvaluationSerializesAndRetries(t *testing.T) {
 	require.EqualValues(t, 2, sends.Load())
 }
 
+func TestTemperatureStalledDeliveryAllowsResetAndRetry(t *testing.T) {
+	for _, action := range []string{"hot", "cold", "forget"} {
+		t.Run(action, func(t *testing.T) {
+			tracker := NewTemperatureTracker()
+			now := time.Now()
+			started, release, firstDone := make(chan struct{}), make(chan struct{}), make(chan struct{})
+			go func() {
+				defer close(firstDone)
+				tracker.Evaluate("drive", 60, testTemperatureThreshold, testTemperatureDuration, now,
+					func() time.Time { return now.Add(-testTemperatureDuration) },
+					func(time.Time) bool {
+						close(started)
+						select {
+						case <-release:
+						case <-time.After(transportTestAllowance):
+						}
+						return false
+					})
+			}()
+			select {
+			case <-started:
+			case <-time.After(transportTestAllowance):
+				t.Fatal("send never started")
+			}
+			// A different device must be able to finish before this send returns.
+			otherDone := make(chan struct{})
+			go func() {
+				tracker.Evaluate("other", 40, testTemperatureThreshold, testTemperatureDuration, now, nil, nil)
+				close(otherDone)
+			}()
+			select {
+			case <-otherDone:
+			case <-time.After(transportTestAllowance):
+				t.Fatal("unrelated device blocked")
+			}
+			select {
+			case <-firstDone:
+				t.Fatal("stalled send returned before release")
+			default:
+			}
+			var sent atomic.Int32
+			send := func(time.Time) bool { sent.Add(1); return true }
+			followingDone := make(chan struct{})
+			go func() {
+				defer close(followingDone)
+				switch action {
+				case "forget":
+					tracker.Forget("drive")
+				case "cold":
+					tracker.Evaluate("drive", 40, testTemperatureThreshold, testTemperatureDuration, now, nil, send)
+				case "hot":
+					tracker.Evaluate("drive", 60, testTemperatureThreshold, testTemperatureDuration, now, nil, send)
+				}
+			}()
+			close(release)
+			for _, done := range []chan struct{}{firstDone, followingDone} {
+				select {
+				case <-done:
+				case <-time.After(transportTestAllowance):
+					t.Fatal("device remained blocked after failed send")
+				}
+			}
+			if action == "hot" {
+				require.EqualValues(t, 1, sent.Load(), "failed hot send must retry")
+			} else {
+				tracker.Evaluate("drive", 60, testTemperatureThreshold, testTemperatureDuration, now, func() time.Time { t.Error("reset must not seed again"); return now.Add(-time.Hour) }, send)
+				require.Zero(t, sent.Load())
+				tracker.Evaluate("drive", 60, testTemperatureThreshold, testTemperatureDuration, now.Add(testTemperatureDuration), nil, send)
+				require.EqualValues(t, 1, sent.Load(), "fresh excursion waits the full duration")
+			}
+			tracker.Evaluate("drive", 60, testTemperatureThreshold, testTemperatureDuration, now.Add(time.Hour), nil, send)
+			require.EqualValues(t, 1, sent.Load(), "successful excursion must not repeat")
+		})
+	}
+}
+
 func TestExceededSince(t *testing.T) {
 	now := time.Now().UTC()
 	old := now.Add(-time.Hour)

--- a/webapp/backend/pkg/notify/temperature_test.go
+++ b/webapp/backend/pkg/notify/temperature_test.go
@@ -191,7 +191,7 @@ func TestTemperatureSubjectDeviceFormat(t *testing.T) {
 		t.Run(tc.suffix, func(t *testing.T) {
 			device := &models.Device{DeviceName: "/dev/sda", Label: tc.label, HostId: tc.host}
 			n := NewTemperatureNotify(logrus.New(), cfg, device, 60, testTemperatureThreshold, now, now, "celsius")
-			require.Equal(t, "Scrutiny temperature alert (60°C >= 55°C for 0s) on "+tc.suffix, n.Payload.Subject)
+			require.Equal(t, "Scrutiny temperature alert (60°C >= 55°C for 0m) on "+tc.suffix, n.Payload.Subject)
 		})
 	}
 }
@@ -202,6 +202,25 @@ func TestTemperaturePayloadPrecisionAndMissingLabels(t *testing.T) {
 	require.NoError(t, err)
 	now := time.Now()
 	n := NewTemperatureNotify(logrus.New(), cfg, &models.Device{DeviceName: "/dev/sda"}, 60, testTemperatureThreshold, now.Add(time.Hour), now, "celsius")
-	require.Contains(t, n.Payload.Subject, "for 0s")
+	require.Contains(t, n.Payload.Subject, "for 0m")
 	require.Contains(t, n.Payload.Subject, "on device: /dev/sda")
+}
+
+func TestTemperatureElapsedFormatting(t *testing.T) {
+	cfg, err := config.Create()
+	require.NoError(t, err)
+	now := time.Now()
+	for _, tc := range []struct {
+		elapsed time.Duration
+		want    string
+	}{
+		{-time.Minute, "0m"}, {0, "0m"}, {time.Second, "0m"},
+		{time.Minute, "1m"}, {testTemperatureDuration + time.Second, "30m"},
+		{time.Hour, "1h0m"}, {time.Hour + testTemperatureDuration, "1h30m"},
+	} {
+		t.Run(tc.elapsed.String(), func(t *testing.T) {
+			n := NewTemperatureNotify(logrus.New(), cfg, &models.Device{}, testTemperatureThreshold, testTemperatureThreshold, now.Add(-tc.elapsed), now, "celsius")
+			require.Contains(t, n.Payload.Subject, "for "+tc.want+")")
+		})
+	}
 }

--- a/webapp/backend/pkg/notify/temperature_test.go
+++ b/webapp/backend/pkg/notify/temperature_test.go
@@ -17,7 +17,7 @@ const testTemperatureThreshold = 55
 const testTemperatureDuration = 30 * time.Minute
 
 func TestTemperatureTrackerExcursions(t *testing.T) {
-	tracker := NewTemperatureTracker()
+	state := temperatureState{canSeed: true}
 	now := time.Date(2026, time.September, 7, 12, 0, 0, 0, time.UTC)
 	for _, step := range []struct {
 		temp    int64
@@ -35,7 +35,7 @@ func TestTemperatureTrackerExcursions(t *testing.T) {
 		{60, 2 * time.Hour, false, 2 * time.Hour},
 		{60, 2*time.Hour + testTemperatureDuration, true, 2 * time.Hour},
 	} {
-		fire, since := tracker.Observe("drive", step.temp, testTemperatureThreshold, testTemperatureDuration, now.Add(step.elapsed), time.Time{})
+		fire, since := state.observe(step.temp, testTemperatureThreshold, testTemperatureDuration, now.Add(step.elapsed), time.Time{})
 		require.Equal(t, step.fire, fire)
 		if step.since == 0 {
 			require.True(t, since.IsZero())
@@ -45,25 +45,22 @@ func TestTemperatureTrackerExcursions(t *testing.T) {
 	}
 }
 
-func TestTemperatureTrackerSeedRetryAndReset(t *testing.T) {
+func TestTemperatureStateSeedAndImmediate(t *testing.T) {
 	now := time.Now()
-	tracker := NewTemperatureTracker()
+	state := temperatureState{canSeed: true}
 	seed := now.Add(-time.Hour)
-	fire, since := tracker.Observe("drive", 60, testTemperatureThreshold, testTemperatureDuration, now, seed)
+	fire, since := state.observe(60, testTemperatureThreshold, testTemperatureDuration, now, seed)
 	require.True(t, fire)
 	require.Equal(t, seed, since)
-	require.True(t, tracker.HasState("drive"))
-	tracker.Unmark("drive")
-	fire, _ = tracker.Observe("drive", 60, testTemperatureThreshold, testTemperatureDuration, now, time.Time{})
-	require.True(t, fire)
-	tracker.Forget("drive")
-	require.False(t, tracker.HasState("drive"))
-	fire, since = tracker.Observe("drive", 60, testTemperatureThreshold, testTemperatureDuration, now, seed)
+	state.reset()
+	fire, since = state.observe(60, testTemperatureThreshold, testTemperatureDuration, now, seed)
 	require.False(t, fire)
 	require.Equal(t, now, since)
-	fire, _ = tracker.Observe("instant", 55, testTemperatureThreshold, 0, now, time.Time{})
+	state = temperatureState{canSeed: true}
+	fire, _ = state.observe(55, testTemperatureThreshold, 0, now, time.Time{})
 	require.True(t, fire)
-	fire, since = tracker.Observe("future", 55, testTemperatureThreshold, testTemperatureDuration, now, now.Add(time.Hour))
+	state = temperatureState{canSeed: true}
+	fire, since = state.observe(55, testTemperatureThreshold, testTemperatureDuration, now, now.Add(time.Hour))
 	require.False(t, fire)
 	require.Equal(t, now, since)
 }
@@ -74,9 +71,9 @@ func TestTemperatureTrackerSettingChangesReset(t *testing.T) {
 		threshold int
 		duration  time.Duration
 	}{{65, testTemperatureDuration}, {55, time.Hour}} {
-		tracker := NewTemperatureTracker()
-		tracker.Observe("drive", 60, testTemperatureThreshold, testTemperatureDuration, now, now.Add(-time.Hour))
-		fire, since := tracker.Observe("drive", 70, change.threshold, change.duration, now.Add(time.Hour), now)
+		state := temperatureState{canSeed: true}
+		state.observe(60, testTemperatureThreshold, testTemperatureDuration, now, now.Add(-time.Hour))
+		fire, since := state.observe(70, change.threshold, change.duration, now.Add(time.Hour), now)
 		require.False(t, fire)
 		require.Equal(t, now.Add(time.Hour), since)
 	}
@@ -90,8 +87,8 @@ func TestTemperatureSeedOnlyBeforeFirstKnownReading(t *testing.T) {
 		sends := 0
 		seed := func() time.Time { seedCalls++; return now.Add(-time.Hour) }
 		send := func(time.Time) bool { sends++; return true }
-		tracker.Evaluate("drive", true, initial, testTemperatureThreshold, testTemperatureDuration, now, seed, send)
-		tracker.Evaluate("drive", true, 60, testTemperatureThreshold, testTemperatureDuration, now, seed, send)
+		tracker.Evaluate("drive", initial, testTemperatureThreshold, testTemperatureDuration, now, seed, send)
+		tracker.Evaluate("drive", 60, testTemperatureThreshold, testTemperatureDuration, now, seed, send)
 		if initial == 0 {
 			require.Equal(t, 1, seedCalls)
 			require.Equal(t, 1, sends)
@@ -112,15 +109,14 @@ func TestTemperatureEvaluationSerializesAndRetries(t *testing.T) {
 	var workers sync.WaitGroup
 	for range uploads {
 		workers.Go(func() {
-			tracker.Evaluate("drive", true, 60, testTemperatureThreshold, testTemperatureDuration, now, seed, send)
+			tracker.Evaluate("drive", 60, testTemperatureThreshold, testTemperatureDuration, now, seed, send)
 		})
 	}
 	workers.Wait()
 	require.EqualValues(t, 1, seeds.Load())
 	require.EqualValues(t, 2, sends.Load(), "failed first attempt must retry once")
-	tracker.Evaluate("drive", false, 60, testTemperatureThreshold, testTemperatureDuration, now, seed, send)
-	require.False(t, tracker.HasState("drive"))
-	tracker.Evaluate("drive", true, 60, testTemperatureThreshold, testTemperatureDuration, now, seed, send)
+	tracker.Forget("drive")
+	tracker.Evaluate("drive", 60, testTemperatureThreshold, testTemperatureDuration, now, seed, send)
 	require.EqualValues(t, 1, seeds.Load(), "resume must not reuse history")
 	require.EqualValues(t, 2, sends.Load())
 }

--- a/webapp/backend/pkg/notify/temperature_test.go
+++ b/webapp/backend/pkg/notify/temperature_test.go
@@ -1,0 +1,190 @@
+package notify
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/analogj/scrutiny/webapp/backend/pkg/config"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/models"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/models/measurements"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+const testTemperatureThreshold = 55
+const testTemperatureDuration = 30 * time.Minute
+
+func TestTemperatureTrackerExcursions(t *testing.T) {
+	tracker := NewTemperatureTracker()
+	now := time.Date(2026, time.September, 7, 12, 0, 0, 0, time.UTC)
+	for _, step := range []struct {
+		temp    int64
+		elapsed time.Duration
+		fire    bool
+		since   time.Duration
+	}{
+		{0, 0, false, 0}, {-1, 0, false, 0}, {54, 0, false, 0},
+		{55, time.Minute, false, time.Minute},
+		{60, 30 * time.Minute, false, time.Minute},
+		{0, 31 * time.Minute, false, time.Minute},
+		{60, 31 * time.Minute, true, time.Minute},
+		{60, time.Hour, false, time.Minute},
+		{54, time.Hour, false, 0},
+		{60, 2 * time.Hour, false, 2 * time.Hour},
+		{60, 2*time.Hour + testTemperatureDuration, true, 2 * time.Hour},
+	} {
+		fire, since := tracker.Observe("drive", step.temp, testTemperatureThreshold, testTemperatureDuration, now.Add(step.elapsed), time.Time{})
+		require.Equal(t, step.fire, fire)
+		if step.since == 0 {
+			require.True(t, since.IsZero())
+		} else {
+			require.Equal(t, now.Add(step.since), since)
+		}
+	}
+}
+
+func TestTemperatureTrackerSeedRetryAndReset(t *testing.T) {
+	now := time.Now()
+	tracker := NewTemperatureTracker()
+	seed := now.Add(-time.Hour)
+	fire, since := tracker.Observe("drive", 60, testTemperatureThreshold, testTemperatureDuration, now, seed)
+	require.True(t, fire)
+	require.Equal(t, seed, since)
+	require.True(t, tracker.HasState("drive"))
+	tracker.Unmark("drive")
+	fire, _ = tracker.Observe("drive", 60, testTemperatureThreshold, testTemperatureDuration, now, time.Time{})
+	require.True(t, fire)
+	tracker.Forget("drive")
+	require.False(t, tracker.HasState("drive"))
+	fire, since = tracker.Observe("drive", 60, testTemperatureThreshold, testTemperatureDuration, now, seed)
+	require.False(t, fire)
+	require.Equal(t, now, since)
+	fire, _ = tracker.Observe("instant", 55, testTemperatureThreshold, 0, now, time.Time{})
+	require.True(t, fire)
+	fire, since = tracker.Observe("future", 55, testTemperatureThreshold, testTemperatureDuration, now, now.Add(time.Hour))
+	require.False(t, fire)
+	require.Equal(t, now, since)
+}
+
+func TestTemperatureTrackerSettingChangesReset(t *testing.T) {
+	now := time.Now()
+	for _, change := range []struct {
+		threshold int
+		duration  time.Duration
+	}{{65, testTemperatureDuration}, {55, time.Hour}} {
+		tracker := NewTemperatureTracker()
+		tracker.Observe("drive", 60, testTemperatureThreshold, testTemperatureDuration, now, now.Add(-time.Hour))
+		fire, since := tracker.Observe("drive", 70, change.threshold, change.duration, now.Add(time.Hour), now)
+		require.False(t, fire)
+		require.Equal(t, now.Add(time.Hour), since)
+	}
+}
+
+func TestTemperatureSeedOnlyBeforeFirstKnownReading(t *testing.T) {
+	now := time.Now()
+	for _, initial := range []int64{0, 40} {
+		tracker := NewTemperatureTracker()
+		seedCalls := 0
+		sends := 0
+		seed := func() time.Time { seedCalls++; return now.Add(-time.Hour) }
+		send := func(time.Time) bool { sends++; return true }
+		tracker.Evaluate("drive", true, initial, testTemperatureThreshold, testTemperatureDuration, now, seed, send)
+		tracker.Evaluate("drive", true, 60, testTemperatureThreshold, testTemperatureDuration, now, seed, send)
+		if initial == 0 {
+			require.Equal(t, 1, seedCalls)
+			require.Equal(t, 1, sends)
+		} else {
+			require.Zero(t, seedCalls)
+			require.Zero(t, sends)
+		}
+	}
+}
+
+func TestTemperatureEvaluationSerializesAndRetries(t *testing.T) {
+	tracker := NewTemperatureTracker()
+	now := time.Now()
+	var seeds, sends atomic.Int32
+	seed := func() time.Time { seeds.Add(1); return now.Add(-time.Hour) }
+	send := func(time.Time) bool { return sends.Add(1) > 1 }
+	const uploads = 20
+	var workers sync.WaitGroup
+	for range uploads {
+		workers.Go(func() {
+			tracker.Evaluate("drive", true, 60, testTemperatureThreshold, testTemperatureDuration, now, seed, send)
+		})
+	}
+	workers.Wait()
+	require.EqualValues(t, 1, seeds.Load())
+	require.EqualValues(t, 2, sends.Load(), "failed first attempt must retry once")
+	tracker.Evaluate("drive", false, 60, testTemperatureThreshold, testTemperatureDuration, now, seed, send)
+	require.False(t, tracker.HasState("drive"))
+	tracker.Evaluate("drive", true, 60, testTemperatureThreshold, testTemperatureDuration, now, seed, send)
+	require.EqualValues(t, 1, seeds.Load(), "resume must not reuse history")
+	require.EqualValues(t, 2, sends.Load())
+}
+
+func TestExceededSince(t *testing.T) {
+	now := time.Now().UTC()
+	old := now.Add(-time.Hour)
+	middle := now.Add(-time.Minute)
+	for _, tc := range []struct {
+		name    string
+		history []measurements.SmartTemperature
+		want    time.Time
+	}{
+		{"empty", nil, now},
+		{"cold", []measurements.SmartTemperature{{Date: old, Temp: 40}}, now},
+		{"unsorted hot", []measurements.SmartTemperature{{Date: now, Temp: 60}, {Date: old, Temp: 55}}, old},
+		{"cold boundary", []measurements.SmartTemperature{{Date: old, Temp: 60}, {Date: middle, Temp: 40}, {Date: now, Temp: 60}}, now},
+		{"unknown ignored", []measurements.SmartTemperature{{Date: old, Temp: 60}, {Date: middle, Temp: 0}, {Date: now, Temp: 55}}, old},
+		{"negative ignored", []measurements.SmartTemperature{{Date: old, Temp: 60}, {Date: now, Temp: -1}}, old},
+		{"unknown only", []measurements.SmartTemperature{{Date: old, Temp: 0}}, now},
+		{"future ignored", []measurements.SmartTemperature{{Date: now.Add(time.Hour), Temp: 60}}, now},
+		{"invalid date", []measurements.SmartTemperature{{Temp: 60}}, now},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			original := append([]measurements.SmartTemperature(nil), tc.history...)
+			require.Equal(t, tc.want, ExceededSince(tc.history, testTemperatureThreshold, now))
+			require.Equal(t, original, tc.history, "must not reorder caller history")
+		})
+	}
+}
+
+func TestNewTemperatureNotify(t *testing.T) {
+	cfg, err := config.Create()
+	require.NoError(t, err)
+	device := &models.Device{DeviceName: "/dev/sda", HostId: "nas", Label: "<hot>"}
+	now := time.Now()
+	for _, unit := range []string{"celsius", "fahrenheit", ""} {
+		n := NewTemperatureNotify(logrus.New(), cfg, device, 60, testTemperatureThreshold, now.Add(-testTemperatureDuration), now, unit)
+		require.Equal(t, NotifyFailureTypeTemperature, n.Payload.FailureType)
+		require.Contains(t, n.Payload.Subject, "30m")
+		require.Contains(t, n.Payload.Subject, "nas")
+		require.Contains(t, n.Payload.Message, "/dev/sda")
+		require.Contains(t, n.Payload.HTMLMessage, "HIGH TEMPERATURE")
+		require.Contains(t, n.Payload.HTMLMessage, "&lt;hot&gt;")
+		if unit == "fahrenheit" {
+			require.Contains(t, n.Payload.Subject, "140°F >= 131°F")
+		} else {
+			require.Contains(t, n.Payload.Subject, "60°C >= 55°C")
+		}
+	}
+}
+
+func TestGateSharesTemperatureTracker(t *testing.T) {
+	gate := NewNotificationGate(logrus.New())
+	require.NotNil(t, gate.Temperature())
+	require.Same(t, gate.Temperature(), gate.Temperature())
+}
+
+func TestTemperaturePayloadPrecisionAndMissingLabels(t *testing.T) {
+	require.Equal(t, "107.6°F", formatTemperature(42, "fahrenheit"))
+	cfg, err := config.Create()
+	require.NoError(t, err)
+	now := time.Now()
+	n := NewTemperatureNotify(logrus.New(), cfg, &models.Device{DeviceName: "/dev/sda"}, 60, testTemperatureThreshold, now.Add(time.Hour), now, "celsius")
+	require.Contains(t, n.Payload.Subject, "for 0s")
+	require.Contains(t, n.Payload.Subject, "on device: /dev/sda")
+}

--- a/webapp/backend/pkg/notify/temperature_test.go
+++ b/webapp/backend/pkg/notify/temperature_test.go
@@ -175,6 +175,27 @@ func TestGateSharesTemperatureTracker(t *testing.T) {
 	require.Same(t, gate.Temperature(), gate.Temperature())
 }
 
+func TestTemperatureSubjectDeviceFormat(t *testing.T) {
+	cfg, err := config.Create()
+	require.NoError(t, err)
+	now := time.Now()
+	for _, tc := range []struct {
+		label, host, suffix string
+	}{
+		{"", "", "device: /dev/sda"},
+		{"Backup", "", "device: Backup (/dev/sda)"},
+		{"", "nas", "device: /dev/sda (host: nas)"},
+		{" Backup ", " nas ", "device: Backup (/dev/sda) (host: nas)"},
+		{" ", " ", "device: /dev/sda"},
+	} {
+		t.Run(tc.suffix, func(t *testing.T) {
+			device := &models.Device{DeviceName: "/dev/sda", Label: tc.label, HostId: tc.host}
+			n := NewTemperatureNotify(logrus.New(), cfg, device, 60, testTemperatureThreshold, now, now, "celsius")
+			require.Equal(t, "Scrutiny temperature alert (60°C >= 55°C for 0s) on "+tc.suffix, n.Payload.Subject)
+		})
+	}
+}
+
 func TestTemperaturePayloadPrecisionAndMissingLabels(t *testing.T) {
 	require.Equal(t, "107.6°F", formatTemperature(42, "fahrenheit"))
 	cfg, err := config.Create()

--- a/webapp/backend/pkg/notify/webhook_sender_test.go
+++ b/webapp/backend/pkg/notify/webhook_sender_test.go
@@ -1,0 +1,58 @@
+package notify
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWebhookDeliveryStatus(t *testing.T) {
+	for _, status := range []int{http.StatusOK, http.StatusNoContent, http.StatusMultipleChoices, http.StatusBadRequest, http.StatusTooManyRequests, http.StatusInternalServerError} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			received := make(chan Payload, 1)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodPost || r.Header.Get("Content-Type") != "application/json" {
+					t.Error("expected JSON POST")
+				}
+				var payload Payload
+				if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+					t.Error(err)
+				}
+				received <- payload
+				w.WriteHeader(status)
+			}))
+			defer server.Close()
+			n := Notify{Logger: logrus.New(), Payload: Payload{Subject: "temperature alert"}}
+			err := n.SendWebhookNotification(server.URL)
+			if status >= http.StatusMultipleChoices {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, n.Payload.Subject, (<-received).Subject)
+		})
+	}
+}
+
+func TestWebhookDeliveryTimeout(t *testing.T) {
+	const testTimeout = 50 * time.Millisecond
+	const safetyTimeout = 2 * time.Second
+	release := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { <-release }))
+	defer server.Close()
+	defer close(release)
+	n := Notify{Logger: logrus.New()}
+	done := make(chan error, 1)
+	go func() { done <- n.sendWebhookNotification(server.URL, &http.Client{Timeout: testTimeout}) }()
+	select {
+	case err := <-done:
+		require.Error(t, err)
+	case <-time.After(safetyTimeout):
+		t.Fatal("webhook delivery did not respect the client timeout")
+	}
+}

--- a/webapp/backend/pkg/web/handler/save_settings.go
+++ b/webapp/backend/pkg/web/handler/save_settings.go
@@ -56,9 +56,8 @@ func SaveSettings(c *gin.Context) {
 }
 
 func validTemperatureNotifySettings(settings *models.Settings) bool {
-	return !settings.Metrics.NotifyOnTemperature ||
-		(settings.Metrics.TemperatureThresholdCelsius >= models.MinTemperatureThresholdCelsius &&
-			settings.Metrics.TemperatureThresholdCelsius <= models.MaxTemperatureThresholdCelsius &&
-			settings.Metrics.TemperatureDurationMinutes >= 0 &&
-			settings.Metrics.TemperatureDurationMinutes <= models.MaxTemperatureDurationMinutes)
+	return settings.Metrics.TemperatureThresholdCelsius >= models.MinTemperatureThresholdCelsius &&
+		settings.Metrics.TemperatureThresholdCelsius <= models.MaxTemperatureThresholdCelsius &&
+		settings.Metrics.TemperatureDurationMinutes >= 0 &&
+		settings.Metrics.TemperatureDurationMinutes <= models.MaxTemperatureDurationMinutes
 }

--- a/webapp/backend/pkg/web/handler/save_settings.go
+++ b/webapp/backend/pkg/web/handler/save_settings.go
@@ -1,12 +1,14 @@
 package handler
 
 import (
+	"fmt"
+	"net/http"
+
 	"github.com/analogj/scrutiny/webapp/backend/pkg/database"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/models"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/version"
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
-	"net/http"
 )
 
 func SaveSettings(c *gin.Context) {
@@ -18,6 +20,10 @@ func SaveSettings(c *gin.Context) {
 	if err != nil {
 		logger.Errorln("Cannot parse updated settings", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
+		return
+	}
+	if !validTemperatureNotifySettings(&settings) {
+		c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": fmt.Sprintf("temperature_threshold_celsius must be %d..%d and temperature_duration_minutes must be 0..%d", models.MinTemperatureThresholdCelsius, models.MaxTemperatureThresholdCelsius, models.MaxTemperatureDurationMinutes)})
 		return
 	}
 	settings.ApplyDefaults()
@@ -44,4 +50,12 @@ func SaveSettings(c *gin.Context) {
 		"collector_trigger_enabled":      collectorTriggerEnabled(),
 		"zfs_pool_modifications_allowed": zfsPoolModificationsAllowed(c),
 	})
+}
+
+func validTemperatureNotifySettings(settings *models.Settings) bool {
+	return !settings.Metrics.NotifyOnTemperature ||
+		(settings.Metrics.TemperatureThresholdCelsius >= models.MinTemperatureThresholdCelsius &&
+			settings.Metrics.TemperatureThresholdCelsius <= models.MaxTemperatureThresholdCelsius &&
+			settings.Metrics.TemperatureDurationMinutes >= 0 &&
+			settings.Metrics.TemperatureDurationMinutes <= models.MaxTemperatureDurationMinutes)
 }

--- a/webapp/backend/pkg/web/handler/save_settings.go
+++ b/webapp/backend/pkg/web/handler/save_settings.go
@@ -16,6 +16,9 @@ func SaveSettings(c *gin.Context) {
 	deviceRepo := c.MustGet("DEVICE_REPOSITORY").(database.DeviceRepo)
 
 	var settings models.Settings
+	// Defaults precede decoding so omitted values differ from explicit zeroes.
+	settings.Metrics.TemperatureThresholdCelsius = models.DefaultTemperatureThresholdCelsius
+	settings.Metrics.TemperatureDurationMinutes = models.DefaultTemperatureDurationMinutes
 	err := c.BindJSON(&settings)
 	if err != nil {
 		logger.Errorln("Cannot parse updated settings", err)

--- a/webapp/backend/pkg/web/handler/settings_test.go
+++ b/webapp/backend/pkg/web/handler/settings_test.go
@@ -2,6 +2,7 @@ package handler_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -16,6 +17,38 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 )
+
+func TestSaveSettingsTemperatureValidation(t *testing.T) {
+	for _, tc := range []struct {
+		name                        string
+		enabled                     bool
+		threshold, duration, status int
+	}{
+		{"zero threshold", true, 0, 30, http.StatusBadRequest},
+		{"negative threshold", true, -1, 30, http.StatusBadRequest},
+		{"high threshold", true, 151, 30, http.StatusBadRequest},
+		{"negative duration", true, 55, -1, http.StatusBadRequest},
+		{"overflow duration", true, 55, models.MaxTemperatureDurationMinutes + 1, http.StatusBadRequest},
+		{"immediate", true, 55, 0, http.StatusOK},
+		{"minimum", true, 1, 30, http.StatusOK},
+		{"maximum", true, 150, models.MaxTemperatureDurationMinutes, http.StatusOK},
+		{"disabled", false, -1, -1, http.StatusOK},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := mock_database.NewMockDeviceRepo(gomock.NewController(t))
+			if tc.status == http.StatusOK {
+				repo.EXPECT().SaveSettings(gomock.Any(), gomock.Any()).Return(nil)
+			}
+			router := setupSettingsRouter(t, repo, false)
+			body := fmt.Sprintf(`{"metrics":{"notify_on_temperature":%t,"temperature_threshold_celsius":%d,"temperature_duration_minutes":%d}}`, tc.enabled, tc.threshold, tc.duration)
+			response := httptest.NewRecorder()
+			request := httptest.NewRequest(http.MethodPost, "/api/settings", strings.NewReader(body))
+			request.Header.Set("Content-Type", "application/json")
+			router.ServeHTTP(response, request)
+			require.Equal(t, tc.status, response.Code, response.Body.String())
+		})
+	}
+}
 
 // setupSettingsRouter creates a minimal Gin router wired to the settings handlers.
 func setupSettingsRouter(t *testing.T, mockRepo *mock_database.MockDeviceRepo, zfsPoolModificationsAllowed bool) *gin.Engine {

--- a/webapp/backend/pkg/web/handler/settings_test.go
+++ b/webapp/backend/pkg/web/handler/settings_test.go
@@ -33,7 +33,12 @@ func TestSaveSettingsTemperatureValidation(t *testing.T) {
 		{"immediate", true, 55, 0, http.StatusOK},
 		{"minimum", true, 1, 30, http.StatusOK},
 		{"maximum", true, 150, models.MaxTemperatureDurationMinutes, http.StatusOK},
-		{"disabled", false, -1, -1, http.StatusOK},
+		{"disabled zero threshold", false, 0, 30, http.StatusBadRequest},
+		{"disabled negative threshold", false, -1, 30, http.StatusBadRequest},
+		{"disabled high threshold", false, 151, 30, http.StatusBadRequest},
+		{"disabled negative duration", false, 55, -1, http.StatusBadRequest},
+		{"disabled overflow duration", false, 55, models.MaxTemperatureDurationMinutes + 1, http.StatusBadRequest},
+		{"disabled immediate", false, 55, 0, http.StatusOK},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			repo := mock_database.NewMockDeviceRepo(gomock.NewController(t))
@@ -58,6 +63,7 @@ func TestSaveSettingsDefaultsOmittedTemperatureValues(t *testing.T) {
 	}{
 		{"both omitted", `{"metrics":{"notify_on_temperature":true}}`, models.DefaultTemperatureDurationMinutes},
 		{"explicit immediate", `{"metrics":{"notify_on_temperature":true,"temperature_duration_minutes":0}}`, 0},
+		{"disabled omitted", `{"metrics":{"notify_on_temperature":false}}`, models.DefaultTemperatureDurationMinutes},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			repo := mock_database.NewMockDeviceRepo(gomock.NewController(t))

--- a/webapp/backend/pkg/web/handler/settings_test.go
+++ b/webapp/backend/pkg/web/handler/settings_test.go
@@ -1,6 +1,7 @@
 package handler_test
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -46,6 +47,30 @@ func TestSaveSettingsTemperatureValidation(t *testing.T) {
 			request.Header.Set("Content-Type", "application/json")
 			router.ServeHTTP(response, request)
 			require.Equal(t, tc.status, response.Code, response.Body.String())
+		})
+	}
+}
+
+func TestSaveSettingsDefaultsOmittedTemperatureValues(t *testing.T) {
+	for _, tc := range []struct {
+		name, body string
+		duration   int
+	}{
+		{"both omitted", `{"metrics":{"notify_on_temperature":true}}`, models.DefaultTemperatureDurationMinutes},
+		{"explicit immediate", `{"metrics":{"notify_on_temperature":true,"temperature_duration_minutes":0}}`, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := mock_database.NewMockDeviceRepo(gomock.NewController(t))
+			repo.EXPECT().SaveSettings(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, settings models.Settings) error {
+				require.Equal(t, models.DefaultTemperatureThresholdCelsius, settings.Metrics.TemperatureThresholdCelsius)
+				require.Equal(t, tc.duration, settings.Metrics.TemperatureDurationMinutes)
+				return nil
+			})
+			response := httptest.NewRecorder()
+			request := httptest.NewRequest(http.MethodPost, "/api/settings", strings.NewReader(tc.body))
+			request.Header.Set("Content-Type", "application/json")
+			setupSettingsRouter(t, repo, false).ServeHTTP(response, request)
+			require.Equal(t, http.StatusOK, response.Code, response.Body.String())
 		})
 	}
 }

--- a/webapp/backend/pkg/web/handler/temperature_notify.go
+++ b/webapp/backend/pkg/web/handler/temperature_notify.go
@@ -1,0 +1,48 @@
+package handler
+
+import (
+	"time"
+
+	"github.com/analogj/scrutiny/webapp/backend/pkg/config"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/database"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/models"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/models/measurements"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/notify"
+	"github.com/gin-gonic/gin"
+	"github.com/sirupsen/logrus"
+)
+
+func maybeNotifyTemperature(c *gin.Context, logger logrus.FieldLogger, appConfig config.Interface, repo database.DeviceRepo, device *models.Device, smart *measurements.Smart, settings *models.Settings, now time.Time) {
+	gateValue, exists := c.Get("NOTIFICATION_GATE")
+	gate, ok := gateValue.(*notify.NotificationGate)
+	if !exists || !ok || gate == nil || settings == nil {
+		return
+	}
+	if !settings.Metrics.NotifyOnTemperature || device.Muted || !validTemperatureNotifySettings(settings) {
+		gate.Temperature().Forget(device.DeviceID)
+		return
+	}
+	threshold := settings.Metrics.TemperatureThresholdCelsius
+	duration := time.Duration(settings.Metrics.TemperatureDurationMinutes) * time.Minute
+	gate.Temperature().Evaluate(device.DeviceID, true, smart.Temp, threshold, duration, now, func() time.Time {
+		if !settings.Collector.StoreTempHistory || smart.Date.IsZero() || smart.Date.After(now) {
+			return now
+		}
+		history, err := repo.GetSmartTemperatureHistoryForDevices(c, database.DURATION_KEY_DAY, []string{device.DeviceID})
+		if err != nil {
+			logger.Warnf("Could not seed temperature notification for device %s: %v", device.DeviceID, err)
+			return now
+		}
+		// The query must contain this upload, rather than only stale stored points.
+		for _, point := range history[device.DeviceID] {
+			if point.Date.Equal(smart.Date) && point.Temp == smart.Temp {
+				return notify.ExceededSince(history[device.DeviceID], threshold, now)
+			}
+		}
+		return now
+	}, func(since time.Time) bool {
+		n := notify.NewTemperatureNotify(logger, appConfig, device, smart.Temp, threshold, since, now, settings.TemperatureUnit)
+		n.LoadDatabaseUrls(c, repo)
+		return gate.TrySend(&n, settings, false)
+	})
+}

--- a/webapp/backend/pkg/web/handler/temperature_notify.go
+++ b/webapp/backend/pkg/web/handler/temperature_notify.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"time"
 
 	"github.com/analogj/scrutiny/webapp/backend/pkg/config"
@@ -11,6 +12,8 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
 )
+
+const temperatureHistoryTimeout = 10 * time.Second
 
 func maybeNotifyTemperature(c *gin.Context, logger logrus.FieldLogger, appConfig config.Interface, repo database.DeviceRepo, device *models.Device, smart *measurements.Smart, settings *models.Settings, now time.Time) {
 	gateValue, exists := c.Get("NOTIFICATION_GATE")
@@ -24,11 +27,17 @@ func maybeNotifyTemperature(c *gin.Context, logger logrus.FieldLogger, appConfig
 	}
 	threshold := settings.Metrics.TemperatureThresholdCelsius
 	duration := time.Duration(settings.Metrics.TemperatureDurationMinutes) * time.Minute
-	gate.Temperature().Evaluate(device.DeviceID, true, smart.Temp, threshold, duration, now, func() time.Time {
-		if !settings.Collector.StoreTempHistory || smart.Date.IsZero() || smart.Date.After(now) {
+	gate.Temperature().Evaluate(device.DeviceID, smart.Temp, threshold, duration, now, func() time.Time {
+		if !settings.Collector.StoreTempHistory {
 			return now
 		}
-		history, err := repo.GetSmartTemperatureHistoryForDevices(c, database.DURATION_KEY_DAY, []string{device.DeviceID})
+		if smart.Date.IsZero() || smart.Date.After(now) {
+			logger.Debugf("Skipping temperature history seed for device %s: upload timestamp is missing or ahead of the server clock", device.DeviceID)
+			return now
+		}
+		queryCtx, cancel := context.WithTimeout(c.Request.Context(), temperatureHistoryTimeout)
+		defer cancel()
+		history, err := repo.GetSmartTemperatureHistoryForDevices(queryCtx, database.DURATION_KEY_DAY, []string{device.DeviceID})
 		if err != nil {
 			logger.Warnf("Could not seed temperature notification for device %s: %v", device.DeviceID, err)
 			return now
@@ -39,6 +48,7 @@ func maybeNotifyTemperature(c *gin.Context, logger logrus.FieldLogger, appConfig
 				return notify.ExceededSince(history[device.DeviceID], threshold, now)
 			}
 		}
+		logger.Debugf("Skipping temperature history seed for device %s: current upload is not visible in history; check collector/InfluxDB clocks and write visibility", device.DeviceID)
 		return now
 	}, func(since time.Time) bool {
 		n := notify.NewTemperatureNotify(logger, appConfig, device, smart.Temp, threshold, since, now, settings.TemperatureUnit)

--- a/webapp/backend/pkg/web/handler/temperature_notify.go
+++ b/webapp/backend/pkg/web/handler/temperature_notify.go
@@ -37,15 +37,15 @@ func maybeNotifyTemperature(c *gin.Context, logger logrus.FieldLogger, appConfig
 		}
 		queryCtx, cancel := context.WithTimeout(c.Request.Context(), temperatureHistoryTimeout)
 		defer cancel()
-		history, err := repo.GetSmartTemperatureHistoryForDevices(queryCtx, database.DURATION_KEY_DAY, []string{device.DeviceID})
+		history, err := repo.GetTemperatureNotificationHistory(queryCtx, device.DeviceID)
 		if err != nil {
 			logger.Warnf("Could not seed temperature notification for device %s: %v", device.DeviceID, err)
 			return now
 		}
 		// The query must contain this upload, rather than only stale stored points.
-		for _, point := range history[device.DeviceID] {
+		for _, point := range history {
 			if point.Date.Equal(smart.Date) && point.Temp == smart.Temp {
-				return notify.ExceededSince(history[device.DeviceID], threshold, now)
+				return notify.ExceededSince(history, threshold, now)
 			}
 		}
 		logger.Debugf("Skipping temperature history seed for device %s: current upload is not visible in history; check collector/InfluxDB clocks and write visibility", device.DeviceID)

--- a/webapp/backend/pkg/web/handler/temperature_notify_test.go
+++ b/webapp/backend/pkg/web/handler/temperature_notify_test.go
@@ -1,0 +1,156 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/analogj/scrutiny/webapp/backend/pkg/config"
+	mock_database "github.com/analogj/scrutiny/webapp/backend/pkg/database/mock"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/models"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/models/measurements"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/notify"
+	"github.com/gin-gonic/gin"
+	"github.com/golang/mock/gomock"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMaybeNotifyTemperature(t *testing.T) {
+	for _, scenario := range []string{"seeded", "disabled", "muted", "storage disabled", "history error", "stale history", "empty history", "unknown", "quiet hours", "retry", "no gate", "missing gate", "wrong gate", "invalid settings", "missing date", "future date", "immediate", "rate limit"} {
+		t.Run(scenario, func(t *testing.T) {
+			cfg, err := config.Create()
+			require.NoError(t, err)
+			var deliveries atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { deliveries.Add(1); w.WriteHeader(http.StatusOK) }))
+			defer server.Close()
+			cfg.Set("notify.urls", []string{server.URL})
+			settings := &models.Settings{}
+			settings.ApplyDefaults()
+			settings.Metrics.NotifyOnTemperature = true
+			settings.Metrics.TemperatureDurationMinutes = models.DefaultTemperatureDurationMinutes
+			settings.Collector.StoreTempHistory = true
+			device := &models.Device{DeviceID: "drive", DeviceName: "/dev/sda"}
+			now := time.Now().UTC().Truncate(time.Second)
+			smart := &measurements.Smart{Temp: 60, Date: now}
+			repo := mock_database.NewMockDeviceRepo(gomock.NewController(t))
+			gate := notify.NewNotificationGate(logrus.New())
+			c, _ := gin.CreateTestContext(httptest.NewRecorder())
+			c.Set("NOTIFICATION_GATE", gate)
+			history := []measurements.SmartTemperature{{Date: now.Add(-time.Hour), Temp: 60}, {Date: now, Temp: 60}}
+			var historyErr error
+			switch scenario {
+			case "disabled":
+				settings.Metrics.NotifyOnTemperature = false
+			case "muted":
+				device.Muted = true
+			case "storage disabled":
+				settings.Collector.StoreTempHistory = false
+			case "history error":
+				historyErr = errors.New("influx unavailable")
+			case "stale history":
+				history = history[:1]
+			case "empty history":
+				history = nil
+			case "unknown":
+				smart.Temp = 0
+			case "quiet hours":
+				settings.Metrics.NotificationQuietStart = time.Now().Add(-time.Minute).Format("15:04")
+				settings.Metrics.NotificationQuietEnd = time.Now().Add(time.Minute).Format("15:04")
+			case "retry":
+				cfg.Set("notify.urls", []string{})
+			case "no gate":
+				c.Set("NOTIFICATION_GATE", (*notify.NotificationGate)(nil))
+			case "missing gate":
+				c.Keys = nil
+			case "wrong gate":
+				c.Set("NOTIFICATION_GATE", "invalid")
+			case "invalid settings":
+				settings.Metrics.TemperatureDurationMinutes = -1
+			case "missing date":
+				smart.Date = time.Time{}
+			case "future date":
+				smart.Date = now.Add(time.Hour)
+			case "immediate":
+				settings.Metrics.TemperatureDurationMinutes = 0
+			case "rate limit":
+				settings.Metrics.NotificationRateLimit = 1
+				n := notify.NewTemperatureNotify(logrus.New(), cfg, device, smart.Temp, settings.Metrics.TemperatureThresholdCelsius, now, now, settings.TemperatureUnit)
+				require.True(t, gate.TrySend(&n, settings, false))
+				deliveries.Store(0)
+			}
+			validGate := scenario != "no gate" && scenario != "missing gate" && scenario != "wrong gate"
+			if settings.Metrics.NotifyOnTemperature && !device.Muted && settings.Collector.StoreTempHistory && smart.Temp > 0 && validGate && scenario != "invalid settings" && !smart.Date.IsZero() && !smart.Date.After(now) {
+				repo.EXPECT().GetSmartTemperatureHistoryForDevices(gomock.Any(), "day", []string{"drive"}).Return(map[string][]measurements.SmartTemperature{"drive": history}, historyErr).Times(1)
+			}
+			if scenario == "seeded" || scenario == "quiet hours" || scenario == "retry" || scenario == "immediate" || scenario == "rate limit" {
+				repo.EXPECT().GetNotifyUrls(gomock.Any()).Return(nil, nil).AnyTimes()
+			}
+			for range 2 {
+				maybeNotifyTemperature(c, logrus.New(), cfg, repo, device, smart, settings, now)
+			}
+			switch scenario {
+			case "seeded", "immediate":
+				require.EqualValues(t, 1, deliveries.Load())
+			case "quiet hours":
+				require.Equal(t, 1, gate.QueueLength())
+				require.Zero(t, deliveries.Load())
+			case "retry":
+				cfg.Set("notify.urls", []string{server.URL})
+				maybeNotifyTemperature(c, logrus.New(), cfg, repo, device, smart, settings, now)
+				require.EqualValues(t, 1, deliveries.Load())
+			case "rate limit":
+				require.Zero(t, deliveries.Load())
+				settings.Metrics.NotificationRateLimit = 0
+				maybeNotifyTemperature(c, logrus.New(), cfg, repo, device, smart, settings, now)
+				require.EqualValues(t, 1, deliveries.Load())
+			default:
+				require.Zero(t, deliveries.Load())
+			}
+			if scenario == "disabled" || scenario == "muted" || scenario == "unknown" || !validGate || scenario == "invalid settings" {
+				require.False(t, gate.Temperature().HasState("drive"))
+			}
+		})
+	}
+}
+
+func TestLoadNotificationSettingsHandlesErrors(t *testing.T) {
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	repo := mock_database.NewMockDeviceRepo(gomock.NewController(t))
+	repo.EXPECT().LoadSettings(gomock.Any()).Return(nil, errors.New("unavailable"))
+	require.Nil(t, loadNotificationSettings(c, logrus.NewEntry(logrus.New()), repo))
+}
+
+func TestTemperatureMuteAndDisableResetActiveExcursion(t *testing.T) {
+	for _, muted := range []bool{true, false} {
+		cfg, err := config.Create()
+		require.NoError(t, err)
+		settings := &models.Settings{}
+		settings.ApplyDefaults()
+		settings.Metrics.NotifyOnTemperature = true
+		settings.Metrics.TemperatureDurationMinutes = models.DefaultTemperatureDurationMinutes
+		gate := notify.NewNotificationGate(logrus.New())
+		c, _ := gin.CreateTestContext(httptest.NewRecorder())
+		c.Set("NOTIFICATION_GATE", gate)
+		device := &models.Device{DeviceID: "drive"}
+		smart := &measurements.Smart{Temp: 60}
+		now := time.Now()
+		repo := mock_database.NewMockDeviceRepo(gomock.NewController(t))
+		maybeNotifyTemperature(c, logrus.New(), cfg, repo, device, smart, settings, now)
+		require.True(t, gate.Temperature().HasState("drive"))
+		device.Muted = muted
+		settings.Metrics.NotifyOnTemperature = muted
+		maybeNotifyTemperature(c, logrus.New(), cfg, repo, device, smart, settings, now.Add(time.Hour))
+		require.False(t, gate.Temperature().HasState("drive"))
+		device.Muted = false
+		settings.Metrics.NotifyOnTemperature = true
+		settings.Collector.StoreTempHistory = true
+		smart.Date = now.Add(time.Hour)
+		// No history or notification calls are expected when resuming.
+		maybeNotifyTemperature(c, logrus.New(), cfg, repo, device, smart, settings, now.Add(time.Hour))
+		require.True(t, gate.Temperature().HasState("drive"))
+	}
+}

--- a/webapp/backend/pkg/web/handler/temperature_notify_test.go
+++ b/webapp/backend/pkg/web/handler/temperature_notify_test.go
@@ -173,9 +173,42 @@ func TestTemperatureMuteAndDisableResetActiveExcursion(t *testing.T) {
 		now := time.Now()
 		repo := mock_database.NewMockDeviceRepo(gomock.NewController(t))
 		maybeNotifyTemperature(c, logrus.New(), cfg, repo, device, smart, settings, now)
+		// Hold a failed send in flight while the handler processes mute/disable.
+		const deliveryTestAllowance = 2 * time.Second
+		started, release, deliveryDone := make(chan struct{}), make(chan struct{}), make(chan struct{})
+		go func() {
+			defer close(deliveryDone)
+			gate.Temperature().Evaluate("drive", 60, settings.Metrics.TemperatureThresholdCelsius,
+				time.Duration(models.DefaultTemperatureDurationMinutes)*time.Minute, now.Add(time.Hour), nil,
+				func(time.Time) bool {
+					close(started)
+					select {
+					case <-release:
+					case <-time.After(deliveryTestAllowance):
+					}
+					return false
+				})
+		}()
+		select {
+		case <-started:
+		case <-time.After(deliveryTestAllowance):
+			t.Fatal("send did not start")
+		}
 		device.Muted = muted
 		settings.Metrics.NotifyOnTemperature = muted
-		maybeNotifyTemperature(c, logrus.New(), cfg, repo, device, smart, settings, now.Add(time.Hour))
+		resetDone := make(chan struct{})
+		go func() {
+			defer close(resetDone)
+			maybeNotifyTemperature(c, logrus.New(), cfg, repo, device, smart, settings, now.Add(time.Hour))
+		}()
+		close(release)
+		for _, done := range []chan struct{}{deliveryDone, resetDone} {
+			select {
+			case <-done:
+			case <-time.After(deliveryTestAllowance):
+				t.Fatal("mute/disable remained blocked after delivery failed")
+			}
+		}
 		device.Muted = false
 		settings.Metrics.NotifyOnTemperature = true
 		settings.Collector.StoreTempHistory = true

--- a/webapp/backend/pkg/web/handler/temperature_notify_test.go
+++ b/webapp/backend/pkg/web/handler/temperature_notify_test.go
@@ -101,7 +101,7 @@ func TestMaybeNotifyTemperature(t *testing.T) {
 			}
 			validGate := scenario != "no gate" && scenario != "missing gate" && scenario != "wrong gate"
 			if settings.Metrics.NotifyOnTemperature && !device.Muted && settings.Collector.StoreTempHistory && smart.Temp > 0 && validGate && scenario != "invalid settings" && !smart.Date.IsZero() && !smart.Date.After(now) {
-				repo.EXPECT().GetSmartTemperatureHistoryForDevices(gomock.Any(), "day", []string{"drive"}).Do(func(ctx context.Context, _ string, _ []string) {
+				repo.EXPECT().GetTemperatureNotificationHistory(gomock.Any(), "drive").Do(func(ctx context.Context, _ string) {
 					deadline, exists := ctx.Deadline()
 					require.True(t, exists, "history lookup must have a deadline")
 					require.Positive(t, time.Until(deadline))
@@ -109,7 +109,7 @@ func TestMaybeNotifyTemperature(t *testing.T) {
 					if scenario == "request canceled" {
 						require.ErrorIs(t, ctx.Err(), context.Canceled)
 					}
-				}).Return(map[string][]measurements.SmartTemperature{"drive": history}, historyErr).Times(1)
+				}).Return(history, historyErr).Times(1)
 			}
 			if scenario == "seeded" || scenario == "quiet hours" || scenario == "retry" || scenario == "immediate" || scenario == "rate limit" || scenario == "webhook error" {
 				repo.EXPECT().GetNotifyUrls(gomock.Any()).Return(nil, nil).AnyTimes()

--- a/webapp/backend/pkg/web/handler/temperature_notify_test.go
+++ b/webapp/backend/pkg/web/handler/temperature_notify_test.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -16,16 +17,26 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/golang/mock/gomock"
 	"github.com/sirupsen/logrus"
+	logrustest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/require"
 )
 
 func TestMaybeNotifyTemperature(t *testing.T) {
-	for _, scenario := range []string{"seeded", "disabled", "muted", "storage disabled", "history error", "stale history", "empty history", "unknown", "quiet hours", "retry", "no gate", "missing gate", "wrong gate", "invalid settings", "missing date", "future date", "immediate", "rate limit"} {
+	for _, scenario := range []string{"seeded", "disabled", "muted", "storage disabled", "history error", "stale history", "empty history", "unknown", "quiet hours", "retry", "no gate", "missing gate", "wrong gate", "invalid settings", "missing date", "future date", "immediate", "rate limit", "webhook error", "request canceled"} {
 		t.Run(scenario, func(t *testing.T) {
 			cfg, err := config.Create()
 			require.NoError(t, err)
+			logger, hook := logrustest.NewNullLogger()
+			logger.SetLevel(logrus.DebugLevel)
 			var deliveries atomic.Int32
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { deliveries.Add(1); w.WriteHeader(http.StatusOK) }))
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				attempt := deliveries.Add(1)
+				if scenario == "webhook error" && attempt == 1 {
+					w.WriteHeader(http.StatusInternalServerError)
+					return
+				}
+				w.WriteHeader(http.StatusOK)
+			}))
 			defer server.Close()
 			cfg.Set("notify.urls", []string{server.URL})
 			settings := &models.Settings{}
@@ -39,6 +50,7 @@ func TestMaybeNotifyTemperature(t *testing.T) {
 			repo := mock_database.NewMockDeviceRepo(gomock.NewController(t))
 			gate := notify.NewNotificationGate(logrus.New())
 			c, _ := gin.CreateTestContext(httptest.NewRecorder())
+			c.Request = httptest.NewRequest(http.MethodPost, "/api/device/drive/smart", nil)
 			c.Set("NOTIFICATION_GATE", gate)
 			history := []measurements.SmartTemperature{{Date: now.Add(-time.Hour), Temp: 60}, {Date: now, Temp: 60}}
 			var historyErr error
@@ -51,6 +63,11 @@ func TestMaybeNotifyTemperature(t *testing.T) {
 				settings.Collector.StoreTempHistory = false
 			case "history error":
 				historyErr = errors.New("influx unavailable")
+			case "request canceled":
+				requestCtx, cancel := context.WithCancel(c.Request.Context())
+				cancel()
+				c.Request = c.Request.WithContext(requestCtx)
+				historyErr = context.Canceled
 			case "stale history":
 				history = history[:1]
 			case "empty history":
@@ -84,15 +101,25 @@ func TestMaybeNotifyTemperature(t *testing.T) {
 			}
 			validGate := scenario != "no gate" && scenario != "missing gate" && scenario != "wrong gate"
 			if settings.Metrics.NotifyOnTemperature && !device.Muted && settings.Collector.StoreTempHistory && smart.Temp > 0 && validGate && scenario != "invalid settings" && !smart.Date.IsZero() && !smart.Date.After(now) {
-				repo.EXPECT().GetSmartTemperatureHistoryForDevices(gomock.Any(), "day", []string{"drive"}).Return(map[string][]measurements.SmartTemperature{"drive": history}, historyErr).Times(1)
+				repo.EXPECT().GetSmartTemperatureHistoryForDevices(gomock.Any(), "day", []string{"drive"}).Do(func(ctx context.Context, _ string, _ []string) {
+					deadline, exists := ctx.Deadline()
+					require.True(t, exists, "history lookup must have a deadline")
+					require.Positive(t, time.Until(deadline))
+					require.LessOrEqual(t, time.Until(deadline), temperatureHistoryTimeout)
+					if scenario == "request canceled" {
+						require.ErrorIs(t, ctx.Err(), context.Canceled)
+					}
+				}).Return(map[string][]measurements.SmartTemperature{"drive": history}, historyErr).Times(1)
 			}
-			if scenario == "seeded" || scenario == "quiet hours" || scenario == "retry" || scenario == "immediate" || scenario == "rate limit" {
+			if scenario == "seeded" || scenario == "quiet hours" || scenario == "retry" || scenario == "immediate" || scenario == "rate limit" || scenario == "webhook error" {
 				repo.EXPECT().GetNotifyUrls(gomock.Any()).Return(nil, nil).AnyTimes()
 			}
 			for range 2 {
-				maybeNotifyTemperature(c, logrus.New(), cfg, repo, device, smart, settings, now)
+				maybeNotifyTemperature(c, logger, cfg, repo, device, smart, settings, now)
 			}
 			switch scenario {
+			case "webhook error":
+				require.EqualValues(t, 2, deliveries.Load(), "HTTP failure must be retried on the next upload")
 			case "seeded", "immediate":
 				require.EqualValues(t, 1, deliveries.Load())
 			case "quiet hours":
@@ -110,8 +137,10 @@ func TestMaybeNotifyTemperature(t *testing.T) {
 			default:
 				require.Zero(t, deliveries.Load())
 			}
-			if scenario == "disabled" || scenario == "muted" || scenario == "unknown" || !validGate || scenario == "invalid settings" {
-				require.False(t, gate.Temperature().HasState("drive"))
+			if scenario == "stale history" || scenario == "empty history" || scenario == "missing date" || scenario == "future date" {
+				require.NotNil(t, hook.LastEntry())
+				require.Equal(t, logrus.DebugLevel, hook.LastEntry().Level)
+				require.Contains(t, hook.LastEntry().Message, "temperature history")
 			}
 		})
 	}
@@ -128,6 +157,10 @@ func TestTemperatureMuteAndDisableResetActiveExcursion(t *testing.T) {
 	for _, muted := range []bool{true, false} {
 		cfg, err := config.Create()
 		require.NoError(t, err)
+		var deliveries atomic.Int32
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { deliveries.Add(1); w.WriteHeader(http.StatusOK) }))
+		defer server.Close()
+		cfg.Set("notify.urls", []string{server.URL})
 		settings := &models.Settings{}
 		settings.ApplyDefaults()
 		settings.Metrics.NotifyOnTemperature = true
@@ -140,17 +173,18 @@ func TestTemperatureMuteAndDisableResetActiveExcursion(t *testing.T) {
 		now := time.Now()
 		repo := mock_database.NewMockDeviceRepo(gomock.NewController(t))
 		maybeNotifyTemperature(c, logrus.New(), cfg, repo, device, smart, settings, now)
-		require.True(t, gate.Temperature().HasState("drive"))
 		device.Muted = muted
 		settings.Metrics.NotifyOnTemperature = muted
 		maybeNotifyTemperature(c, logrus.New(), cfg, repo, device, smart, settings, now.Add(time.Hour))
-		require.False(t, gate.Temperature().HasState("drive"))
 		device.Muted = false
 		settings.Metrics.NotifyOnTemperature = true
 		settings.Collector.StoreTempHistory = true
 		smart.Date = now.Add(time.Hour)
 		// No history or notification calls are expected when resuming.
 		maybeNotifyTemperature(c, logrus.New(), cfg, repo, device, smart, settings, now.Add(time.Hour))
-		require.True(t, gate.Temperature().HasState("drive"))
+		require.Zero(t, deliveries.Load())
+		repo.EXPECT().GetNotifyUrls(gomock.Any()).Return(nil, nil).Times(1)
+		maybeNotifyTemperature(c, logrus.New(), cfg, repo, device, smart, settings, now.Add(time.Hour+time.Duration(models.DefaultTemperatureDurationMinutes)*time.Minute))
+		require.EqualValues(t, 1, deliveries.Load(), "resumed excursion must wait the full duration")
 	}
 }

--- a/webapp/backend/pkg/web/handler/temperature_upload_test.go
+++ b/webapp/backend/pkg/web/handler/temperature_upload_test.go
@@ -2,6 +2,9 @@ package handler_test
 
 import (
 	"errors"
+	"fmt"
+	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -12,6 +15,7 @@ import (
 	"github.com/analogj/scrutiny/webapp/backend/pkg"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/config"
 	mock_database "github.com/analogj/scrutiny/webapp/backend/pkg/database/mock"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/metrics"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/models"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/models/measurements"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/notify"
@@ -23,45 +27,79 @@ import (
 )
 
 func TestUploadTemperatureDeliversOnce(t *testing.T) {
-	var deliveries atomic.Int32
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { deliveries.Add(1); w.WriteHeader(http.StatusOK) }))
-	defer server.Close()
-	cfg, err := config.Create()
-	require.NoError(t, err)
-	cfg.Set("notify.urls", []string{server.URL})
-	settings := &models.Settings{}
-	settings.ApplyDefaults()
-	settings.Metrics.NotifyOnTemperature = true
-	settings.Metrics.TemperatureDurationMinutes = models.DefaultTemperatureDurationMinutes
-	settings.Collector.StoreTempHistory = true
-	device := models.Device{DeviceID: "drive", WWN: "wwn", DeviceName: "/dev/sda", DeviceStatus: pkg.DeviceStatusPassed}
-	now := time.Now().UTC().Truncate(time.Second)
-	repo := mock_database.NewMockDeviceRepo(gomock.NewController(t))
-	repo.EXPECT().GetDeviceDetails(gomock.Any(), "drive").Return(device, nil).Times(2)
-	repo.EXPECT().UpdateDevice(gomock.Any(), "drive", gomock.Any()).Return(device, nil).Times(2)
-	repo.EXPECT().SaveSmartAttributes(gomock.Any(), "wwn", gomock.Any()).Return(measurements.Smart{Temp: 60, Date: now, Status: pkg.DeviceStatusPassed}, nil).Times(2)
-	repo.EXPECT().UpdateDeviceHasForcedFailure(gomock.Any(), "drive", false).Return(nil).Times(2)
-	repo.EXPECT().SaveSmartTemperature(gomock.Any(), "wwn", "drive", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(2)
-	repo.EXPECT().LoadSettings(gomock.Any()).Return(settings, nil).Times(2)
-	repo.EXPECT().GetTemperatureNotificationHistory(gomock.Any(), "drive").Return([]measurements.SmartTemperature{{Date: now.Add(-time.Hour), Temp: 60}, {Date: now, Temp: 60}}, nil).Times(1)
-	repo.EXPECT().GetNotifyUrls(gomock.Any()).Return(nil, nil).Times(1)
-	gate := notify.NewNotificationGate(logrus.New())
-	router := gin.New()
-	router.Use(func(c *gin.Context) {
-		c.Set("LOGGER", logrus.WithField("test", t.Name()))
-		c.Set("CONFIG", cfg)
-		c.Set("DEVICE_REPOSITORY", repo)
-		c.Set("NOTIFICATION_GATE", gate)
-	})
-	router.POST("/api/device/:id/smart", handler.UploadDeviceMetrics)
-	for range 2 {
-		request := httptest.NewRequest(http.MethodPost, "/api/device/drive/smart", strings.NewReader(smartPayload(0)))
-		request.Header.Set("Content-Type", "application/json")
-		response := httptest.NewRecorder()
-		router.ServeHTTP(response, request)
-		require.Equal(t, http.StatusOK, response.Code, response.Body.String())
+	for _, stalled := range []bool{false, true} {
+		t.Run(fmt.Sprint("stalled=", stalled), func(t *testing.T) {
+			var deliveries atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { deliveries.Add(1); w.WriteHeader(http.StatusOK) }))
+			defer server.Close()
+			cfg, err := config.Create()
+			require.NoError(t, err)
+			cfg.Set("notify.urls", []string{server.URL})
+			if stalled {
+				listener, listenErr := net.Listen("tcp", "127.0.0.1:0")
+				require.NoError(t, listenErr)
+				defer listener.Close()
+				const smtpBudget = 100 * time.Millisecond
+				const fixtureSafety = 3 * time.Second
+				go func() {
+					for {
+						conn, acceptErr := listener.Accept()
+						if acceptErr != nil {
+							return
+						}
+						deliveries.Add(1)
+						_ = conn.SetDeadline(time.Now().Add(fixtureSafety))
+						_, _ = io.Copy(io.Discard, conn)
+						_ = conn.Close()
+					}
+				}()
+				cfg.Set("notify.urls", []string{"smtp://" + listener.Addr().String() + "/?fromaddress=sender@example.com&toaddresses=recipient@example.com&usestarttls=No&auth=None&timeout=" + smtpBudget.String()})
+			}
+			settings := &models.Settings{}
+			settings.ApplyDefaults()
+			settings.Metrics.NotifyOnTemperature = true
+			settings.Metrics.TemperatureDurationMinutes = models.DefaultTemperatureDurationMinutes
+			settings.Collector.StoreTempHistory = true
+			device := models.Device{DeviceID: "drive", WWN: "wwn", DeviceName: "/dev/sda", DeviceStatus: pkg.DeviceStatusPassed}
+			now := time.Now().UTC().Truncate(time.Second)
+			repo := mock_database.NewMockDeviceRepo(gomock.NewController(t))
+			repo.EXPECT().GetDeviceDetails(gomock.Any(), "drive").Return(device, nil).Times(2)
+			repo.EXPECT().UpdateDevice(gomock.Any(), "drive", gomock.Any()).Return(device, nil).Times(2)
+			repo.EXPECT().SaveSmartAttributes(gomock.Any(), "wwn", gomock.Any()).Return(measurements.Smart{Temp: 60, Date: now, Status: pkg.DeviceStatusPassed}, nil).Times(2)
+			repo.EXPECT().UpdateDeviceHasForcedFailure(gomock.Any(), "drive", false).Return(nil).Times(2)
+			repo.EXPECT().SaveSmartTemperature(gomock.Any(), "wwn", "drive", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(2)
+			repo.EXPECT().LoadSettings(gomock.Any()).Return(settings, nil).Times(2)
+			repo.EXPECT().GetTemperatureNotificationHistory(gomock.Any(), "drive").Return([]measurements.SmartTemperature{{Date: now.Add(-time.Hour), Temp: 60}, {Date: now, Temp: 60}}, nil).Times(1)
+			wantDeliveries := 1
+			if stalled {
+				wantDeliveries = 2
+			}
+			repo.EXPECT().GetNotifyUrls(gomock.Any()).Return(nil, nil).Times(wantDeliveries)
+			repo.EXPECT().GetWorkloadInsights(gomock.Any(), "week").Return(nil, nil).Times(2)
+			gate := notify.NewNotificationGate(logrus.New())
+			collector := metrics.NewCollector(logrus.NewEntry(logrus.New()))
+			router := gin.New()
+			router.Use(func(c *gin.Context) {
+				c.Set("LOGGER", logrus.WithField("test", t.Name()))
+				c.Set("CONFIG", cfg)
+				c.Set("DEVICE_REPOSITORY", repo)
+				c.Set("NOTIFICATION_GATE", gate)
+				c.Set("METRICS_COLLECTOR", collector)
+			})
+			router.POST("/api/device/:id/smart", handler.UploadDeviceMetrics)
+			for range 2 {
+				start := time.Now()
+				request := httptest.NewRequest(http.MethodPost, "/api/device/drive/smart", strings.NewReader(smartPayload(0)))
+				request.Header.Set("Content-Type", "application/json")
+				response := httptest.NewRecorder()
+				router.ServeHTTP(response, request)
+				require.Equal(t, http.StatusOK, response.Code, response.Body.String())
+				const uploadTestAllowance = 2 * time.Second
+				require.Less(t, time.Since(start), uploadTestAllowance)
+			}
+			require.EqualValues(t, wantDeliveries, deliveries.Load())
+		})
 	}
-	require.EqualValues(t, 1, deliveries.Load())
 }
 
 func TestUploadSharesNotificationSettings(t *testing.T) {

--- a/webapp/backend/pkg/web/handler/temperature_upload_test.go
+++ b/webapp/backend/pkg/web/handler/temperature_upload_test.go
@@ -43,7 +43,7 @@ func TestUploadTemperatureDeliversOnce(t *testing.T) {
 	repo.EXPECT().UpdateDeviceHasForcedFailure(gomock.Any(), "drive", false).Return(nil).Times(2)
 	repo.EXPECT().SaveSmartTemperature(gomock.Any(), "wwn", "drive", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(2)
 	repo.EXPECT().LoadSettings(gomock.Any()).Return(settings, nil).Times(2)
-	repo.EXPECT().GetSmartTemperatureHistoryForDevices(gomock.Any(), "day", []string{"drive"}).Return(map[string][]measurements.SmartTemperature{"drive": {{Date: now.Add(-time.Hour), Temp: 60}, {Date: now, Temp: 60}}}, nil).Times(1)
+	repo.EXPECT().GetTemperatureNotificationHistory(gomock.Any(), "drive").Return([]measurements.SmartTemperature{{Date: now.Add(-time.Hour), Temp: 60}, {Date: now, Temp: 60}}, nil).Times(1)
 	repo.EXPECT().GetNotifyUrls(gomock.Any()).Return(nil, nil).Times(1)
 	gate := notify.NewNotificationGate(logrus.New())
 	router := gin.New()

--- a/webapp/backend/pkg/web/handler/temperature_upload_test.go
+++ b/webapp/backend/pkg/web/handler/temperature_upload_test.go
@@ -1,0 +1,64 @@
+package handler_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/analogj/scrutiny/webapp/backend/pkg"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/config"
+	mock_database "github.com/analogj/scrutiny/webapp/backend/pkg/database/mock"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/models"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/models/measurements"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/notify"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/web/handler"
+	"github.com/gin-gonic/gin"
+	"github.com/golang/mock/gomock"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUploadTemperatureDeliversOnce(t *testing.T) {
+	var deliveries atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { deliveries.Add(1); w.WriteHeader(http.StatusOK) }))
+	defer server.Close()
+	cfg, err := config.Create()
+	require.NoError(t, err)
+	cfg.Set("notify.urls", []string{server.URL})
+	settings := &models.Settings{}
+	settings.ApplyDefaults()
+	settings.Metrics.NotifyOnTemperature = true
+	settings.Metrics.TemperatureDurationMinutes = models.DefaultTemperatureDurationMinutes
+	settings.Collector.StoreTempHistory = true
+	device := models.Device{DeviceID: "drive", WWN: "wwn", DeviceName: "/dev/sda", DeviceStatus: pkg.DeviceStatusPassed}
+	now := time.Now().UTC().Truncate(time.Second)
+	repo := mock_database.NewMockDeviceRepo(gomock.NewController(t))
+	repo.EXPECT().GetDeviceDetails(gomock.Any(), "drive").Return(device, nil).Times(2)
+	repo.EXPECT().UpdateDevice(gomock.Any(), "drive", gomock.Any()).Return(device, nil).Times(2)
+	repo.EXPECT().SaveSmartAttributes(gomock.Any(), "wwn", gomock.Any()).Return(measurements.Smart{Temp: 60, Date: now, Status: pkg.DeviceStatusPassed}, nil).Times(2)
+	repo.EXPECT().UpdateDeviceHasForcedFailure(gomock.Any(), "drive", false).Return(nil).Times(2)
+	repo.EXPECT().SaveSmartTemperature(gomock.Any(), "wwn", "drive", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(2)
+	repo.EXPECT().LoadSettings(gomock.Any()).Return(settings, nil).Times(2)
+	repo.EXPECT().GetSmartTemperatureHistoryForDevices(gomock.Any(), "day", []string{"drive"}).Return(map[string][]measurements.SmartTemperature{"drive": {{Date: now.Add(-time.Hour), Temp: 60}, {Date: now, Temp: 60}}}, nil).Times(1)
+	repo.EXPECT().GetNotifyUrls(gomock.Any()).Return(nil, nil).Times(1)
+	gate := notify.NewNotificationGate(logrus.New())
+	router := gin.New()
+	router.Use(func(c *gin.Context) {
+		c.Set("LOGGER", logrus.WithField("test", t.Name()))
+		c.Set("CONFIG", cfg)
+		c.Set("DEVICE_REPOSITORY", repo)
+		c.Set("NOTIFICATION_GATE", gate)
+	})
+	router.POST("/api/device/:id/smart", handler.UploadDeviceMetrics)
+	for range 2 {
+		request := httptest.NewRequest(http.MethodPost, "/api/device/drive/smart", strings.NewReader(smartPayload(0)))
+		request.Header.Set("Content-Type", "application/json")
+		response := httptest.NewRecorder()
+		router.ServeHTTP(response, request)
+		require.Equal(t, http.StatusOK, response.Code, response.Body.String())
+	}
+	require.EqualValues(t, 1, deliveries.Load())
+}

--- a/webapp/backend/pkg/web/handler/temperature_upload_test.go
+++ b/webapp/backend/pkg/web/handler/temperature_upload_test.go
@@ -1,6 +1,7 @@
 package handler_test
 
 import (
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -61,4 +62,82 @@ func TestUploadTemperatureDeliversOnce(t *testing.T) {
 		require.Equal(t, http.StatusOK, response.Code, response.Body.String())
 	}
 	require.EqualValues(t, 1, deliveries.Load())
+}
+
+func TestUploadSharesNotificationSettings(t *testing.T) {
+	for _, scenario := range []string{"available", "missing", "load error", "no gate", "nil gate", "quiet hours", "rate limit"} {
+		t.Run(scenario, func(t *testing.T) {
+			var deliveries atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				deliveries.Add(1)
+				w.WriteHeader(http.StatusNoContent)
+			}))
+			defer server.Close()
+			cfg, err := config.Create()
+			require.NoError(t, err)
+			cfg.Set("notify.urls", []string{server.URL})
+			cfg.Set(config.DB_USER_SETTINGS_SUBKEY+".metrics.notify_level", pkg.MetricsNotifyLevelFail)
+			cfg.Set(config.DB_USER_SETTINGS_SUBKEY+".metrics.status_threshold", pkg.MetricsStatusThresholdSmart)
+			cfg.Set(config.DB_USER_SETTINGS_SUBKEY+".metrics.repeat_notifications", true)
+			settings := &models.Settings{}
+			settings.ApplyDefaults()
+			settings.Metrics.NotifyOnTemperature = true
+			if scenario == "quiet hours" {
+				now := time.Now()
+				settings.Metrics.NotificationQuietStart = now.Add(-time.Hour).Format("15:04")
+				settings.Metrics.NotificationQuietEnd = now.Add(time.Hour).Format("15:04")
+			}
+			if scenario == "rate limit" {
+				settings.Metrics.NotificationRateLimit = 1
+			}
+			var settingsError error
+			if scenario == "missing" || scenario == "load error" {
+				settings = nil
+			}
+			if scenario == "load error" {
+				settingsError = errors.New("settings unavailable")
+			}
+			device := models.Device{DeviceID: "drive", WWN: "wwn", DeviceName: "/dev/sda", DeviceStatus: pkg.DeviceStatusFailedSmart}
+			repo := mock_database.NewMockDeviceRepo(gomock.NewController(t))
+			repo.EXPECT().GetDeviceDetails(gomock.Any(), "drive").Return(device, nil)
+			repo.EXPECT().UpdateDevice(gomock.Any(), "drive", gomock.Any()).Return(device, nil)
+			repo.EXPECT().SaveSmartAttributes(gomock.Any(), "wwn", gomock.Any()).Return(measurements.Smart{Temp: 60, Status: device.DeviceStatus}, nil)
+			repo.EXPECT().UpdateDeviceHasForcedFailure(gomock.Any(), "drive", false).Return(nil)
+			repo.EXPECT().UpdateDeviceStatus(gomock.Any(), "drive", device.DeviceStatus).Return(device, nil)
+			repo.EXPECT().SaveSmartTemperature(gomock.Any(), "wwn", "drive", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+			repo.EXPECT().LoadSettings(gomock.Any()).Return(settings, settingsError).Times(1)
+			urlLoads := 1
+			if scenario == "available" || scenario == "quiet hours" || scenario == "rate limit" {
+				urlLoads++
+			}
+			repo.EXPECT().GetNotifyUrls(gomock.Any()).Return(nil, nil).Times(urlLoads)
+			gate := notify.NewNotificationGate(logrus.New())
+			if scenario == "nil gate" {
+				gate = nil
+			}
+			router := gin.New()
+			router.Use(func(c *gin.Context) {
+				c.Set("LOGGER", logrus.WithField("test", t.Name()))
+				c.Set("CONFIG", cfg)
+				c.Set("DEVICE_REPOSITORY", repo)
+				if scenario != "no gate" {
+					c.Set("NOTIFICATION_GATE", gate)
+				}
+			})
+			router.POST("/api/device/:id/smart", handler.UploadDeviceMetrics)
+			request := httptest.NewRequest(http.MethodPost, "/api/device/drive/smart", strings.NewReader(smartPayload(0)))
+			request.Header.Set("Content-Type", "application/json")
+			response := httptest.NewRecorder()
+			router.ServeHTTP(response, request)
+			require.Equal(t, http.StatusOK, response.Code)
+			wantDeliveries := urlLoads
+			if scenario == "quiet hours" {
+				require.Equal(t, urlLoads, gate.QueueLength(), "SMART and temperature must both respect quiet hours")
+				wantDeliveries = 0
+			} else if scenario == "rate limit" {
+				wantDeliveries = settings.Metrics.NotificationRateLimit
+			}
+			require.EqualValues(t, wantDeliveries, deliveries.Load())
+		})
+	}
 }

--- a/webapp/backend/pkg/web/handler/upload_device_metrics.go
+++ b/webapp/backend/pkg/web/handler/upload_device_metrics.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/analogj/scrutiny/webapp/backend/pkg"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/config"
@@ -97,7 +98,12 @@ func UploadDeviceMetrics(c *gin.Context) {
 		sendDeviceNotification(c, logger, appConfig, deviceRepo, device.DeviceID, &updatedDevice)
 	}
 
-	maybeNotifyReplacementRiskFromSettings(c, logger, appConfig, deviceRepo, &updatedDevice, smartData.Attributes)
+	if settings := loadNotificationSettings(c, logger, deviceRepo); settings != nil {
+		if settings.Metrics.NotifyOnReplacementRisk {
+			maybeNotifyReplacementRisk(c, logger, appConfig, deviceRepo, &updatedDevice, smartData.Attributes, settings)
+		}
+		maybeNotifyTemperature(c, logger, appConfig, deviceRepo, &updatedDevice, &smartData, settings, time.Now())
+	}
 
 	refreshPrometheusMetrics(c, logger, deviceRepo, device.DeviceID, &updatedDevice, &smartData)
 
@@ -189,14 +195,13 @@ func sendDeviceNotification(c *gin.Context, logger *logrus.Entry, appConfig conf
 	}
 }
 
-func maybeNotifyReplacementRiskFromSettings(c *gin.Context, logger *logrus.Entry, appConfig config.Interface, deviceRepo database.DeviceRepo, updatedDevice *models.Device, attributes map[string]measurements.SmartAttribute) {
-	riskSettings, riskSettingsErr := deviceRepo.LoadSettings(c)
-	if riskSettingsErr != nil {
-		logger.Warnf("Could not load settings for replacement risk notification: %v", riskSettingsErr)
+func loadNotificationSettings(c *gin.Context, logger *logrus.Entry, deviceRepo database.DeviceRepo) *models.Settings {
+	settings, err := deviceRepo.LoadSettings(c)
+	if err != nil {
+		logger.Warnf("Could not load notification settings: %v", err)
+		return nil
 	}
-	if riskSettings != nil && riskSettings.Metrics.NotifyOnReplacementRisk {
-		maybeNotifyReplacementRisk(c, logger, appConfig, deviceRepo, updatedDevice, attributes, riskSettings)
-	}
+	return settings
 }
 
 func refreshPrometheusMetrics(c *gin.Context, logger *logrus.Entry, deviceRepo database.DeviceRepo, deviceID string, updatedDevice *models.Device, smartData *measurements.Smart) {

--- a/webapp/backend/pkg/web/handler/upload_device_metrics.go
+++ b/webapp/backend/pkg/web/handler/upload_device_metrics.go
@@ -80,6 +80,7 @@ func UploadDeviceMetrics(c *gin.Context) {
 	}
 
 	clearCollectorErrorState(c, updatedDevice.DeviceID)
+	settings := loadNotificationSettings(c, logger, deviceRepo)
 
 	// check for error
 	if notify.ShouldNotify(
@@ -95,10 +96,10 @@ func UploadDeviceMetrics(c *gin.Context) {
 		deviceRepo,
 		appConfig,
 	) {
-		sendDeviceNotification(c, logger, appConfig, deviceRepo, device.DeviceID, &updatedDevice)
+		sendDeviceNotification(c, logger, appConfig, deviceRepo, device.DeviceID, &updatedDevice, settings)
 	}
 
-	if settings := loadNotificationSettings(c, logger, deviceRepo); settings != nil {
+	if settings != nil {
 		if settings.Metrics.NotifyOnReplacementRisk {
 			maybeNotifyReplacementRisk(c, logger, appConfig, deviceRepo, &updatedDevice, smartData.Attributes, settings)
 		}
@@ -175,19 +176,13 @@ func reconcileDeviceStatus(c *gin.Context, logger *logrus.Entry, deviceRepo data
 	return device, true
 }
 
-func sendDeviceNotification(c *gin.Context, logger *logrus.Entry, appConfig config.Interface, deviceRepo database.DeviceRepo, deviceID string, updatedDevice *models.Device) {
+func sendDeviceNotification(c *gin.Context, logger *logrus.Entry, appConfig config.Interface, deviceRepo database.DeviceRepo, deviceID string, updatedDevice *models.Device, settings *models.Settings) {
 	liveNotify := notify.New(logger, appConfig, *updatedDevice, false)
 	liveNotify.LoadDatabaseUrls(c, deviceRepo)
 	if gateVal, exists := c.Get("NOTIFICATION_GATE"); exists {
-		if gate, ok := gateVal.(*notify.NotificationGate); ok {
-			settings, settingsErr := deviceRepo.LoadSettings(c)
-			if settingsErr != nil {
-				logger.Warnf("Failed to load settings for notification gate: %v", settingsErr)
-			}
-			if settings != nil {
-				gate.TrySend(&liveNotify, settings, false)
-				return
-			}
+		if gate, ok := gateVal.(*notify.NotificationGate); ok && gate != nil && settings != nil {
+			gate.TrySend(&liveNotify, settings, false)
+			return
 		}
 	}
 	if sendErr := liveNotify.Send(); sendErr != nil {

--- a/webapp/backend/pkg/web/missed_ping_monitor.go
+++ b/webapp/backend/pkg/web/missed_ping_monitor.go
@@ -193,7 +193,8 @@ type checkMissedPingsData struct {
 	lastSeenTimes   map[string]time.Time
 }
 
-// loadCheckData loads all data needed for missed ping checks
+// loadCheckData loads settings, flushes pending quiet-hours notifications, then
+// loads device data if missed ping checks are enabled.
 func (m *MissedPingMonitor) loadCheckData() (*checkMissedPingsData, error) {
 	deviceRepo, err := m.getOrCreateRepo()
 	if err != nil {
@@ -206,6 +207,13 @@ func (m *MissedPingMonitor) loadCheckData() (*checkMissedPingsData, error) {
 		m.resetRepo()
 		m.logger.Errorf("Failed to load settings from database: %v", err)
 		return nil, err
+	}
+
+	// Quiet-hours delivery is independent of missed ping alerts and device queries.
+	if gate := m.appEngine.NotificationGate; gate != nil && settings != nil && gate.QueueLength() > 0 {
+		flushNotify := notify.Notify{Logger: m.logger, Config: m.appEngine.Config}
+		flushNotify.LoadDatabaseUrls(m.ctx, deviceRepo)
+		gate.FlushQuietQueue(&flushNotify, settings)
 	}
 
 	if settings == nil || !settings.Metrics.NotifyOnMissedPing {
@@ -332,16 +340,6 @@ func (m *MissedPingMonitor) checkMissedPings() {
 		m.lastError = nil
 		m.statusMu.Unlock()
 		return
-	}
-
-	// Flush any notifications queued during quiet hours
-	if gate := m.appEngine.NotificationGate; gate != nil && data.settings != nil {
-		flushNotify := notify.Notify{
-			Logger: m.logger,
-			Config: m.appEngine.Config,
-		}
-		flushNotify.LoadDatabaseUrls(m.ctx, m.deviceRepo)
-		gate.FlushQuietQueue(&flushNotify, data.settings)
 	}
 
 	// Clear previous error on successful data load

--- a/webapp/backend/pkg/web/missed_ping_quiet_hours_test.go
+++ b/webapp/backend/pkg/web/missed_ping_quiet_hours_test.go
@@ -1,0 +1,86 @@
+package web
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	mock_database "github.com/analogj/scrutiny/webapp/backend/pkg/database/mock"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/models"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/notify"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMissedPingMonitorFlushesQuietQueueIndependently(t *testing.T) {
+	for _, scenario := range []string{"disabled", "enabled", "device query fails", "last seen query fails", "settings missing", "settings query fails", "empty queue"} {
+		t.Run(scenario, func(t *testing.T) {
+			var deliveries atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				deliveries.Add(1)
+				w.WriteHeader(http.StatusNoContent)
+			}))
+			defer server.Close()
+			ae, ctrl := createTestAppEngine(t)
+			gate := notify.NewNotificationGate(ae.Logger)
+			ae.NotificationGate = gate
+			monitor := NewMissedPingMonitor(ae)
+			defer monitor.cancel()
+			repo := mock_database.NewMockDeviceRepo(ctrl)
+			monitor.deviceRepo = repo
+			now := time.Now()
+			quiet := &models.Settings{}
+			quiet.Metrics.NotificationQuietStart = now.Add(-time.Hour).Format("15:04")
+			quiet.Metrics.NotificationQuietEnd = now.Add(time.Hour).Format("15:04")
+			const threshold = 55
+			send := func(since time.Time) bool {
+				n := notify.NewTemperatureNotify(ae.Logger, ae.Config, &models.Device{DeviceName: "/dev/sda"}, threshold, threshold, since, now, "celsius")
+				return gate.TrySend(&n, quiet, false)
+			}
+			if scenario != "empty queue" {
+				gate.Temperature().Evaluate("drive", threshold, threshold, 0, now, nil, send)
+				require.Equal(t, 1, gate.QueueLength())
+			}
+			settings := &models.Settings{}
+			settings.Metrics.NotifyOnMissedPing = scenario == "enabled" || scenario == "device query fails" || scenario == "last seen query fails"
+			queryError := errors.New("query failed")
+			var settingsError error
+			switch scenario {
+			case "settings missing":
+				settings = nil
+			case "settings query fails":
+				settingsError = queryError
+				repo.EXPECT().Close().Return(nil)
+			case "device query fails":
+				repo.EXPECT().GetDevices(monitor.ctx).Return(nil, queryError)
+				repo.EXPECT().Close().Return(nil)
+			case "last seen query fails":
+				repo.EXPECT().GetDevices(monitor.ctx).Return(nil, nil)
+				repo.EXPECT().GetDevicesLastSeenTimes(monitor.ctx).Return(nil, queryError)
+				repo.EXPECT().Close().Return(nil)
+			case "enabled":
+				repo.EXPECT().GetDevices(monitor.ctx).Return(nil, nil)
+				repo.EXPECT().GetDevicesLastSeenTimes(monitor.ctx).Return(nil, nil)
+			}
+			repo.EXPECT().LoadSettings(monitor.ctx).Return(settings, settingsError)
+			canFlush := settings != nil && settingsError == nil && scenario != "empty queue"
+			if canFlush {
+				repo.EXPECT().GetNotifyUrls(monitor.ctx).Return([]models.NotifyUrl{{URL: server.URL}}, nil)
+			}
+			monitor.checkMissedPings()
+			if canFlush {
+				require.EqualValues(t, 1, deliveries.Load())
+				require.Zero(t, gate.QueueLength())
+				gate.Temperature().Evaluate("drive", threshold, threshold, 0, now.Add(time.Minute), nil, send)
+				require.Zero(t, gate.QueueLength(), "a delivered excursion must not be queued again")
+			} else {
+				require.Zero(t, deliveries.Load())
+				if scenario != "empty queue" {
+					require.Equal(t, 1, gate.QueueLength())
+				}
+			}
+		})
+	}
+}

--- a/webapp/frontend/src/app/core/config/app.config.ts
+++ b/webapp/frontend/src/app/core/config/app.config.ts
@@ -30,6 +30,13 @@ export type DashboardSort =
 
 export type TemperatureUnit = 'celsius' | 'fahrenheit';
 
+export const DEFAULT_TEMPERATURE_THRESHOLD_CELSIUS = 55;
+export const DEFAULT_TEMPERATURE_DURATION_MINUTES = 30;
+export const MIN_TEMPERATURE_THRESHOLD_CELSIUS = 1;
+export const MAX_TEMPERATURE_THRESHOLD_CELSIUS = 150;
+// Largest whole-minute duration representable by the backend's int64 nanoseconds.
+export const MAX_TEMPERATURE_DURATION_MINUTES = 153722867;
+
 export type LineStroke = 'smooth' | 'straight' | 'stepline';
 
 export type DevicePoweredOnUnit = 'humanize' | 'device_hours';
@@ -129,6 +136,9 @@ export interface AppConfig {
     };
 
     metrics?: {
+        notify_on_temperature?: boolean;
+        temperature_threshold_celsius?: number;
+        temperature_duration_minutes?: number;
         notify_level?: MetricsNotifyLevel;
         status_filter_attributes?: MetricsStatusFilterAttributes;
         status_threshold?: MetricsStatusThreshold;
@@ -223,6 +233,9 @@ export const appConfig: AppConfig = {
     },
 
     metrics: {
+        notify_on_temperature: false,
+        temperature_threshold_celsius: DEFAULT_TEMPERATURE_THRESHOLD_CELSIUS,
+        temperature_duration_minutes: DEFAULT_TEMPERATURE_DURATION_MINUTES,
         notify_level: MetricsNotifyLevel.Fail,
         status_filter_attributes: MetricsStatusFilterAttributes.All,
         status_threshold: MetricsStatusThreshold.Both,

--- a/webapp/frontend/src/app/data/mock/settings/data.ts
+++ b/webapp/frontend/src/app/data/mock/settings/data.ts
@@ -1,3 +1,5 @@
+import { DEFAULT_TEMPERATURE_THRESHOLD_CELSIUS, DEFAULT_TEMPERATURE_DURATION_MINUTES } from 'app/core/config/app.config';
+
 export const settings = {
     zfs_pool_modifications_allowed: true,
     settings: {
@@ -13,6 +15,9 @@ export const settings = {
         time_format: '24',
         line_stroke: 'smooth',
         metrics: {
+            notify_on_temperature: false,
+            temperature_threshold_celsius: DEFAULT_TEMPERATURE_THRESHOLD_CELSIUS,
+            temperature_duration_minutes: DEFAULT_TEMPERATURE_DURATION_MINUTES,
             notify_level: 2,
             status_filter_attributes: 0,
             status_threshold: 3,

--- a/webapp/frontend/src/app/layout/common/dashboard-settings/dashboard-settings.component.html
+++ b/webapp/frontend/src/app/layout/common/dashboard-settings/dashboard-settings.component.html
@@ -43,7 +43,7 @@
         <div class="flex flex-col mt-5 gt-md:flex-row">
             <mat-form-field class="flex-auto gt-xs:pr-3 gt-md:pr-3">
                 <mat-label>Temperature</mat-label>
-                <mat-select [(ngModel)]="temperatureUnit">
+                <mat-select [ngModel]="temperatureUnit" (ngModelChange)="setTemperatureUnit($event)">
                     <mat-option value="celsius">Celsius</mat-option>
                     <mat-option value="fahrenheit">Fahrenheit</mat-option>
                 </mat-select>
@@ -279,7 +279,16 @@
         <div class="flex flex-col mt-5 gt-md:flex-row">
             <mat-form-field class="flex-auto gt-xs:pr-3 gt-md:pr-3">
                 <mat-label>Temperature Threshold ({{ temperatureUnit === 'fahrenheit' ? '°F' : '°C' }})</mat-label>
-                <input matInput type="number" [(ngModel)]="temperatureThresholdDisplay" [min]="temperatureThresholdMin" [max]="temperatureThresholdMax" step="any" required />
+                <input
+                    matInput
+                    type="number"
+                    [(ngModel)]="temperatureThresholdDisplay"
+                    (blur)="normalizeTemperatureThreshold()"
+                    [min]="temperatureThresholdMin"
+                    [max]="temperatureThresholdMax"
+                    step="any"
+                    required
+                />
                 <mat-hint>Stored to the nearest whole degree Celsius</mat-hint>
             </mat-form-field>
             <mat-form-field class="flex-auto gt-xs:pr-3 gt-md:pl-3">

--- a/webapp/frontend/src/app/layout/common/dashboard-settings/dashboard-settings.component.html
+++ b/webapp/frontend/src/app/layout/common/dashboard-settings/dashboard-settings.component.html
@@ -264,6 +264,36 @@
         </div>
         }
 
+        <!-- Temperature Notifications -->
+        <div class="flex flex-col mt-5 gt-md:flex-row">
+            <mat-form-field class="flex-auto gt-xs:pr-3 gt-md:pr-3">
+                <mat-label>Temperature Notifications</mat-label>
+                <mat-select [(ngModel)]="notifyOnTemperature">
+                    <mat-option [value]="true">Enabled</mat-option>
+                    <mat-option [value]="false">Disabled</mat-option>
+                </mat-select>
+                <mat-hint>Alert once when a drive stays hot</mat-hint>
+            </mat-form-field>
+        </div>
+        @if (notifyOnTemperature) {
+        <div class="flex flex-col mt-5 gt-md:flex-row">
+            <mat-form-field class="flex-auto gt-xs:pr-3 gt-md:pr-3">
+                <mat-label>Temperature Threshold ({{ temperatureUnit === 'fahrenheit' ? '°F' : '°C' }})</mat-label>
+                <input matInput type="number" [(ngModel)]="temperatureThresholdDisplay" [min]="temperatureThresholdMin" [max]="temperatureThresholdMax" step="any" required />
+                <mat-hint>Stored to the nearest whole degree Celsius</mat-hint>
+            </mat-form-field>
+            <mat-form-field class="flex-auto gt-xs:pr-3 gt-md:pl-3">
+                <mat-label>Sustained Duration (minutes)</mat-label>
+                <input matInput type="number" [(ngModel)]="temperatureDurationMinutes" min="0" [max]="maxTemperatureDurationMinutes" step="1" required />
+                <mat-hint>0 = notify on the first reading at or above the threshold</mat-hint>
+            </mat-form-field>
+        </div>
+        @if (temperatureSettingsInvalid) {
+        <p role="alert" class="mt-5">
+            Enter a threshold between {{ temperatureThresholdMin }} and {{ temperatureThresholdMax }} and a whole-minute duration between 0 and {{ maxTemperatureDurationMinutes }}.
+        </p>
+        } }
+
         <!-- Notification Rate Limiting -->
         <div class="flex flex-col mt-5 gt-md:flex-row">
             <mat-form-field class="flex-auto gt-xs:pr-3 gt-md:pr-3">
@@ -888,5 +918,5 @@
 </mat-dialog-content>
 <mat-dialog-actions align="end">
     <button mat-button mat-dialog-close>Cancel</button>
-    <button mat-button mat-dialog-close (click)="saveSettings()" cdkFocusInitial>Save</button>
+    <button mat-button mat-dialog-close (click)="saveSettings()" [disabled]="temperatureSettingsInvalid" cdkFocusInitial>Save</button>
 </mat-dialog-actions>

--- a/webapp/frontend/src/app/layout/common/dashboard-settings/dashboard-settings.component.spec.ts
+++ b/webapp/frontend/src/app/layout/common/dashboard-settings/dashboard-settings.component.spec.ts
@@ -7,7 +7,7 @@ import { ScrutinyConfigService } from 'app/core/config/scrutiny-config.service';
 import { AttributeOverrideService } from 'app/core/config/attribute-override.service';
 import { DashboardService } from 'app/modules/dashboard/dashboard.service';
 import { NotifyUrlService } from 'app/core/config/notify-url.service';
-import { AppConfig, appConfig } from 'app/core/config/app.config';
+import { AppConfig, appConfig, DEFAULT_TEMPERATURE_THRESHOLD_CELSIUS, DEFAULT_TEMPERATURE_DURATION_MINUTES } from 'app/core/config/app.config';
 
 describe('DashboardSettingsComponent temperature notifications', () => {
     let component: DashboardSettingsComponent;
@@ -103,6 +103,34 @@ describe('DashboardSettingsComponent temperature notifications', () => {
         for (const invalid of [null, -1, 0.5, Infinity, 153722868]) {
             component.temperatureDurationMinutes = invalid;
             expect(component.temperatureSettingsInvalid).toBeTrue();
+        }
+    });
+
+    it('uses valid defaults for invalid hidden values when notifications are disabled', () => {
+        component.notifyOnTemperature = false;
+        for (const invalid of [null, NaN, Infinity, -1, component.temperatureThresholdMax + 1]) {
+            component.temperatureThresholdDisplay = invalid;
+            component.saveSettings();
+            expect(configService.config?.metrics?.temperature_threshold_celsius).toBe(DEFAULT_TEMPERATURE_THRESHOLD_CELSIUS);
+        }
+        for (const invalid of [null, NaN, Infinity, -1, 0.5, component.maxTemperatureDurationMinutes + 1]) {
+            component.temperatureDurationMinutes = invalid;
+            component.saveSettings();
+            expect(configService.config?.metrics?.temperature_duration_minutes).toBe(DEFAULT_TEMPERATURE_DURATION_MINUTES);
+            expect(configService.config?.metrics?.notify_on_temperature).toBeFalse();
+        }
+    });
+
+    it('preserves valid hidden settings, including immediate delivery, when disabled', () => {
+        component.notifyOnTemperature = false;
+        component.setTemperatureUnit('fahrenheit');
+        const threshold = 60;
+        component.temperatureThresholdCelsius = threshold;
+        for (const duration of [0, component.maxTemperatureDurationMinutes]) {
+            component.temperatureDurationMinutes = duration;
+            component.saveSettings();
+            expect(configService.config?.metrics?.temperature_threshold_celsius).toBe(threshold);
+            expect(configService.config?.metrics?.temperature_duration_minutes).toBe(duration);
         }
     });
 

--- a/webapp/frontend/src/app/layout/common/dashboard-settings/dashboard-settings.component.spec.ts
+++ b/webapp/frontend/src/app/layout/common/dashboard-settings/dashboard-settings.component.spec.ts
@@ -1,0 +1,86 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClient } from '@angular/common/http';
+import { BehaviorSubject } from 'rxjs';
+import { DashboardSettingsComponent } from './dashboard-settings.component';
+import { ScrutinyConfigService } from 'app/core/config/scrutiny-config.service';
+import { AttributeOverrideService } from 'app/core/config/attribute-override.service';
+import { DashboardService } from 'app/modules/dashboard/dashboard.service';
+import { NotifyUrlService } from 'app/core/config/notify-url.service';
+import { AppConfig, appConfig } from 'app/core/config/app.config';
+
+describe('DashboardSettingsComponent temperature notifications', () => {
+    let component: DashboardSettingsComponent;
+    let configService: { config$: BehaviorSubject<AppConfig>; config?: AppConfig };
+
+    beforeEach(() => {
+        configService = { config$: new BehaviorSubject<AppConfig>(structuredClone(appConfig)) };
+        TestBed.configureTestingModule({
+            providers: [
+                { provide: ScrutinyConfigService, useValue: configService },
+                { provide: AttributeOverrideService, useValue: {} },
+                { provide: DashboardService, useValue: {} },
+                { provide: NotifyUrlService, useValue: {} },
+                { provide: HttpClient, useValue: {} },
+            ],
+        });
+        component = TestBed.runInInjectionContext(() => new DashboardSettingsComponent());
+        spyOn(component, 'loadOverrides');
+        spyOn(component, 'loadOverrideDevices');
+        spyOn(component, 'loadNotifyUrls');
+        component.ngOnInit();
+    });
+
+    it('loads defaults and preserves an immediate duration', () => {
+        expect(component.notifyOnTemperature).toBeFalse();
+        expect(component.temperatureThresholdCelsius).toBe(55);
+        expect(component.temperatureDurationMinutes).toBe(30);
+        configService.config$.next({ ...appConfig, metrics: { ...appConfig.metrics, temperature_duration_minutes: 0 } });
+        expect(component.temperatureDurationMinutes).toBe(0);
+    });
+
+    it('round-trips both units and switches units without changing Celsius', () => {
+        component.temperatureThresholdDisplay = 60;
+        expect(component.temperatureThresholdCelsius).toBe(60);
+        component.temperatureUnit = 'fahrenheit';
+        expect(component.temperatureThresholdDisplay).toBe(140);
+        component.temperatureThresholdDisplay = 131;
+        expect(component.temperatureThresholdCelsius).toBe(55);
+        expect(component.temperatureThresholdMin).toBeCloseTo(33.8);
+        expect(component.temperatureThresholdMax).toBe(302);
+        component.temperatureUnit = 'celsius';
+        expect(component.temperatureThresholdDisplay).toBe(55);
+        expect(component.temperatureThresholdMin).toBe(1);
+        expect(component.temperatureThresholdMax).toBe(150);
+    });
+
+    it('saves Celsius and a zero duration', () => {
+        component.notifyOnTemperature = true;
+        component.temperatureUnit = 'fahrenheit';
+        component.temperatureThresholdDisplay = 140;
+        component.temperatureDurationMinutes = 0;
+        component.saveSettings();
+        expect(configService.config?.metrics?.notify_on_temperature).toBeTrue();
+        expect(configService.config?.metrics?.temperature_threshold_celsius).toBe(60);
+        expect(configService.config?.metrics?.temperature_duration_minutes).toBe(0);
+    });
+
+    it('rejects empty and out-of-range thresholds while enabled', () => {
+        component.notifyOnTemperature = true;
+        for (const invalid of [null, NaN, 0, 151]) {
+            component.temperatureThresholdDisplay = invalid;
+            expect(component.temperatureSettingsInvalid).toBeTrue();
+            component.saveSettings();
+            expect(configService.config).toBeUndefined();
+        }
+        component.notifyOnTemperature = false;
+        expect(component.temperatureSettingsInvalid).toBeFalse();
+    });
+
+    it('rejects invalid durations', () => {
+        component.notifyOnTemperature = true;
+        for (const invalid of [null, -1, 0.5, Infinity, 153722868]) {
+            component.temperatureDurationMinutes = invalid;
+            expect(component.temperatureSettingsInvalid).toBeTrue();
+        }
+    });
+});

--- a/webapp/frontend/src/app/layout/common/dashboard-settings/dashboard-settings.component.spec.ts
+++ b/webapp/frontend/src/app/layout/common/dashboard-settings/dashboard-settings.component.spec.ts
@@ -1,4 +1,5 @@
-import { TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatIconTestingModule } from '@angular/material/icon/testing';
 import { HttpClient } from '@angular/common/http';
 import { BehaviorSubject } from 'rxjs';
 import { DashboardSettingsComponent } from './dashboard-settings.component';
@@ -10,11 +11,13 @@ import { AppConfig, appConfig } from 'app/core/config/app.config';
 
 describe('DashboardSettingsComponent temperature notifications', () => {
     let component: DashboardSettingsComponent;
+    let fixture: ComponentFixture<DashboardSettingsComponent>;
     let configService: { config$: BehaviorSubject<AppConfig>; config?: AppConfig };
 
-    beforeEach(() => {
+    beforeEach(async () => {
         configService = { config$: new BehaviorSubject<AppConfig>(structuredClone(appConfig)) };
         TestBed.configureTestingModule({
+            imports: [DashboardSettingsComponent, MatIconTestingModule],
             providers: [
                 { provide: ScrutinyConfigService, useValue: configService },
                 { provide: AttributeOverrideService, useValue: {} },
@@ -23,11 +26,13 @@ describe('DashboardSettingsComponent temperature notifications', () => {
                 { provide: HttpClient, useValue: {} },
             ],
         });
-        component = TestBed.runInInjectionContext(() => new DashboardSettingsComponent());
+        fixture = TestBed.createComponent(DashboardSettingsComponent);
+        component = fixture.componentInstance;
         spyOn(component, 'loadOverrides');
         spyOn(component, 'loadOverrideDevices');
         spyOn(component, 'loadNotifyUrls');
-        component.ngOnInit();
+        fixture.detectChanges();
+        await fixture.whenStable();
     });
 
     it('loads defaults and preserves an immediate duration', () => {
@@ -41,21 +46,37 @@ describe('DashboardSettingsComponent temperature notifications', () => {
     it('round-trips both units and switches units without changing Celsius', () => {
         component.temperatureThresholdDisplay = 60;
         expect(component.temperatureThresholdCelsius).toBe(60);
-        component.temperatureUnit = 'fahrenheit';
+        component.setTemperatureUnit('fahrenheit');
         expect(component.temperatureThresholdDisplay).toBe(140);
         component.temperatureThresholdDisplay = 131;
         expect(component.temperatureThresholdCelsius).toBe(55);
         expect(component.temperatureThresholdMin).toBeCloseTo(33.8);
         expect(component.temperatureThresholdMax).toBe(302);
-        component.temperatureUnit = 'celsius';
+        component.setTemperatureUnit('celsius');
         expect(component.temperatureThresholdDisplay).toBe(55);
         expect(component.temperatureThresholdMin).toBe(1);
         expect(component.temperatureThresholdMax).toBe(150);
     });
 
+    it('keeps boundary thresholds valid when switching units and leaves invalid values invalid', () => {
+        component.notifyOnTemperature = true;
+        for (const boundary of [component.temperatureThresholdMin, component.temperatureThresholdMax]) {
+            component.temperatureThresholdDisplay = boundary;
+            component.setTemperatureUnit('fahrenheit');
+            expect(component.temperatureSettingsInvalid).toBeFalse();
+            component.setTemperatureUnit('celsius');
+            expect(component.temperatureThresholdDisplay).toBe(boundary);
+            expect(component.temperatureSettingsInvalid).toBeFalse();
+        }
+        component.temperatureThresholdDisplay = 0.9;
+        component.setTemperatureUnit('fahrenheit');
+        component.setTemperatureUnit('celsius');
+        expect(component.temperatureSettingsInvalid).toBeTrue();
+    });
+
     it('saves Celsius and a zero duration', () => {
         component.notifyOnTemperature = true;
-        component.temperatureUnit = 'fahrenheit';
+        component.setTemperatureUnit('fahrenheit');
         component.temperatureThresholdDisplay = 140;
         component.temperatureDurationMinutes = 0;
         component.saveSettings();
@@ -66,8 +87,9 @@ describe('DashboardSettingsComponent temperature notifications', () => {
 
     it('rejects empty and out-of-range thresholds while enabled', () => {
         component.notifyOnTemperature = true;
-        for (const invalid of [null, NaN, 0, 151]) {
+        for (const invalid of [null, NaN, Infinity, 0, 0.9, 150.1, 151]) {
             component.temperatureThresholdDisplay = invalid;
+            component.normalizeTemperatureThreshold();
             expect(component.temperatureSettingsInvalid).toBeTrue();
             component.saveSettings();
             expect(configService.config).toBeUndefined();
@@ -82,5 +104,63 @@ describe('DashboardSettingsComponent temperature notifications', () => {
             component.temperatureDurationMinutes = invalid;
             expect(component.temperatureSettingsInvalid).toBeTrue();
         }
+    });
+
+    it('preserves fractional and empty values when switching units and rounds on save', () => {
+        component.notifyOnTemperature = true;
+        component.temperatureThresholdDisplay = 55.5;
+        component.setTemperatureUnit('fahrenheit');
+        expect(component.temperatureThresholdDisplay).toBeCloseTo(131.9);
+        component.setTemperatureUnit('celsius');
+        expect(component.temperatureThresholdDisplay).toBeCloseTo(55.5);
+        component.saveSettings();
+        expect(configService.config?.metrics?.temperature_threshold_celsius).toBe(56);
+        component.temperatureThresholdDisplay = null;
+        component.setTemperatureUnit('fahrenheit');
+        expect(component.temperatureThresholdDisplay).toBeNull();
+    });
+
+    it('preserves Fahrenheit keystrokes until blur', async () => {
+        configService.config$.next({ ...appConfig, temperature_unit: 'fahrenheit', metrics: { ...appConfig.metrics, notify_on_temperature: true } });
+        fixture.changeDetectorRef.markForCheck();
+        fixture.detectChanges();
+        await fixture.whenStable();
+        const input: HTMLInputElement = fixture.nativeElement.querySelector('input[step="any"]');
+        for (const value of ['1', '13', '131', '131.5']) {
+            input.value = value;
+            input.dispatchEvent(new Event('input'));
+            fixture.detectChanges();
+            await fixture.whenStable();
+            expect(input.value).toBe(value);
+        }
+        input.dispatchEvent(new Event('blur'));
+        fixture.detectChanges();
+        await fixture.whenStable();
+        expect(input.value).toBe('131');
+    });
+
+    it('normalizes fractional Celsius only on blur and keeps cleared input invalid', async () => {
+        component.notifyOnTemperature = true;
+        fixture.changeDetectorRef.markForCheck();
+        fixture.detectChanges();
+        await fixture.whenStable();
+        const input: HTMLInputElement = fixture.nativeElement.querySelector('input[step="any"]');
+        input.value = '55.5';
+        input.dispatchEvent(new Event('input'));
+        fixture.detectChanges();
+        await fixture.whenStable();
+        expect(input.value).toBe('55.5');
+        input.dispatchEvent(new Event('blur'));
+        fixture.detectChanges();
+        await fixture.whenStable();
+        expect(input.value).toBe('56');
+        input.value = '';
+        input.dispatchEvent(new Event('input'));
+        input.dispatchEvent(new Event('blur'));
+        fixture.detectChanges();
+        await fixture.whenStable();
+        expect(input.value).toBe('');
+        const saveButton: HTMLButtonElement = fixture.nativeElement.querySelector('button[cdkFocusInitial]');
+        expect(saveButton.disabled).toBeTrue();
     });
 });

--- a/webapp/frontend/src/app/layout/common/dashboard-settings/dashboard-settings.component.ts
+++ b/webapp/frontend/src/app/layout/common/dashboard-settings/dashboard-settings.component.ts
@@ -2,6 +2,11 @@ import { Component, OnInit, inject, ChangeDetectionStrategy } from '@angular/cor
 import { HttpClient } from '@angular/common/http';
 import {
     AppConfig,
+    DEFAULT_TEMPERATURE_THRESHOLD_CELSIUS,
+    DEFAULT_TEMPERATURE_DURATION_MINUTES,
+    MIN_TEMPERATURE_THRESHOLD_CELSIUS,
+    MAX_TEMPERATURE_THRESHOLD_CELSIUS,
+    MAX_TEMPERATURE_DURATION_MINUTES,
     DashboardColumns,
     DashboardDensity,
     DashboardHostPageSize,
@@ -43,6 +48,7 @@ import { MatTable, MatColumnDef, MatHeaderCellDef, MatHeaderCell, MatCellDef, Ma
 import { MatTooltip } from '@angular/material/tooltip';
 import { MatSlideToggle } from '@angular/material/slide-toggle';
 import { HelpLinkIconComponent } from 'app/layout/common/help-link-icon/help-link-icon.component';
+import { TemperaturePipe } from 'app/shared/temperature.pipe';
 
 @Component({
     selector: 'app-dashboard-settings',
@@ -112,6 +118,48 @@ export class DashboardSettingsComponent implements OnInit {
 
     // Collector error settings
     notifyOnCollectorError: boolean;
+
+    notifyOnTemperature = false;
+    temperatureThresholdCelsius: number | null = DEFAULT_TEMPERATURE_THRESHOLD_CELSIUS;
+    temperatureDurationMinutes: number | null = DEFAULT_TEMPERATURE_DURATION_MINUTES;
+    readonly maxTemperatureDurationMinutes = MAX_TEMPERATURE_DURATION_MINUTES;
+
+    get temperatureThresholdDisplay(): number | null {
+        if (this.temperatureThresholdCelsius == null) {
+            return null;
+        }
+        return this.temperatureUnit === 'fahrenheit' ? TemperaturePipe.celsiusToFahrenheit(this.temperatureThresholdCelsius) : this.temperatureThresholdCelsius;
+    }
+
+    set temperatureThresholdDisplay(value: number | null) {
+        if (value == null || !Number.isFinite(value)) {
+            this.temperatureThresholdCelsius = null;
+            return;
+        }
+        this.temperatureThresholdCelsius = Math.round(this.temperatureUnit === 'fahrenheit' ? TemperaturePipe.fahrenheitToCelsius(value) : value);
+    }
+
+    get temperatureThresholdMin(): number {
+        return this.temperatureUnit === 'fahrenheit' ? TemperaturePipe.celsiusToFahrenheit(MIN_TEMPERATURE_THRESHOLD_CELSIUS) : MIN_TEMPERATURE_THRESHOLD_CELSIUS;
+    }
+
+    get temperatureThresholdMax(): number {
+        return this.temperatureUnit === 'fahrenheit' ? TemperaturePipe.celsiusToFahrenheit(MAX_TEMPERATURE_THRESHOLD_CELSIUS) : MAX_TEMPERATURE_THRESHOLD_CELSIUS;
+    }
+
+    get temperatureSettingsInvalid(): boolean {
+        return (
+            this.notifyOnTemperature &&
+            (this.temperatureThresholdCelsius == null ||
+                !Number.isInteger(this.temperatureThresholdCelsius) ||
+                this.temperatureThresholdCelsius < MIN_TEMPERATURE_THRESHOLD_CELSIUS ||
+                this.temperatureThresholdCelsius > MAX_TEMPERATURE_THRESHOLD_CELSIUS ||
+                this.temperatureDurationMinutes == null ||
+                !Number.isInteger(this.temperatureDurationMinutes) ||
+                this.temperatureDurationMinutes < 0 ||
+                this.temperatureDurationMinutes > MAX_TEMPERATURE_DURATION_MINUTES)
+        );
+    }
 
     // Missed ping settings
     notifyOnMissedPing: boolean;
@@ -241,6 +289,10 @@ export class DashboardSettingsComponent implements OnInit {
 
             // Collector error settings
             this.notifyOnCollectorError = config.metrics.notify_on_collector_error ?? true;
+
+            this.notifyOnTemperature = config.metrics.notify_on_temperature ?? false;
+            this.temperatureThresholdCelsius = config.metrics.temperature_threshold_celsius ?? DEFAULT_TEMPERATURE_THRESHOLD_CELSIUS;
+            this.temperatureDurationMinutes = config.metrics.temperature_duration_minutes ?? DEFAULT_TEMPERATURE_DURATION_MINUTES;
 
             // Missed ping settings
             this.notifyOnMissedPing = config.metrics.notify_on_missed_ping ?? false;
@@ -559,6 +611,9 @@ export class DashboardSettingsComponent implements OnInit {
     }
 
     saveSettings(): void {
+        if (this.temperatureSettingsInvalid) {
+            return;
+        }
         const newSettings: AppConfig = {
             navigation: {
                 show_zfs_pools: this.showZFSPools,
@@ -587,6 +642,9 @@ export class DashboardSettingsComponent implements OnInit {
                 status_threshold: this.statusThreshold as MetricsStatusThreshold,
                 repeat_notifications: this.repeatNotifications,
                 notify_on_collector_error: this.notifyOnCollectorError,
+                notify_on_temperature: this.notifyOnTemperature,
+                temperature_threshold_celsius: this.temperatureThresholdCelsius ?? DEFAULT_TEMPERATURE_THRESHOLD_CELSIUS,
+                temperature_duration_minutes: this.temperatureDurationMinutes ?? DEFAULT_TEMPERATURE_DURATION_MINUTES,
                 notify_on_missed_ping: this.notifyOnMissedPing,
                 missed_ping_timeout_minutes: this.missedPingTimeoutMinutes,
                 missed_ping_check_interval_mins: this.missedPingCheckIntervalMins,

--- a/webapp/frontend/src/app/layout/common/dashboard-settings/dashboard-settings.component.ts
+++ b/webapp/frontend/src/app/layout/common/dashboard-settings/dashboard-settings.component.ts
@@ -120,23 +120,38 @@ export class DashboardSettingsComponent implements OnInit {
     notifyOnCollectorError: boolean;
 
     notifyOnTemperature = false;
-    temperatureThresholdCelsius: number | null = DEFAULT_TEMPERATURE_THRESHOLD_CELSIUS;
+    temperatureThresholdDisplay: number | null = DEFAULT_TEMPERATURE_THRESHOLD_CELSIUS;
     temperatureDurationMinutes: number | null = DEFAULT_TEMPERATURE_DURATION_MINUTES;
     readonly maxTemperatureDurationMinutes = MAX_TEMPERATURE_DURATION_MINUTES;
 
-    get temperatureThresholdDisplay(): number | null {
-        if (this.temperatureThresholdCelsius == null) {
+    get temperatureThresholdCelsius(): number | null {
+        const value = this.temperatureThresholdDisplay;
+        if (value == null || !Number.isFinite(value)) {
             return null;
         }
-        return this.temperatureUnit === 'fahrenheit' ? TemperaturePipe.celsiusToFahrenheit(this.temperatureThresholdCelsius) : this.temperatureThresholdCelsius;
+        return Math.round(this.temperatureUnit === 'fahrenheit' ? TemperaturePipe.fahrenheitToCelsius(value) : value);
     }
 
-    set temperatureThresholdDisplay(value: number | null) {
-        if (value == null || !Number.isFinite(value)) {
-            this.temperatureThresholdCelsius = null;
-            return;
+    set temperatureThresholdCelsius(value: number | null) {
+        this.temperatureThresholdDisplay = value == null ? null : this.temperatureUnit === 'fahrenheit' ? TemperaturePipe.celsiusToFahrenheit(value) : value;
+    }
+
+    setTemperatureUnit(unit: string): void {
+        const value = this.temperatureThresholdDisplay;
+        let celsius = value == null ? null : this.temperatureUnit === 'fahrenheit' ? TemperaturePipe.fahrenheitToCelsius(value) : value;
+        if (celsius != null && !this.temperatureThresholdInvalid) {
+            // Keep valid boundary values in range despite floating-point conversion error.
+            celsius = Math.min(MAX_TEMPERATURE_THRESHOLD_CELSIUS, Math.max(MIN_TEMPERATURE_THRESHOLD_CELSIUS, celsius));
         }
-        this.temperatureThresholdCelsius = Math.round(this.temperatureUnit === 'fahrenheit' ? TemperaturePipe.fahrenheitToCelsius(value) : value);
+        this.temperatureUnit = unit;
+        this.temperatureThresholdCelsius = celsius;
+    }
+
+    normalizeTemperatureThreshold(): void {
+        if (!this.temperatureThresholdInvalid) {
+            const celsius = this.temperatureThresholdCelsius;
+            this.temperatureThresholdCelsius = celsius;
+        }
     }
 
     get temperatureThresholdMin(): number {
@@ -147,13 +162,15 @@ export class DashboardSettingsComponent implements OnInit {
         return this.temperatureUnit === 'fahrenheit' ? TemperaturePipe.celsiusToFahrenheit(MAX_TEMPERATURE_THRESHOLD_CELSIUS) : MAX_TEMPERATURE_THRESHOLD_CELSIUS;
     }
 
+    get temperatureThresholdInvalid(): boolean {
+        const value = this.temperatureThresholdDisplay;
+        return value == null || !Number.isFinite(value) || value < this.temperatureThresholdMin || value > this.temperatureThresholdMax;
+    }
+
     get temperatureSettingsInvalid(): boolean {
         return (
             this.notifyOnTemperature &&
-            (this.temperatureThresholdCelsius == null ||
-                !Number.isInteger(this.temperatureThresholdCelsius) ||
-                this.temperatureThresholdCelsius < MIN_TEMPERATURE_THRESHOLD_CELSIUS ||
-                this.temperatureThresholdCelsius > MAX_TEMPERATURE_THRESHOLD_CELSIUS ||
+            (this.temperatureThresholdInvalid ||
                 this.temperatureDurationMinutes == null ||
                 !Number.isInteger(this.temperatureDurationMinutes) ||
                 this.temperatureDurationMinutes < 0 ||
@@ -614,6 +631,7 @@ export class DashboardSettingsComponent implements OnInit {
         if (this.temperatureSettingsInvalid) {
             return;
         }
+        this.normalizeTemperatureThreshold();
         const newSettings: AppConfig = {
             navigation: {
                 show_zfs_pools: this.showZFSPools,

--- a/webapp/frontend/src/app/layout/common/dashboard-settings/dashboard-settings.component.ts
+++ b/webapp/frontend/src/app/layout/common/dashboard-settings/dashboard-settings.component.ts
@@ -167,15 +167,17 @@ export class DashboardSettingsComponent implements OnInit {
         return value == null || !Number.isFinite(value) || value < this.temperatureThresholdMin || value > this.temperatureThresholdMax;
     }
 
-    get temperatureSettingsInvalid(): boolean {
+    get temperatureDurationInvalid(): boolean {
         return (
-            this.notifyOnTemperature &&
-            (this.temperatureThresholdInvalid ||
-                this.temperatureDurationMinutes == null ||
-                !Number.isInteger(this.temperatureDurationMinutes) ||
-                this.temperatureDurationMinutes < 0 ||
-                this.temperatureDurationMinutes > MAX_TEMPERATURE_DURATION_MINUTES)
+            this.temperatureDurationMinutes == null ||
+            !Number.isInteger(this.temperatureDurationMinutes) ||
+            this.temperatureDurationMinutes < 0 ||
+            this.temperatureDurationMinutes > MAX_TEMPERATURE_DURATION_MINUTES
         );
+    }
+
+    get temperatureSettingsInvalid(): boolean {
+        return this.notifyOnTemperature && (this.temperatureThresholdInvalid || this.temperatureDurationInvalid);
     }
 
     // Missed ping settings
@@ -661,8 +663,8 @@ export class DashboardSettingsComponent implements OnInit {
                 repeat_notifications: this.repeatNotifications,
                 notify_on_collector_error: this.notifyOnCollectorError,
                 notify_on_temperature: this.notifyOnTemperature,
-                temperature_threshold_celsius: this.temperatureThresholdCelsius ?? DEFAULT_TEMPERATURE_THRESHOLD_CELSIUS,
-                temperature_duration_minutes: this.temperatureDurationMinutes ?? DEFAULT_TEMPERATURE_DURATION_MINUTES,
+                temperature_threshold_celsius: this.temperatureThresholdInvalid ? DEFAULT_TEMPERATURE_THRESHOLD_CELSIUS : this.temperatureThresholdCelsius,
+                temperature_duration_minutes: this.temperatureDurationInvalid ? DEFAULT_TEMPERATURE_DURATION_MINUTES : this.temperatureDurationMinutes,
                 notify_on_missed_ping: this.notifyOnMissedPing,
                 missed_ping_timeout_minutes: this.missedPingTimeoutMinutes,
                 missed_ping_check_interval_mins: this.missedPingCheckIntervalMins,

--- a/webapp/frontend/src/app/shared/temperature.pipe.spec.ts
+++ b/webapp/frontend/src/app/shared/temperature.pipe.spec.ts
@@ -1,6 +1,11 @@
 import { TemperaturePipe } from './temperature.pipe';
 
 describe('TemperaturePipe', () => {
+    it('converts Fahrenheit back to Celsius', () => {
+        for (const celsius of [-40, 0, 1, 55, 150]) {
+            expect(TemperaturePipe.fahrenheitToCelsius(TemperaturePipe.celsiusToFahrenheit(celsius))).toBeCloseTo(celsius);
+        }
+    });
     it('create an instance', () => {
         const pipe = new TemperaturePipe();
         expect(pipe).toBeTruthy();

--- a/webapp/frontend/src/app/shared/temperature.pipe.ts
+++ b/webapp/frontend/src/app/shared/temperature.pipe.ts
@@ -3,6 +3,11 @@ import { formatNumber } from '@angular/common';
 
 @Pipe({ name: 'temperature' })
 export class TemperaturePipe implements PipeTransform {
+    static fahrenheitToCelsius(fahrenheitTemp: number): number {
+        const fahrenheitOffset = 32;
+        const celsiusScale = 5 / 9;
+        return (fahrenheitTemp - fahrenheitOffset) * celsiusScale;
+    }
     static celsiusToFahrenheit(celsiusTemp: number): number {
         return (celsiusTemp * 9) / 5 + 32;
     }


### PR DESCRIPTION
## Summary

Add optional alerts when a drive stays at or above a configurable temperature threshold for a configurable duration.

The feature defaults to disabled, with a threshold of 55°C for 30 minutes. Each hot excursion alerts once; cooling below the threshold silently re-arms it. A duration of zero alerts on the first hot upload.

## Type of Change

- [x] New feature
- [x] Bug fix
- [x] Documentation update
- [x] Refactoring

## Changes Made

- Add temperature notification settings, Celsius/Fahrenheit editing, API validation, and database defaults.
- Evaluate temperature on collector uploads, respecting device muting, quiet hours, and notification rate limits.
- Seed new timers from up to 24 hours of raw history when temperature storage is enabled and the current upload is present.
- Reset timers after threshold/duration changes or uploads while alerts are disabled or the device is muted.
- Repair the legacy temperature-history storage setting key.
- Flush quiet-hours digests independently of missed-ping alerts and retain them after failed or rate-limited delivery.
- Bound HTTP webhook requests to 10 seconds and require successful HTTP status codes.
- Preserve delivery retries while suppressing repeated missing-endpoint warnings.
- Reuse notification settings within each upload and document notification behavior and limitations.

## Testing

- [x] Tested locally
- [x] Added regression tests
- [ ] All existing tests pass

207 frontend tests, the production frontend build, changed-file frontend lint, icon/theme checks, and OpenAPI parsing pass.

Affected Go tests pass with known Unix-specific fixtures excluded. The broader native Windows run encounters existing platform-specific failures. Shared-InfluxDB integration tests were excluded; full Linux tests and backend lint remain for CI.

## Additional Notes

Notification state and quiet-hours queues remain in memory. Restart seeding is bounded and may produce another alert for an ongoing excursion. Temperature alerts do not send recovery notifications or apply hysteresis.

Direct temperature notifications use failure type `Temperature`. Quiet-hours digests retain the existing `MissedPing` type for compatibility. Partial delivery failures may repeat messages to destinations that already succeeded.
