### PR TITLE
fix(dashboard): persist temperature drive selection

### DIFF
--- a/webapp/frontend/src/app/modules/dashboard/dashboard.component.spec.ts
+++ b/webapp/frontend/src/app/modules/dashboard/dashboard.component.spec.ts
@@ -22,7 +22,11 @@ describe('DashboardComponent temperature chart', () => {
             theme: 'light',
             time_format: '24',
         };
-        const temperatureSelection = new TemperatureSelection();
+        const temperatureSelection = new TemperatureSelection({
+            getItem: () => null,
+            setItem: () => undefined,
+        });
+        spyOn(temperatureSelection, 'restore').and.callThrough();
 
         dashboardService = jasmine.createSpyObj('DashboardService', ['getSummaryPage', 'getTemperatureDeviceOptions', 'getSummaryTempData', 'getFilesystemSummaryData'], {
             pageData$: of({
@@ -100,6 +104,10 @@ describe('DashboardComponent temperature chart', () => {
 
         expect(driveFilterButton?.textContent).toContain('Drives (0/19)');
         expect(driveFilterButton?.textContent).not.toContain(`/${component.temperatureSelection.maxSelected})`);
+    });
+
+    it('restores selection against active temperature devices', () => {
+        expect(component.temperatureSelection.restore).toHaveBeenCalledWith(jasmine.arrayContaining(['drive-1']));
     });
 
     it('binds loaded temperature data before the lazy chart instance exists', () => {

--- a/webapp/frontend/src/app/modules/dashboard/dashboard.component.ts
+++ b/webapp/frontend/src/app/modules/dashboard/dashboard.component.ts
@@ -178,6 +178,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
             .pipe(takeUntil(this._unsubscribeAll))
             .subscribe((devices) => {
                 this.temperatureDevices = devices;
+                this.temperatureSelection.restore(devices.map((device) => device.device_id));
                 if (this.temperatureSelection.ids.length > 0) {
                     this.loadSelectedTemperatureHistory();
                 }

--- a/webapp/frontend/src/app/modules/dashboard/temperature-selection.spec.ts
+++ b/webapp/frontend/src/app/modules/dashboard/temperature-selection.spec.ts
@@ -1,8 +1,19 @@
 import { TemperatureSelection } from './temperature-selection';
 
+function createStorage(initialValue: string | null = null) {
+    let value = initialValue;
+    return {
+        getItem: (_key: string) => value,
+        setItem: (_key: string, nextValue: string) => {
+            value = nextValue;
+        },
+        value: () => value,
+    };
+}
+
 describe('TemperatureSelection', () => {
     it('starts empty, caps selection at twenty, and preserves existing selections', () => {
-        const selection = new TemperatureSelection();
+        const selection = new TemperatureSelection(createStorage());
 
         for (let index = 0; index < 21; index++) {
             selection.toggle(`device-${index}`);
@@ -14,10 +25,39 @@ describe('TemperatureSelection', () => {
     });
 
     it('removes an already selected device', () => {
-        const selection = new TemperatureSelection();
+        const selection = new TemperatureSelection(createStorage());
         selection.toggle('device-1');
 
         selection.toggle('device-1');
+
+        expect(selection.ids).toEqual([]);
+    });
+
+    it('restores only available devices and caps stored selections at twenty', () => {
+        const storedIDs = ['stale-device', ...Array.from({ length: 21 }, (_, index) => `device-${index}`)];
+        const selection = new TemperatureSelection(createStorage(JSON.stringify(storedIDs)));
+
+        selection.restore(Array.from({ length: 21 }, (_, index) => `device-${index}`));
+
+        expect(selection.ids).toEqual(Array.from({ length: 20 }, (_, index) => `device-${index}`));
+    });
+
+    it('persists additions and removals', () => {
+        const storage = createStorage();
+        const selection = new TemperatureSelection(storage);
+
+        selection.restore(['device-1']);
+        selection.toggle('device-1');
+        expect(storage.value()).toBe('["device-1"]');
+
+        selection.toggle('device-1');
+        expect(storage.value()).toBe('[]');
+    });
+
+    it('ignores malformed stored data', () => {
+        const selection = new TemperatureSelection(createStorage('{malformed'));
+
+        selection.restore(['device-1']);
 
         expect(selection.ids).toEqual([]);
     });

--- a/webapp/frontend/src/app/modules/dashboard/temperature-selection.ts
+++ b/webapp/frontend/src/app/modules/dashboard/temperature-selection.ts
@@ -1,6 +1,13 @@
+const TEMPERATURE_SELECTION_STORAGE_KEY = 'scrutiny_temperature_selection';
+
+type TemperatureSelectionStorage = Pick<Storage, 'getItem' | 'setItem'>;
+
 export class TemperatureSelection {
     readonly maxSelected = 20;
     private readonly selected = new Set<string>();
+    private hydrated = false;
+
+    constructor(private readonly storage: TemperatureSelectionStorage | undefined = TemperatureSelection.browserStorage()) {}
 
     get ids(): string[] {
         return Array.from(this.selected);
@@ -10,12 +17,72 @@ export class TemperatureSelection {
         return this.selected.has(deviceID);
     }
 
+    restore(availableDeviceIDs: readonly string[]): void {
+        const available = new Set(availableDeviceIDs);
+        if (!this.hydrated) {
+            this.hydrated = true;
+            for (const deviceID of this.readStoredIDs()) {
+                if (available.has(deviceID)) {
+                    this.selected.add(deviceID);
+                }
+                if (this.selected.size >= this.maxSelected) {
+                    break;
+                }
+            }
+        }
+
+        let changed = false;
+        for (const deviceID of this.selected) {
+            if (!available.has(deviceID)) {
+                this.selected.delete(deviceID);
+                changed = true;
+            }
+        }
+        if (changed) {
+            this.persist();
+        }
+    }
+
     toggle(deviceID: string): void {
         if (this.selected.delete(deviceID)) {
+            this.persist();
             return;
         }
         if (this.selected.size < this.maxSelected) {
             this.selected.add(deviceID);
+            this.persist();
+        }
+    }
+
+    private readStoredIDs(): string[] {
+        try {
+            const stored = this.storage?.getItem(TEMPERATURE_SELECTION_STORAGE_KEY);
+            if (!stored) {
+                return [];
+            }
+            const parsed: unknown = JSON.parse(stored);
+            if (!Array.isArray(parsed)) {
+                return [];
+            }
+            return parsed.filter((deviceID): deviceID is string => typeof deviceID === 'string' && deviceID.length > 0);
+        } catch {
+            return [];
+        }
+    }
+
+    private persist(): void {
+        try {
+            this.storage?.setItem(TEMPERATURE_SELECTION_STORAGE_KEY, JSON.stringify(this.ids));
+        } catch {
+            // Selection persistence is optional; keep in-memory behavior when storage is unavailable.
+        }
+    }
+
+    private static browserStorage(): TemperatureSelectionStorage | undefined {
+        try {
+            return globalThis.localStorage;
+        } catch {
+            return undefined;
         }
     }
 }


### PR DESCRIPTION
## Summary

Persist dashboard temperature-drive selections across browser reloads.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

Related to [Discussion #782](https://github.com/Starosdev/scrutiny/discussions/782).

## Changes Made

- Store selected temperature device IDs in browser local storage.
- Restore selections after active temperature devices load.
- Prune inactive IDs and retain the existing 20-device limit.
- Ignore malformed or unavailable browser storage without breaking in-memory selection.

## Testing

- [x] I have tested this locally
- [x] I have added/updated tests that prove my fix/feature works
- [x] All existing tests pass

Focused Angular tests: 11 passed. Frontend lint passed. Production build passed.

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary (particularly complex areas)
- [x] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [x] No console.log, debug statements, or commented-out code

## Screenshots (if applicable)

Not applicable.

## Additional Notes

No backend or deployment changes.
