### PR TITLE
[ISSUE-824] Repair promotion CI checks

### DIFF
--- a/webapp/backend/pkg/database/scrutiny_repository_zfs.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_zfs.go
@@ -20,7 +20,7 @@ import (
 
 // RegisterZFSPool inserts or updates a ZFS pool in the database
 func (sr *scrutinyRepository) RegisterZFSPool(ctx context.Context, pool models.ZFSPool) error {
-	return sr.registerZFSPoolWithDB(ctx, sr.gormClient, pool, time.Now())
+	return sr.registerZFSPoolWithDB(ctx, sr.gormClient, &pool, time.Now())
 }
 
 // RegisterZFSPoolInventory atomically records a complete pool inventory for one host.
@@ -50,7 +50,7 @@ func (sr *scrutinyRepository) RegisterZFSPoolInventory(ctx context.Context, host
 			pool.HostID = hostID
 			pool.LastSeenAt = now
 			pool.LastInventoryAt = now
-			if err := sr.registerZFSPoolWithDB(ctx, tx, pool, now); err != nil {
+			if err := sr.registerZFSPoolWithDB(ctx, tx, &pool, now); err != nil {
 				return err
 			}
 		}
@@ -58,7 +58,7 @@ func (sr *scrutinyRepository) RegisterZFSPoolInventory(ctx context.Context, host
 	})
 }
 
-func (sr *scrutinyRepository) registerZFSPoolWithDB(ctx context.Context, db *gorm.DB, pool models.ZFSPool, now time.Time) error {
+func (sr *scrutinyRepository) registerZFSPoolWithDB(ctx context.Context, db *gorm.DB, pool *models.ZFSPool, now time.Time) error {
 	pool.UpdatedAt = now
 
 	// Check if pool already exists
@@ -67,7 +67,7 @@ func (sr *scrutinyRepository) registerZFSPoolWithDB(ctx context.Context, db *gor
 
 	if errors.Is(result.Error, gorm.ErrRecordNotFound) {
 		// New pool - create it
-		if err := db.WithContext(ctx).Create(&pool).Error; err != nil {
+		if err := db.WithContext(ctx).Create(pool).Error; err != nil {
 			return err
 		}
 	} else if result.Error != nil {

--- a/webapp/backend/pkg/reports/formatter_pdf.go
+++ b/webapp/backend/pkg/reports/formatter_pdf.go
@@ -178,11 +178,12 @@ func writeZFSSection(pdf *fpdf.Fpdf, report *ReportData) {
 	pdf.SetFont("Helvetica", "", 8)
 	for _, pool := range report.ZFSPools {
 		displayHealth := pool.DisplayHealth()
-		if displayHealth == "UNKNOWN" {
+		switch {
+		case displayHealth == "UNKNOWN":
 			pdf.SetTextColor(255, 193, 7)
-		} else if displayHealth != "ONLINE" {
+		case displayHealth != "ONLINE":
 			pdf.SetTextColor(220, 53, 69)
-		} else {
+		default:
 			pdf.SetTextColor(33, 37, 41)
 		}
 		pdf.CellFormat(colWidths[0], 6, pool.Name, "1", 0, "L", false, 0, "")

--- a/webapp/backend/pkg/reports/models.go
+++ b/webapp/backend/pkg/reports/models.go
@@ -133,7 +133,7 @@ type ZFSPoolReport struct {
 	ErrorsChecksum int64      `json:"errors_checksum"`
 }
 
-func (p ZFSPoolReport) DisplayHealth() string {
+func (p *ZFSPoolReport) DisplayHealth() string {
 	if p.Presence != "" && p.Presence != "present" {
 		return strings.ToUpper(p.Presence)
 	}

--- a/webapp/frontend/src/app/modules/zfs-pool-detail/zfs-pool-detail.component.spec.ts
+++ b/webapp/frontend/src/app/modules/zfs-pool-detail/zfs-pool-detail.component.spec.ts
@@ -4,6 +4,7 @@ import { provideRouter } from '@angular/router';
 import { AppConfig } from 'app/core/config/app.config';
 import { ScrutinyConfigService } from 'app/core/config/scrutiny-config.service';
 import { ZFSPoolModel } from 'app/core/models/zfs-pool-model';
+import { ZFSPoolDetailsResponseWrapper } from 'app/core/models/zfs-pool-summary-model';
 import { BehaviorSubject, of } from 'rxjs';
 import { ZFSPoolDetailComponent } from './zfs-pool-detail.component';
 import { ZFSPoolDetailService } from './zfs-pool-detail.service';
@@ -11,6 +12,7 @@ import { ZFSPoolDetailService } from './zfs-pool-detail.service';
 describe('ZFSPoolDetailComponent', () => {
     let fixture: ComponentFixture<ZFSPoolDetailComponent>;
     let config: BehaviorSubject<AppConfig>;
+    let poolData: BehaviorSubject<ZFSPoolDetailsResponseWrapper>;
 
     const pool = {
         guid: '1',
@@ -42,6 +44,7 @@ describe('ZFSPoolDetailComponent', () => {
 
     beforeEach(async () => {
         config = new BehaviorSubject<AppConfig>({ zfs_pool_modifications_allowed: false });
+        poolData = new BehaviorSubject<ZFSPoolDetailsResponseWrapper>({ success: true, data: { pool, metrics_history: [] } });
         const iconRegistry = jasmine.createSpyObj<MatIconRegistry>('MatIconRegistry', ['getNamedSvgIcon']);
         iconRegistry.getNamedSvgIcon.and.returnValue(of(document.createElementNS('http://www.w3.org/2000/svg', 'svg')));
 
@@ -54,7 +57,7 @@ describe('ZFSPoolDetailComponent', () => {
                 {
                     provide: ZFSPoolDetailService,
                     useValue: {
-                        data$: of({ success: true, data: { pool, metrics_history: [] } }),
+                        data$: poolData.asObservable(),
                         setMuted: jasmine.createSpy('setMuted').and.returnValue(of({ success: true })),
                     },
                 },
@@ -77,7 +80,7 @@ describe('ZFSPoolDetailComponent', () => {
     });
 
     it('shows missing inventory instead of historical online status', () => {
-        fixture.componentInstance.pool = { ...pool, presence: 'missing' };
+        poolData.next({ success: true, data: { pool: { ...pool, presence: 'missing' }, metrics_history: [] } });
         fixture.detectChanges();
 
         const text = fixture.nativeElement.textContent as string;


### PR DESCRIPTION
## Summary

Repair the backend lint and frontend test failures blocking promotion PR #842.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

Related to #824 and #842.

## Changes Made

- Pass large ZFS pool values by pointer to satisfy backend lint without changing behavior.
- Rewrite PDF health color selection as a switch and use a pointer receiver for the report health helper.
- Drive the missing-pool frontend test through the service observable so OnPush change detection follows the production data path.

## Testing

- [x] I have tested this locally
- [x] I have added/updated tests that prove my fix/feature works
- [x] All existing tests pass

Validation:

- `go test ./webapp/backend/pkg/database ./webapp/backend/pkg/reports`
- CI-equivalent `go mod vendor` and `golangci-lint run --timeout=5m --new-from-rev=origin/master` with Go 1.25.0
- Frontend `npm run lint`
- Frontend `npx ng test --watch=false --browsers=ChromeHeadless --code-coverage` (214/214)

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary (particularly complex areas)
- [x] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [x] No console.log, debug statements, or commented-out code

## Screenshots (if applicable)

Not applicable.

## Additional Notes

Merge this PR into `develop`, then rerun promotion PR #842 from `develop` to `master`.
