### PR TITLE
ci: gate releases on multi-architecture image builds

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -3,10 +3,8 @@ name: Docker
 on:
   push:
     # master is deliberately absent. Every tag this workflow publishes for a
-    # release is enabled on the tag ref alone, so a master push resolves to zero
-    # tags and buildx fails outright with "tag is needed when pushing to
-    # registry". Releases arrive here through the v*.*.* tag that
-    # semantic-release creates.
+    # release is enabled on the tag ref alone. Releases arrive here through the
+    # v*.*.* tag that semantic-release creates.
     branches:
       - beta
       - develop
@@ -18,14 +16,9 @@ on:
       - 'Makefile'
       - 'go.mod'
       - 'go.sum'
-      # CHANGELOG.md is here so a release commit matches this filter on its own
-      # terms. semantic-release tags a chore(release) commit touching only
-      # CHANGELOG.md and version.go, and version.go is excluded above, so
-      # otherwise a release commit matches nothing and the tag build runs only
-      # because path filters have not gated tag pushes in practice. The tag build
-      # is the sole publisher of release images, and a silent miss would leave a
-      # published GitHub release with no image, so the filter should not be the
-      # thing standing between a tag and its images.
+      # CHANGELOG.md lets a release commit match this filter on its own terms.
+      # semantic-release tags a chore(release) commit touching only CHANGELOG.md
+      # and version.go, and version.go is excluded above.
       - 'CHANGELOG.md'
     tags:
       - 'v*.*.*'
@@ -45,7 +38,7 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  validate-dispatch:
+  validate_dispatch:
     name: Validate manual image tag
     runs-on: ubuntu-latest
     steps:
@@ -58,395 +51,48 @@ jobs:
             exit 1
           fi
 
