### PR TITLE
fix: bump socket.io-parser override to 4.2.7

### DIFF
--- a/webapp/frontend/package-lock.json
+++ b/webapp/frontend/package-lock.json
@@ -10741,9 +10741,9 @@
       "license": "MIT"
     },
     "node_modules/socket.io-parser": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
-      "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.7.tgz",
+      "integrity": "sha512-IH/iSeO9T6gz1KkFleGDWkG9N3dl4jXVYUtMhIqH10Md0ttMer8nUNWiP1DKuNrybD2xBrixLJdCC9J6ECoYkg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/webapp/frontend/package.json
+++ b/webapp/frontend/package.json
@@ -96,7 +96,7 @@
     "postcss": "8.5.15",
     "qs": "6.15.2",
     "engine.io": "6.6.9",
-    "socket.io-parser": "4.2.6",
+    "socket.io-parser": "^4.2.7",
     "ws": "8.21.3"
   }
 }


### PR DESCRIPTION
## Summary

Update the frontend dependency override for the vulnerable `socket.io-parser` transitive dependency.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

Closes #813

## Changes Made

- Change the `socket.io-parser` override from `4.2.6` to `^4.2.7`.
- Regenerate the frontend lockfile so it resolves `socket.io-parser` 4.2.7.

## Testing

- [x] I have tested this locally
- [ ] I have added/updated tests that prove my fix/feature
- [x] All existing tests pass

Validation:

- `npm ci --legacy-peer-deps --ignore-scripts`
- `npm test -- --watch=false --browsers=ChromeHeadless --code-coverage` (212 tests passed)
- `npm run lint`
- `npm audit --package-lock-only --json`: relevant `socket.io-parser` and `socket.io` findings cleared; existing unrelated advisories remain.

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary (particularly complex areas)
- [x] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [x] No console.log, debug statements, or commented-out code

## Screenshots (if applicable)

Not applicable.

## Additional Notes

This dependency is used through the frontend development dependency graph and does not change shipped runtime artifacts.
