### PR TITLE
[829] Preserve device history across collector host migration

### DIFF
--- a/docs/TROUBLESHOOTING_DEVICE_COLLECTOR.md
+++ b/docs/TROUBLESHOOTING_DEVICE_COLLECTOR.md
@@ -421,6 +421,19 @@ the host-id:
 
 See the [Hub/Spoke installation guide](./INSTALL_HUB_SPOKE.md) for more information.
 
+### Moving a monitored device to another collector host
+
+`host_id` is mutable device metadata. When a collector registers a device again, Scrutiny updates its stored host ID while preserving the device identity and SMART history. Keep the device's model, serial number, and WWN available so the generated `device_id` remains stable.
+
+To move devices without deleting history:
+
+1. Set the new value with `host.id` in the collector config, `--host-id`, or `COLLECTOR_HOST_ID`.
+2. Stop the old collector before starting the new one for the same devices.
+3. Run one collection from the new host.
+4. Confirm the device appears under the new host ID in the SMART dashboard.
+
+An empty host ID clears the stored assignment. If two collectors report the same device, the most recent registration wins. Devices with no model, serial number, or WWN use a device-name and host-ID fallback identity, so host migration cannot preserve their history reliably.
+
 ## Collector DEBUG mode
 
 You can use environmental variables to enable debug logging and/or log files for the collector:

--- a/webapp/backend/pkg/database/scrutiny_repository_device_history_query_test.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_device_history_query_test.go
@@ -1,0 +1,28 @@
+package database
+
+import (
+	"testing"
+
+	mock_config "github.com/analogj/scrutiny/webapp/backend/pkg/config/mock"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeviceHistoryQueriesUseStableWWNInsteadOfHostID(t *testing.T) {
+	t.Parallel()
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	fakeConfig := mock_config.NewMockInterface(mockCtrl)
+	fakeConfig.EXPECT().GetString(cfgInfluxDBBucket).Return("metrics").AnyTimes()
+
+	deviceRepo := scrutinyRepository{appConfig: fakeConfig}
+
+	smartQuery := deviceRepo.aggregateSmartAttributesQuery("wwn-1", DURATION_KEY_FOREVER, 1, 0, nil)
+	require.Contains(t, smartQuery, `r["device_wwn"] == "wwn-1"`)
+	require.NotContains(t, smartQuery, "host_id")
+
+	temperatureQuery := deviceRepo.aggregateTempQuery(DURATION_KEY_FOREVER, "wwn-1")
+	require.Contains(t, temperatureQuery, `r["device_wwn"]`)
+	require.NotContains(t, temperatureQuery, "host_id")
+}

--- a/webapp/backend/pkg/database/scrutiny_repository_device_register_test.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_device_register_test.go
@@ -36,6 +36,7 @@ func TestRegisterDeviceRefreshesMetadataOnConflict(t *testing.T) {
 	initial := models.Device{
 		DeviceID:       deviceID,
 		WWN:            "wwn-1",
+		HostId:         "TrueNAS",
 		DeviceName:     "sda",
 		ModelName:      "Samsung SSD 870 EVO 4TB",
 		SerialNumber:   "",
@@ -49,26 +50,28 @@ func TestRegisterDeviceRefreshesMetadataOnConflict(t *testing.T) {
 	require.NoError(t, repo.RegisterDevice(ctx, initial))
 
 	refreshed := models.Device{
-		DeviceID:        deviceID,
-		WWN:             "wwn-1",
-		DeviceName:      "sda",
-		ModelName:       "Samsung SSD 870 EVO 4TB",
-		Manufacturer:    "Samsung",
-		SerialNumber:    "S7HDNF0Y548663E",
-		Capacity:        4000787030016,
-		Firmware:        "SVT02B6Q",
-		InterfaceType:   "SATA",
-		InterfaceSpeed:  "6.0 Gb/s",
-		FormFactor:      "2.5 inches",
-		RotationSpeed:   0,
-		DeviceProtocol:  "ATA",
-		SmartSupport:    common.SmartSupport{Available: true},
+		DeviceID:         deviceID,
+		WWN:              "wwn-1",
+		HostId:           "homeserver2",
+		DeviceName:       "sda",
+		ModelName:        "Samsung SSD 870 EVO 4TB",
+		Manufacturer:     "Samsung",
+		SerialNumber:     "S7HDNF0Y548663E",
+		Capacity:         4000787030016,
+		Firmware:         "SVT02B6Q",
+		InterfaceType:    "SATA",
+		InterfaceSpeed:   "6.0 Gb/s",
+		FormFactor:       "2.5 inches",
+		RotationSpeed:    0,
+		DeviceProtocol:   "ATA",
+		SmartSupport:     common.SmartSupport{Available: true},
 		CollectorVersion: "1.61.0",
 	}
 	require.NoError(t, repo.RegisterDevice(ctx, refreshed))
 
 	var stored models.Device
 	require.NoError(t, repo.gormClient.WithContext(ctx).Where(queryDeviceID, deviceID).First(&stored).Error)
+	require.Equal(t, "homeserver2", stored.HostId)
 	require.Equal(t, "S7HDNF0Y548663E", stored.SerialNumber)
 	require.Equal(t, int64(4000787030016), stored.Capacity)
 	require.Equal(t, "SVT02B6Q", stored.Firmware)
@@ -76,6 +79,28 @@ func TestRegisterDeviceRefreshesMetadataOnConflict(t *testing.T) {
 	require.Equal(t, "6.0 Gb/s", stored.InterfaceSpeed)
 	require.Equal(t, "2.5 inches", stored.FormFactor)
 	require.Equal(t, "Samsung", stored.Manufacturer)
+}
+
+func TestRegisterDeviceClearsHostIDWhenCollectorStopsSendingIt(t *testing.T) {
+	repo := createDeviceRegisterTestRepository(t)
+	ctx := context.Background()
+
+	device := models.Device{
+		DeviceID:     "device-1",
+		WWN:          "wwn-1",
+		HostId:       "old-host",
+		DeviceName:   "sda",
+		ModelName:    "Samsung SSD 870 EVO 4TB",
+		SerialNumber: "S7HDNF0Y548663E",
+	}
+	require.NoError(t, repo.RegisterDevice(ctx, device))
+
+	device.HostId = ""
+	require.NoError(t, repo.RegisterDevice(ctx, device))
+
+	var stored models.Device
+	require.NoError(t, repo.gormClient.WithContext(ctx).Where(queryDeviceID, device.DeviceID).First(&stored).Error)
+	require.Empty(t, stored.HostId)
 }
 
 func TestRegisterDeviceRekeysLegacyRowWhenSerialAppearsForStableWWN(t *testing.T) {
@@ -96,15 +121,15 @@ func TestRegisterDeviceRekeysLegacyRowWhenSerialAppearsForStableWWN(t *testing.T
 	}))
 
 	require.NoError(t, repo.RegisterDevice(ctx, models.Device{
-		DeviceID:        refreshedID,
-		WWN:             "0x50014ee2c06ce3c3",
-		HostId:          "host-1",
-		DeviceName:      "sdb",
-		ModelName:       "WDC WD80EFZZ-68BTXN0",
-		Manufacturer:    "Western Digital",
-		SerialNumber:    "WD-CA2XZ08L",
-		Capacity:        8001563222016,
-		DeviceProtocol:  "ATA",
+		DeviceID:         refreshedID,
+		WWN:              "0x50014ee2c06ce3c3",
+		HostId:           "host-1",
+		DeviceName:       "sdb",
+		ModelName:        "WDC WD80EFZZ-68BTXN0",
+		Manufacturer:     "Western Digital",
+		SerialNumber:     "WD-CA2XZ08L",
+		Capacity:         8001563222016,
+		DeviceProtocol:   "ATA",
 		CollectorVersion: "1.61.0",
 	}))
 
@@ -140,28 +165,28 @@ func TestRegisterDeviceDeletesLegacyDuplicateOnceCanonicalRowExists(t *testing.T
 		Update("created_at", legacyCreatedAt).Error)
 
 	require.NoError(t, repo.RegisterDevice(ctx, models.Device{
-		DeviceID:        canonicalID,
-		WWN:             "0x50014ee2c06ce3c3",
-		HostId:          "host-1",
-		DeviceName:      "sdb",
-		ModelName:       "WDC WD80EFZZ-68BTXN0",
-		Manufacturer:    "Western Digital",
-		SerialNumber:    "WD-CA2XZ08L",
-		Capacity:        8001563222016,
-		DeviceProtocol:  "ATA",
+		DeviceID:         canonicalID,
+		WWN:              "0x50014ee2c06ce3c3",
+		HostId:           "host-1",
+		DeviceName:       "sdb",
+		ModelName:        "WDC WD80EFZZ-68BTXN0",
+		Manufacturer:     "Western Digital",
+		SerialNumber:     "WD-CA2XZ08L",
+		Capacity:         8001563222016,
+		DeviceProtocol:   "ATA",
 		CollectorVersion: "1.61.0",
 	}))
 
 	require.NoError(t, repo.RegisterDevice(ctx, models.Device{
-		DeviceID:        canonicalID,
-		WWN:             "0x50014ee2c06ce3c3",
-		HostId:          "host-1",
-		DeviceName:      "sdb",
-		ModelName:       "WDC WD80EFZZ-68BTXN0",
-		Manufacturer:    "Western Digital",
-		SerialNumber:    "WD-CA2XZ08L",
-		Capacity:        8001563222016,
-		DeviceProtocol:  "ATA",
+		DeviceID:         canonicalID,
+		WWN:              "0x50014ee2c06ce3c3",
+		HostId:           "host-1",
+		DeviceName:       "sdb",
+		ModelName:        "WDC WD80EFZZ-68BTXN0",
+		Manufacturer:     "Western Digital",
+		SerialNumber:     "WD-CA2XZ08L",
+		Capacity:         8001563222016,
+		DeviceProtocol:   "ATA",
 		CollectorVersion: "1.61.0",
 	}))
 

--- a/webapp/backend/pkg/web/handler/register_devices_test.go
+++ b/webapp/backend/pkg/web/handler/register_devices_test.go
@@ -1,0 +1,67 @@
+package handler
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	mock_database "github.com/analogj/scrutiny/webapp/backend/pkg/database/mock"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/models"
+	"github.com/gin-gonic/gin"
+	"github.com/golang/mock/gomock"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegisterDevicesKeepsDeviceIDStableWhenHostIDChanges(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	repo := mock_database.NewMockDeviceRepo(ctrl)
+	var registered []models.Device
+	repo.EXPECT().RegisterDevice(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, device models.Device) error {
+		registered = append(registered, device)
+		return nil
+	}).Times(2)
+
+	register := func(hostID string) models.Device {
+		payload, err := json.Marshal(models.DeviceWrapper{Data: []models.Device{{
+			WWN:          "0x5000cca264eb01d7",
+			DeviceName:   "sdd",
+			ModelName:    "Samsung SSD 870 EVO 4TB",
+			SerialNumber: "35ELXMLGS",
+			HostId:       hostID,
+		}}})
+		require.NoError(t, err)
+
+		req := httptest.NewRequest(http.MethodPost, "/api/devices/register", bytes.NewReader(payload))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = req
+		c.Set("DEVICE_REPOSITORY", repo)
+		c.Set("LOGGER", logrus.NewEntry(logrus.New()))
+
+		RegisterDevices(c)
+
+		require.Equal(t, http.StatusOK, w.Code)
+		var response models.DeviceWrapper
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+		require.True(t, response.Success)
+		require.Len(t, response.Data, 1)
+		return response.Data[0]
+	}
+
+	initial := register("TrueNAS")
+	moved := register("homeserver2")
+
+	require.Len(t, registered, 2)
+	require.Equal(t, "TrueNAS", registered[0].HostId)
+	require.Equal(t, "homeserver2", registered[1].HostId)
+	require.Equal(t, initial.DeviceID, moved.DeviceID)
+	require.Equal(t, registered[0].DeviceID, registered[1].DeviceID)
+}


### PR DESCRIPTION
## Summary

Preserve SMART and temperature history when a monitored device moves between collector hosts.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

Fixes #829

## Changes Made

- Added repository coverage for `TrueNAS` to `homeserver2` host migration and empty host IDs.
- Added HTTP registration coverage proving host changes do not change stable `device_id` values.
- Added SMART and temperature query coverage proving history selectors use stable WWNs rather than `host_id`.
- Documented collector host migration steps, concurrent collector behavior, and fallback identity limitations.

## Testing

- [x] I have tested this locally
- [x] I have added/updated tests that prove my fix/feature works
- [x] All existing tests pass

Commands:

```text
go test -count=1 ./webapp/backend/pkg/... ./collector/...
```

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary (particularly complex areas)
- [x] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [x] No console.log, debug statements, or commented-out code

## Screenshots (if applicable)

Not applicable.

## Additional Notes

The existing registration path already updates mutable `host_id` metadata and keeps history keyed by stable device identity, so this change requires no schema or runtime redesign. Devices without model, serial number, or WWN retain documented fallback limitations.