-  collector:
-    needs: validate-dispatch
+  image_matrix:
+    name: Validate Docker image matrix
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      all: ${{ steps.matrix.outputs.all }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7.0.1
+      - name: Test Docker image matrix
+        run: bash docker/tests/image-matrix_test.sh
+      - name: Export Docker image matrix
+        id: matrix
+        run: echo "all=$(jq -c . docker/image-matrix.json)" >> "$GITHUB_OUTPUT"
+
+  build:
+    name: Build ${{ matrix.image }}
+    needs: [validate_dispatch, image_matrix]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
       contents: read
       packages: write
-
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.image_matrix.outputs.all) }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
-        with:
-          platforms: 'arm64,arm'
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
-      - name: Log into registry ${{ env.REGISTRY }}
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v4
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract Docker metadata
-        id: meta
-        uses: docker/metadata-action@v6
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          flavor: |
-            latest=false
-          tags: |
-            # Manual trigger
-            type=raw,value=${{ inputs.tag_suffix }}-collector,enable=${{ github.event_name == 'workflow_dispatch' }}
-            # Branch builds
-            type=raw,value=latest-collector,enable=${{ startsWith(github.ref, 'refs/tags/v') && github.event_name != 'workflow_dispatch' }}
-            type=raw,value=beta-collector,enable=${{ github.ref == 'refs/heads/beta' && github.event_name != 'workflow_dispatch' }}
-            type=raw,value=develop-collector,enable=${{ github.ref == 'refs/heads/develop' && github.event_name != 'workflow_dispatch' }}
-            # Version tags
-            type=semver,pattern={{version}}-collector
-            type=semver,pattern={{major}}.{{minor}}-collector
-            type=semver,pattern={{major}}-collector,enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
-
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v7
-        with:
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
-          context: .
-          file: docker/Dockerfile.collector
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=docker-collector
-          cache-to: type=gha,mode=max,scope=docker-collector
-
-  collector-omnibus:
-    needs: validate-dispatch
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v7.0.1
-        with:
-          fetch-depth: 0
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
-        with:
-          platforms: 'arm64,arm'
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
-      - name: Log into registry ${{ env.REGISTRY }}
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v4
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract Docker metadata
-        id: meta
-        uses: docker/metadata-action@v6
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          flavor: |
-            latest=false
-          tags: |
-            # Manual trigger
-            type=raw,value=${{ inputs.tag_suffix }}-collector-omnibus,enable=${{ github.event_name == 'workflow_dispatch' }}
-            # Branch builds
-            type=raw,value=latest-collector-omnibus,enable=${{ startsWith(github.ref, 'refs/tags/v') && github.event_name != 'workflow_dispatch' }}
-            type=raw,value=beta-collector-omnibus,enable=${{ github.ref == 'refs/heads/beta' && github.event_name != 'workflow_dispatch' }}
-            type=raw,value=develop-collector-omnibus,enable=${{ github.ref == 'refs/heads/develop' && github.event_name != 'workflow_dispatch' }}
-            # Version tags
-            type=semver,pattern={{version}}-collector-omnibus
-            type=semver,pattern={{major}}.{{minor}}-collector-omnibus
-            type=semver,pattern={{major}}-collector-omnibus,enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
-
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v7
-        with:
-          platforms: linux/amd64,linux/arm64
-          context: .
-          file: docker/Dockerfile.collector-omnibus
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=docker-collector-omnibus
-          cache-to: type=gha,mode=max,scope=docker-collector-omnibus
-
-  collector-zfs:
-    needs: validate-dispatch
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v7.0.1
-        with:
-          fetch-depth: 0
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
-        with:
-          platforms: 'arm64,arm'
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
-      - name: Log into registry ${{ env.REGISTRY }}
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v4
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract Docker metadata
-        id: meta
-        uses: docker/metadata-action@v6
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          flavor: |
-            latest=false
-          tags: |
-            # Manual trigger
-            type=raw,value=${{ inputs.tag_suffix }}-collector-zfs,enable=${{ github.event_name == 'workflow_dispatch' }}
-            # Branch builds
-            type=raw,value=latest-collector-zfs,enable=${{ startsWith(github.ref, 'refs/tags/v') && github.event_name != 'workflow_dispatch' }}
-            type=raw,value=beta-collector-zfs,enable=${{ github.ref == 'refs/heads/beta' && github.event_name != 'workflow_dispatch' }}
-            type=raw,value=develop-collector-zfs,enable=${{ github.ref == 'refs/heads/develop' && github.event_name != 'workflow_dispatch' }}
-            # Version tags
-            type=semver,pattern={{version}}-collector-zfs
-            type=semver,pattern={{major}}.{{minor}}-collector-zfs
-            type=semver,pattern={{major}}-collector-zfs,enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
-
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v7
-        with:
-          platforms: linux/amd64,linux/arm64
-          context: .
-          file: docker/Dockerfile.collector-zfs
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=docker-collector-zfs
-          cache-to: type=gha,mode=max,scope=docker-collector-zfs
-
-  collector-mdadm:
-    needs: validate-dispatch
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v7.0.1
-        with:
-          fetch-depth: 0
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
-        with:
-          platforms: 'arm64,arm'
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
-      - name: Log into registry ${{ env.REGISTRY }}
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v4
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract Docker metadata
-        id: meta
-        uses: docker/metadata-action@v6
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          flavor: |
-            latest=false
-          tags: |
-            # Manual trigger
-            type=raw,value=${{ inputs.tag_suffix }}-collector-mdadm,enable=${{ github.event_name == 'workflow_dispatch' }}
-            # Branch builds
-            type=raw,value=latest-collector-mdadm,enable=${{ startsWith(github.ref, 'refs/tags/v') && github.event_name != 'workflow_dispatch' }}
-            type=raw,value=beta-collector-mdadm,enable=${{ github.ref == 'refs/heads/beta' && github.event_name != 'workflow_dispatch' }}
-            type=raw,value=develop-collector-mdadm,enable=${{ github.ref == 'refs/heads/develop' && github.event_name != 'workflow_dispatch' }}
-            # Version tags
-            type=semver,pattern={{version}}-collector-mdadm
-            type=semver,pattern={{major}}.{{minor}}-collector-mdadm
-            type=semver,pattern={{major}}-collector-mdadm,enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
-
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v7
-        with:
-          platforms: linux/amd64,linux/arm64
-          context: .
-          file: docker/Dockerfile.collector-mdadm
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=docker-collector-mdadm
-          cache-to: type=gha,mode=max,scope=docker-collector-mdadm
-
-  collector-btrfs:
-    needs: validate-dispatch
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v7.0.1
-        with:
-          fetch-depth: 0
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
-        with:
-          platforms: 'arm64,arm'
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
-      - name: Log into registry ${{ env.REGISTRY }}
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v4
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract Docker metadata
-        id: meta
-        uses: docker/metadata-action@v6
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          flavor: |
-            latest=false
-          tags: |
-            # Manual trigger
-            type=raw,value=${{ inputs.tag_suffix }}-collector-btrfs,enable=${{ github.event_name == 'workflow_dispatch' }}
-            # Branch builds
-            type=raw,value=latest-collector-btrfs,enable=${{ startsWith(github.ref, 'refs/tags/v') && github.event_name != 'workflow_dispatch' }}
-            type=raw,value=beta-collector-btrfs,enable=${{ github.ref == 'refs/heads/beta' && github.event_name != 'workflow_dispatch' }}
-            type=raw,value=develop-collector-btrfs,enable=${{ github.ref == 'refs/heads/develop' && github.event_name != 'workflow_dispatch' }}
-            # Version tags
-            type=semver,pattern={{version}}-collector-btrfs
-            type=semver,pattern={{major}}.{{minor}}-collector-btrfs
-            type=semver,pattern={{major}}-collector-btrfs,enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
-
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v7
-        with:
-          platforms: linux/amd64,linux/arm64
-          context: .
-          file: docker/Dockerfile.collector-btrfs
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=docker-collector-btrfs
-          cache-to: type=gha,mode=max,scope=docker-collector-btrfs
-
-  collector-performance:
-    needs: validate-dispatch
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v7.0.1
-        with:
-          fetch-depth: 0
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
-        with:
-          platforms: 'arm64,arm'
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
-      - name: Log into registry ${{ env.REGISTRY }}
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v4
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract Docker metadata
-        id: meta
-        uses: docker/metadata-action@v6
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          flavor: |
-            latest=false
-          tags: |
-            # Manual trigger
-            type=raw,value=${{ inputs.tag_suffix }}-collector-performance,enable=${{ github.event_name == 'workflow_dispatch' }}
-            # Branch builds
-            type=raw,value=latest-collector-performance,enable=${{ startsWith(github.ref, 'refs/tags/v') && github.event_name != 'workflow_dispatch' }}
-            type=raw,value=beta-collector-performance,enable=${{ github.ref == 'refs/heads/beta' && github.event_name != 'workflow_dispatch' }}
-            type=raw,value=develop-collector-performance,enable=${{ github.ref == 'refs/heads/develop' && github.event_name != 'workflow_dispatch' }}
-            # Version tags
-            type=semver,pattern={{version}}-collector-performance
-            type=semver,pattern={{major}}.{{minor}}-collector-performance
-            type=semver,pattern={{major}}-collector-performance,enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
-
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v7
-        with:
-          platforms: linux/amd64,linux/arm64
-          context: .
-          file: docker/Dockerfile.collector-performance
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=docker-collector-performance
-          cache-to: type=gha,mode=max,scope=docker-collector-performance
-
-  web:
-    needs: validate-dispatch
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v7.0.1
-
       - name: Populate frontend version information
+        if: matrix.frontend == true
         run: cd webapp/frontend && ./git.version.sh
-
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
         with:
-          platforms: 'arm64,arm'
-
+          platforms: ${{ matrix.qemu }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
-
       - name: Log into registry ${{ env.REGISTRY }}
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v4
@@ -454,7 +100,6 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Extract Docker metadata
         id: meta
         uses: docker/metadata-action@v6
@@ -464,99 +109,30 @@ jobs:
             latest=false
           tags: |
             # Manual trigger
-            type=raw,value=${{ inputs.tag_suffix }}-web,enable=${{ github.event_name == 'workflow_dispatch' }}
+            type=raw,value=${{ inputs.tag_suffix }}-${{ matrix.image }},enable=${{ github.event_name == 'workflow_dispatch' }}
             # Branch builds
-            type=raw,value=latest-web,enable=${{ startsWith(github.ref, 'refs/tags/v') && github.event_name != 'workflow_dispatch' }}
-            type=raw,value=beta-web,enable=${{ github.ref == 'refs/heads/beta' && github.event_name != 'workflow_dispatch' }}
-            type=raw,value=develop-web,enable=${{ github.ref == 'refs/heads/develop' && github.event_name != 'workflow_dispatch' }}
+            type=raw,value=latest-${{ matrix.image }},enable=${{ startsWith(github.ref, 'refs/tags/v') && github.event_name != 'workflow_dispatch' }}
+            type=raw,value=beta-${{ matrix.image }},enable=${{ github.ref == 'refs/heads/beta' && github.event_name != 'workflow_dispatch' }}
+            type=raw,value=develop-${{ matrix.image }},enable=${{ github.ref == 'refs/heads/develop' && github.event_name != 'workflow_dispatch' }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && github.event_name != 'workflow_dispatch' && matrix.default_image == true }}
+            type=raw,value=beta,enable=${{ github.ref == 'refs/heads/beta' && github.event_name != 'workflow_dispatch' && matrix.default_image == true }}
+            type=raw,value=develop,enable=${{ github.ref == 'refs/heads/develop' && github.event_name != 'workflow_dispatch' && matrix.default_image == true }}
             # Version tags
-            type=semver,pattern={{version}}-web
-            type=semver,pattern={{major}}.{{minor}}-web
-            type=semver,pattern={{major}}-web,enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
+            type=semver,pattern={{version}}-${{ matrix.image }}
+            type=semver,pattern={{major}}.{{minor}}-${{ matrix.image }}
+            type=semver,pattern={{major}}-${{ matrix.image }},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
+            type=semver,pattern={{version}},enable=${{ matrix.default_image == true }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ matrix.default_image == true }}
+            type=semver,pattern={{major}},enable=${{ matrix.default_image == true && !startsWith(github.ref, 'refs/tags/v0.') }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v7
         with:
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.platforms }}
           context: .
-          file: docker/Dockerfile.web
+          file: ${{ matrix.dockerfile }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=docker-web
-          cache-to: type=gha,mode=max,scope=docker-web
-
-  omnibus:
-    needs: validate-dispatch
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v7.0.1
-
-      - name: Populate frontend version information
-        run: cd webapp/frontend && ./git.version.sh
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
-        with:
-          platforms: 'arm64,arm'
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
-      - name: Log into registry ${{ env.REGISTRY }}
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v4
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract Docker metadata
-        id: meta
-        uses: docker/metadata-action@v6
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          flavor: |
-            latest=false
-          tags: |
-            # Manual trigger
-            type=raw,value=${{ inputs.tag_suffix }}-omnibus,enable=${{ github.event_name == 'workflow_dispatch' }}
-            type=raw,value=${{ inputs.tag_suffix }},enable=${{ github.event_name == 'workflow_dispatch' && inputs.tag_suffix == 'latest' }}
-            # Branch builds
-            type=raw,value=latest-omnibus,enable=${{ startsWith(github.ref, 'refs/tags/v') && github.event_name != 'workflow_dispatch' }}
-            type=raw,value=beta-omnibus,enable=${{ github.ref == 'refs/heads/beta' && github.event_name != 'workflow_dispatch' }}
-            type=raw,value=beta,enable=${{ github.ref == 'refs/heads/beta' && github.event_name != 'workflow_dispatch' }}
-            type=raw,value=develop-omnibus,enable=${{ github.ref == 'refs/heads/develop' && github.event_name != 'workflow_dispatch' }}
-            type=raw,value=develop,enable=${{ github.ref == 'refs/heads/develop' && github.event_name != 'workflow_dispatch' }}
-            # Version tags
-            type=semver,pattern={{version}}-omnibus
-            type=semver,pattern={{major}}.{{minor}}-omnibus
-            type=semver,pattern={{major}}-omnibus,enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
-            # Bare version tags. Omnibus is the default image, so it owns the
-            # unsuffixed names. Without these the default image can only be
-            # tracked as a moving latest and cannot be pinned to a release.
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
-            # Default latest tag (omnibus is the default). Release tag refs are
-            # the only publisher for moving stable tags, so they share release
-            # contents.
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && github.event_name != 'workflow_dispatch' }}
-
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v7
-        with:
-          platforms: linux/amd64,linux/arm64
-          context: .
-          file: docker/Dockerfile
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=docker-omnibus
-          cache-to: type=gha,mode=max,scope=docker-omnibus
+          cache-from: type=gha,scope=${{ matrix.cache_scope }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.cache_scope }}

--- a/.github/workflows/docker-permissions.yaml
+++ b/.github/workflows/docker-permissions.yaml
@@ -12,6 +12,25 @@ on:
       - '.github/workflows/docker-permissions.yaml'
 
 jobs:
+  image_matrix:
+    name: Validate Docker image matrix
+    runs-on: ubuntu-latest
+    outputs:
+      pr_build: ${{ steps.matrix.outputs.pr_build }}
+      apparmor: ${{ steps.matrix.outputs.apparmor }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7.0.1
+      - name: Test Docker image matrix
+        run: bash docker/tests/image-matrix_test.sh
+      - name: Export Docker image matrix
+        id: matrix
+        run: |
+          {
+            echo "pr_build=$(jq -c '[.[] | select(.pr_build == true)]' docker/image-matrix.json)"
+            echo "apparmor=$(jq -c '[.[] | select(.apparmor_kind != null)]' docker/image-matrix.json)"
+          } >> "$GITHUB_OUTPUT"
+
   frontend-permissions:
     name: Test Docker frontend permissions
     runs-on: ubuntu-latest
@@ -22,40 +41,21 @@ jobs:
       - name: Test Docker frontend permissions
         run: bash docker/tests/frontend-permissions_test.sh
 
-  # Every Dockerfile this repository publishes is built here, so a broken image
-  # is caught on the pull request rather than by the tag build. That matters
-  # because release.yaml publishes the GitHub release before docker-build.yaml
-  # runs on the resulting tag: a failure there leaves a published release with
-  # no image behind it.
-  #
-  # The AppArmor matrix below is not the right place for this. It carries a
-  # "kind" that selects an AppArmor test, and half these images have nothing
-  # meaningful to assert under it.
-  #
-  # amd64 only, deliberately. The publish path builds linux/amd64 and
-  # linux/arm64 through QEMU, so an arm64-only failure still reaches the tag
-  # build first. Emulated arm64 builds of eight images on every pull request is
-  # a large standing cost for a narrower class of failure; see #824 for that
-  # half.
   build-images:
     name: Build (${{ matrix.image }})
+    needs: image_matrix
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - image: web
-            dockerfile: docker/Dockerfile.web
-          - image: collector-zfs
-            dockerfile: docker/Dockerfile.collector-zfs
-          - image: collector-mdadm
-            dockerfile: docker/Dockerfile.collector-mdadm
-          - image: collector-btrfs
-            dockerfile: docker/Dockerfile.collector-btrfs
+        include: ${{ fromJSON(needs.image_matrix.outputs.pr_build) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7.0.1
+      - name: Populate frontend version information
+        if: matrix.frontend == true
+        run: cd webapp/frontend && ./git.version.sh
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
       - name: Build image
@@ -65,29 +65,19 @@ jobs:
           file: ${{ matrix.dockerfile }}
           platforms: linux/amd64
           push: false
+          tags: scrutiny-pr-${{ matrix.image }}
           cache-from: type=gha,scope=prbuild-${{ matrix.image }}
           cache-to: type=gha,mode=max,scope=prbuild-${{ matrix.image }}
 
   apparmor:
     name: AppArmor (${{ matrix.image }})
+    needs: image_matrix
     runs-on: ubuntu-24.04
     timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - image: omnibus
-            dockerfile: docker/Dockerfile
-            kind: omnibus
-          - image: collector
-            dockerfile: docker/Dockerfile.collector
-            kind: collector
-          - image: collector-omnibus
-            dockerfile: docker/Dockerfile.collector-omnibus
-            kind: collector
-          - image: collector-performance
-            dockerfile: docker/Dockerfile.collector-performance
-            kind: collector
+        include: ${{ fromJSON(needs.image_matrix.outputs.apparmor) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7.0.1
@@ -96,4 +86,4 @@ jobs:
       - name: Build image
         run: docker build -f "${{ matrix.dockerfile }}" -t scrutiny-apparmor-test .
       - name: Test enforcing AppArmor profile
-        run: bash docker/tests/apparmor_test.sh scrutiny-apparmor-test "${{ matrix.kind }}"
+        run: bash docker/tests/apparmor_test.sh scrutiny-apparmor-test "${{ matrix.apparmor_kind }}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,8 +20,61 @@ permissions:
   pull-requests: write
 
 jobs:
+  image_matrix:
+    name: Validate Docker image matrix
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      all: ${{ steps.matrix.outputs.all }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7.0.1
+      - name: Test Docker image matrix
+        run: bash docker/tests/image-matrix_test.sh
+      - name: Export Docker image matrix
+        id: matrix
+        run: echo "all=$(jq -c . docker/image-matrix.json)" >> "$GITHUB_OUTPUT"
+
+  validate_images:
+    name: Validate Docker image (${{ matrix.image }})
+    needs: image_matrix
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.image_matrix.outputs.all) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7.0.1
+        with:
+          ref: ${{ github.sha }}
+      - name: Populate frontend version information
+        if: matrix.frontend == true
+        run: cd webapp/frontend && ./git.version.sh
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+        with:
+          platforms: ${{ matrix.qemu }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+      - name: Build image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          platforms: ${{ matrix.platforms }}
+          push: false
+          tags: scrutiny-release-validation-${{ matrix.image }}
+          cache-from: type=gha,scope=release-validation-${{ matrix.image }}
+          cache-to: type=gha,mode=max,scope=release-validation-${{ matrix.image }}
+
   release:
     name: Semantic Release
+    needs: validate_images
     runs-on: ubuntu-latest
     outputs:
       new_release_published: ${{ steps.semantic.outputs.new_release_published }}
@@ -61,7 +114,8 @@ jobs:
           esac
 
           git commit --allow-empty -m "$COMMIT_MSG"
-          git push https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git HEAD:${{ github.ref_name }}
+          remote="https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git"
+          git push "$remote" "HEAD:${{ github.ref_name }}"
 
       - name: Semantic Release
         id: semantic
@@ -77,8 +131,8 @@ jobs:
         id: prev_tag
         if: steps.semantic.outputs.new_release_published == 'true'
         run: |
-          PREV_TAG=$(git describe --tags --abbrev=0 v${{ steps.semantic.outputs.new_release_version }}^ 2>/dev/null || echo "")
-          echo "tag=$PREV_TAG" >> $GITHUB_OUTPUT
+          PREV_TAG=$(git describe --tags --abbrev=0 "v${{ steps.semantic.outputs.new_release_version }}^" 2>/dev/null || echo "")
+          echo "tag=$PREV_TAG" >> "$GITHUB_OUTPUT"
 
       - name: Generate release notes from PRs
         id: release_notes

--- a/docker/image-matrix.json
+++ b/docker/image-matrix.json
@@ -1,0 +1,90 @@
+[
+  {
+    "image": "collector",
+    "dockerfile": "docker/Dockerfile.collector",
+    "platforms": "linux/amd64,linux/arm64,linux/arm/v7",
+    "qemu": "arm64,arm",
+    "cache_scope": "docker-collector",
+    "pr_build": false,
+    "apparmor_kind": "collector",
+    "frontend": false,
+    "default_image": false
+  },
+  {
+    "image": "collector-omnibus",
+    "dockerfile": "docker/Dockerfile.collector-omnibus",
+    "platforms": "linux/amd64,linux/arm64",
+    "qemu": "arm64,arm",
+    "cache_scope": "docker-collector-omnibus",
+    "pr_build": false,
+    "apparmor_kind": "collector",
+    "frontend": false,
+    "default_image": false
+  },
+  {
+    "image": "collector-zfs",
+    "dockerfile": "docker/Dockerfile.collector-zfs",
+    "platforms": "linux/amd64,linux/arm64",
+    "qemu": "arm64,arm",
+    "cache_scope": "docker-collector-zfs",
+    "pr_build": true,
+    "apparmor_kind": null,
+    "frontend": false,
+    "default_image": false
+  },
+  {
+    "image": "collector-mdadm",
+    "dockerfile": "docker/Dockerfile.collector-mdadm",
+    "platforms": "linux/amd64,linux/arm64",
+    "qemu": "arm64,arm",
+    "cache_scope": "docker-collector-mdadm",
+    "pr_build": true,
+    "apparmor_kind": null,
+    "frontend": false,
+    "default_image": false
+  },
+  {
+    "image": "collector-btrfs",
+    "dockerfile": "docker/Dockerfile.collector-btrfs",
+    "platforms": "linux/amd64,linux/arm64",
+    "qemu": "arm64,arm",
+    "cache_scope": "docker-collector-btrfs",
+    "pr_build": true,
+    "apparmor_kind": null,
+    "frontend": false,
+    "default_image": false
+  },
+  {
+    "image": "collector-performance",
+    "dockerfile": "docker/Dockerfile.collector-performance",
+    "platforms": "linux/amd64,linux/arm64",
+    "qemu": "arm64,arm",
+    "cache_scope": "docker-collector-performance",
+    "pr_build": false,
+    "apparmor_kind": "collector",
+    "frontend": false,
+    "default_image": false
+  },
+  {
+    "image": "web",
+    "dockerfile": "docker/Dockerfile.web",
+    "platforms": "linux/amd64,linux/arm64",
+    "qemu": "arm64,arm",
+    "cache_scope": "docker-web",
+    "pr_build": true,
+    "apparmor_kind": null,
+    "frontend": true,
+    "default_image": false
+  },
+  {
+    "image": "omnibus",
+    "dockerfile": "docker/Dockerfile",
+    "platforms": "linux/amd64,linux/arm64",
+    "qemu": "arm64,arm",
+    "cache_scope": "docker-omnibus",
+    "pr_build": false,
+    "apparmor_kind": "omnibus",
+    "frontend": true,
+    "default_image": true
+  }
+]

--- a/docker/tests/image-matrix_test.sh
+++ b/docker/tests/image-matrix_test.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+matrix_file="${repo_root}/docker/image-matrix.json"
+
+jq -e '
+    type == "array" and length > 0
+    and all(.[];
+        (.image | type == "string")
+        and (.dockerfile | type == "string")
+        and (.platforms | contains("linux/amd64"))
+        and (.platforms | contains("linux/arm64"))
+        and (.qemu | type == "string")
+        and (.cache_scope | type == "string")
+        and (.pr_build | type == "boolean")
+        and (.frontend | type == "boolean")
+        and (.default_image | type == "boolean")
+    )
+    and ([.[].image] | length == (unique | length))
+    and ([.[] | select(.pr_build == true)] | length > 0)
+    and ([.[] | select(.apparmor_kind != null)] | length > 0)
+    and all(.[]; (.pr_build == true or .apparmor_kind != null))
+    and all(.[]; (.pr_build != true or .apparmor_kind == null))
+    and ([.[] | select(.default_image == true)] | length == 1)
+' "${matrix_file}" >/dev/null
+
+manifest_files=()
+while IFS= read -r path; do
+    manifest_files+=( "${path}" )
+done < <(jq -r '.[].dockerfile' "${matrix_file}" | sort)
+
+repository_files=()
+while IFS= read -r path; do
+    repository_files+=( "${path}" )
+done < <(find "${repo_root}/docker" -maxdepth 1 -type f -name 'Dockerfile*' -print | sed "s#^${repo_root}/##" | sort)
+
+diff -u <(printf '%s\n' "${repository_files[@]}") <(printf '%s\n' "${manifest_files[@]}")
+
+echo "Docker image matrix tests passed"

--- a/docs/DEPLOYMENTS.md
+++ b/docs/DEPLOYMENTS.md
@@ -47,6 +47,11 @@ it is not a GitHub Actions runner.
 
 Production releases are created manually through `.github/workflows/release.yaml` via `workflow_dispatch`.
 
+Before semantic-release creates a release tag, that workflow validates every
+published Dockerfile for its production platforms with Buildx and QEMU. The
+validation does not push images; the release tag then triggers
+`.github/workflows/docker-build.yaml` to publish them.
+
 The release job installs exact versions from the root package-lock.json with
 npm ci, then runs .github/scripts/run-semantic-release.mjs. Update
 package.json and package-lock.json together when changing release tooling.


### PR DESCRIPTION
## Summary

Gate stable releases on successful multi-architecture Docker image builds.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [x] CI/CD or infrastructure change

## Related Issues

Closes #824

## Changes Made

- Added one canonical matrix for all published Dockerfiles, platforms, cache scopes, and PR/AppArmor coverage.
- Added a parity test that requires every docker/Dockerfile* entry to appear in the matrix.
- Added release-time Buildx/QEMU validation before semantic-release creates a tag or GitHub release.
- Refactored PR checks and image publishing to consume the canonical matrix.
- Documented release image validation.

## Testing

- [x] I have tested this locally
- [x] I have added/updated tests that prove my fix/feature works
- [ ] All existing tests pass

Local validation:

- bash docker/tests/image-matrix_test.sh
- bash -n docker/tests/image-matrix_test.sh
- actionlint .github/workflows/docker-permissions.yaml .github/workflows/docker-build.yaml .github/workflows/release.yaml
- Pre-commit lint checks

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary (particularly complex areas)
- [x] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [x] No console.log, debug statements, or commented-out code

## Screenshots (if applicable)

Not applicable.

## Additional Notes

Full multi-architecture Docker builds run in GitHub Actions during release validation. Local verification covers the matrix, shell syntax, workflow syntax, and repository lint hooks.
