### PR TITLE
feat: SCSI drive improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,7 +545,7 @@ Scrutiny computes drive workload statistics from existing S.M.A.R.T attribute hi
 
 - **ATA**: Uses SMART attributes 241/242 (Total LBAs Written/Read) or DeviceStats 1.24/1.40 (Logical Sectors Written/Read)
 - **NVMe**: Uses Data Units Written/Read counters
-- **SCSI**: Limited support (cumulative byte counters are not stored as SMART attributes)
+- **SCSI/SAS**: Uses the "gigabytes processed" fields from the SCSI Read/Write Error Counter log pages as cumulative read/write counters. SAS SSDs that report the Solid State Media log page's "Percentage used endurance indicator" (`endurance_used`) also get endurance/percentage-used tracking, matching NVMe. Not all SAS drives report these fields, in which case workload/endurance data is unavailable for that device.
 
 ### Viewing Workload Data
 

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ These S.M.A.R.T hard drive self-tests can help you detect and replace failing ha
 - **Mobile-Optimized Interface** - Bottom tab bar (Home, Drives, ZFS, Workload, Settings), health overview home tab, card-based data views, and responsive layouts below 960px
 - **API Timeout Configuration** - Adjust timeouts for slow storage systems
 - **Performance Benchmarking** - fio-based benchmarks for throughput, IOPS, and latency with historical tracking
-- **ATA Self-Test History** - Persist and display recent ATA SMART self-test log entries on device detail pages
+- **SMART Self-Test History** - Persist and display recent ATA and SCSI/SAS SMART self-test log entries on device detail pages
 - **Scheduled Reports** [WIP] - Automated health reports on daily/weekly/monthly schedules with HTML emails and PDF export
 - **Missed Ping Digest** - Batch notification when multiple collectors go unreachable
 - **HTML Email Notifications** - Rich HTML formatting with plain-text fallback for SMTP notifications, including reports, test notifications, collector errors, missed ping digests, heartbeat, performance degradation, replacement risk, and MDADM degradation alerts
@@ -561,18 +561,19 @@ Some SSDs report misleading wear percentages through SMART. To supplement those 
 
 This value is user-supplied and does not replace the existing SMART wear indicators.
 
-## ATA SMART Self-Test History
+## SMART Self-Test History
 
-Scrutiny now retains ATA SMART self-test log entries that are already present in uploaded `smartctl` payloads. On ATA drive detail pages, the web UI shows a **SMART Self-Tests** card with the recorded test type, pass/attention status, controller detail string, and power-on age.
+Scrutiny now retains ATA and SCSI/SAS SMART self-test log entries that are already present in uploaded `smartctl` payloads. On ATA and SCSI/SAS drive detail pages, the web UI shows a **SMART Self-Tests** card with the recorded test type, pass/attention status, controller detail string, and power-on age.
 
 - Data is read from normal SMART uploads; no separate self-test collector is required
-- Only ATA devices show this section today
-- Scrutiny keeps the most recent 21 entries per physical ATA device identity using collection time and controller log position, including when lifetime hours wrap
-- Raw controller hours remain available. Absolute power-on ages are shown only when the current Power-On Hours and log order identify one rollover epoch; otherwise the UI shows "Unknown (may be wrapped)"
-- Existing history remains intact during upgrade. Ages stay unknown until a new collection provides enough context; already pruned or overwritten records cannot be recovered
+- Both ATA (`AtaSmartSelfTestLog`) and SCSI/SAS (`scsi_self_test_N` log entries) devices show this section
+- Scrutiny keeps the most recent 21 entries per physical device identity using collection time and controller log position, including when ATA lifetime hours wrap
+- Raw controller hours remain available. SCSI/SAS entries report smartctl's absolute, non-wrapping `accumulated_power_on_hours`, so their power-on age is always known. ATA entries use a 16-bit lifetime-hours counter that can wrap; for those, an absolute power-on age is shown only when the current Power-On Hours and log order identify one rollover epoch, otherwise the UI shows "Unknown (may be wrapped)"
+- Existing history remains intact during upgrade. ATA ages stay unknown until a new collection provides enough context; already pruned or overwritten records cannot be recovered
 - Rolling back to a web release that uses the old raw-lifetime uniqueness key requires restoring a pre-upgrade database backup
 - The API route `GET /api/device/{id}/selftest` returns the same history used by the device detail page
 - This feature records and displays history only; it does not trigger or schedule drive self-tests from the web UI
+- See [PR #848](https://github.com/Starosdev/scrutiny/pull/848) for background on SCSI/SAS self-test history and endurance handling
 
 ## SMART Attribute Overrides
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -421,6 +421,7 @@ curl -X POST -H "Content-Type: application/json" \
 | `smart-scsi2.json` | SCSI | SCSI drive (variant) |
 | `smart-scsi-failed.json` | SCSI | SCSI drive with failures |
 | `smart-scsi-sas-env-temp.json` | SCSI | SCSI SAS drive with environment temp |
+| `smart-scsi-sas-ssd.json` | SCSI | SAS SSD with `endurance_used` and `gigabytes_processed` |
 | `smart-megaraid0.json` | ATA | MegaRAID virtual disk |
 | `smart-sat.json` | ATA | SAT (SCSI-to-ATA Translation) device |
 

--- a/collector/pkg/detect/detect.go
+++ b/collector/pkg/detect/detect.go
@@ -222,7 +222,14 @@ func (d *Detect) SmartCtlInfo(device *models.Device) error {
 	device.ModelName = availableDeviceInfo.ModelName
 	device.InterfaceSpeed = availableDeviceInfo.InterfaceSpeed.Current.String
 	device.SerialNumber = availableDeviceInfo.SerialNumber
-	device.Firmware = availableDeviceInfo.FirmwareVersion
+	// Only overwrite a previously known firmware/revision when this run actually
+	// reported one; smartctl omits both firmware_version and scsi_revision when
+	// the drive doesn't answer that inquiry (e.g. transient errors, permissions,
+	// or invocation args that didn't include -i/-x), and we don't want to blank
+	// out a value we already have on file.
+	if firmware := availableDeviceInfo.Firmware(); firmware != "" {
+		device.Firmware = firmware
+	}
 	device.RotationSpeed = availableDeviceInfo.RotationRate
 	device.Capacity = availableDeviceInfo.Capacity()
 	device.FormFactor = availableDeviceInfo.FormFactor.Name

--- a/collector/pkg/detect/detect_test.go
+++ b/collector/pkg/detect/detect_test.go
@@ -525,6 +525,42 @@ func TestDetect_SmartCtlInfo(t *testing.T) {
 		assert.Equal(t, "jmb39x-q,0", someDevice.DeviceType)
 	})
 
+	// SCSI/SAS drives don't populate "firmware_version" in smartctl's JSON
+	// output; the equivalent value is reported under "scsi_revision" instead.
+	// SmartCtlInfo must fall back to it so device.Firmware is not left blank.
+	t.Run("should populate firmware from scsi_revision for a SAS SSD", func(t *testing.T) {
+		fakeShell, fakeConfig, someLogger := setupSmartCtlInfoArgvMocks(t, "sdp",
+			[]string{"--info", "--json", "/dev/sdp"},
+			"testdata/smartctl_info_sas_ssd.json", nil, nil)
+
+		d := detect.Detect{Logger: someLogger, Shell: fakeShell, Config: fakeConfig}
+		someDevice := &models.Device{DeviceName: "sdp"}
+
+		require.NoError(t, d.SmartCtlInfo(someDevice))
+
+		assert.Equal(t, "HPE VO003840JWZJK", someDevice.ModelName)
+		assert.Equal(t, "ABCDEFGHIJKLMNOP", someDevice.SerialNumber)
+		assert.Equal(t, "HPD5", someDevice.Firmware)
+		assert.Equal(t, "SCSI", someDevice.DeviceProtocol)
+	})
+
+	// A run where smartctl reports neither firmware_version nor scsi_revision
+	// (e.g. transient error, permissions, or args without -i/-x) must not blank
+	// out a firmware value already on file for the device.
+	t.Run("should not clear a previously known firmware when missing from payload", func(t *testing.T) {
+		fakeShell, fakeConfig, someLogger := setupSmartCtlInfoArgvMocks(t, "sdp",
+			[]string{"--info", "--json", "/dev/sdp"},
+			"testdata/smartctl_info_sas_ssd_no_revision.json", nil, nil)
+
+		d := detect.Detect{Logger: someLogger, Shell: fakeShell, Config: fakeConfig}
+		someDevice := &models.Device{DeviceName: "sdp", Firmware: "HPD5"}
+
+		require.NoError(t, d.SmartCtlInfo(someDevice))
+
+		assert.Equal(t, "HPE VO003840JWZJK", someDevice.ModelName)
+		assert.Equal(t, "HPD5", someDevice.Firmware)
+	})
+
 	t.Run("should reject output on a fatal exit status", func(t *testing.T) {
 		fakeShell, fakeConfig, someLogger := setupSmartCtlInfoMocks(t, "sda", "jmb39x-q,0",
 			"testdata/smartctl_info_jmb39x_exit4.json", exitErrorWithCode(t, 2))

--- a/collector/pkg/detect/testdata/smartctl_info_sas_ssd.json
+++ b/collector/pkg/detect/testdata/smartctl_info_sas_ssd.json
@@ -1,0 +1,70 @@
+{
+  "json_format_version": [
+    1,
+    0
+  ],
+  "smartctl": {
+    "version": [
+      7,
+      5
+    ],
+    "pre_release": false,
+    "svn_revision": "5714",
+    "platform_info": "x86_64-linux-7.0.14-9-pve",
+    "build_info": "(local build)",
+    "argv": [
+      "smartctl",
+      "--info",
+      "--json",
+      "--device",
+      "scsi",
+      "/dev/sdp"
+    ],
+    "exit_status": 0
+  },
+  "local_time": {
+    "time_t": 1789148192,
+    "asctime": "Fri Sep 11 13:36:32 2026 EDT"
+  },
+  "device": {
+    "name": "/dev/sdp",
+    "info_name": "/dev/sdp",
+    "type": "scsi",
+    "protocol": "SCSI"
+  },
+  "scsi_vendor": "HPE",
+  "scsi_product": "VO003840JWZJK",
+  "model_name": "HPE VO003840JWZJK",
+  "scsi_model_name": "HPE VO003840JWZJK",
+  "scsi_revision": "HPD5",
+  "scsi_version": "SPC-5",
+  "user_capacity": {
+    "blocks": 7501476528,
+    "bytes": 3840755982336
+  },
+  "logical_block_size": 512,
+  "physical_block_size": 4096,
+  "rotation_rate": 0,
+  "form_factor": {
+    "scsi_value": 3,
+    "name": "2.5 inches"
+  },
+  "logical_unit_id": "0x50000f0b005750f0",
+  "serial_number": "ABCDEFGHIJKLMNOP",
+  "device_type": {
+    "scsi_terminology": "Peripheral Device Type [PDT]",
+    "scsi_value": 0,
+    "name": "disk"
+  },
+  "scsi_transport_protocol": {
+    "name": "SAS (SPL-4)",
+    "value": 6
+  },
+  "smart_support": {
+    "available": true,
+    "enabled": true
+  },
+  "smart_status": {
+    "passed": true
+  }
+}

--- a/collector/pkg/detect/testdata/smartctl_info_sas_ssd_no_revision.json
+++ b/collector/pkg/detect/testdata/smartctl_info_sas_ssd_no_revision.json
@@ -1,0 +1,53 @@
+{
+  "json_format_version": [
+    1,
+    0
+  ],
+  "smartctl": {
+    "version": [
+      7,
+      5
+    ],
+    "pre_release": false,
+    "svn_revision": "5714",
+    "platform_info": "x86_64-linux-7.0.14-9-pve",
+    "build_info": "(local build)",
+    "argv": [
+      "smartctl",
+      "-H",
+      "-l",
+      "error",
+      "--json",
+      "--device",
+      "scsi",
+      "/dev/sdp"
+    ],
+    "exit_status": 0
+  },
+  "local_time": {
+    "time_t": 1789148192,
+    "asctime": "Fri Sep 11 13:36:32 2026 EDT"
+  },
+  "device": {
+    "name": "/dev/sdp",
+    "info_name": "/dev/sdp",
+    "type": "scsi",
+    "protocol": "SCSI"
+  },
+  "model_name": "HPE VO003840JWZJK",
+  "user_capacity": {
+    "blocks": 7501476528,
+    "bytes": 3840755982336
+  },
+  "logical_block_size": 512,
+  "physical_block_size": 4096,
+  "rotation_rate": 0,
+  "serial_number": "ABCDEFGHIJKLMNOP",
+  "smart_support": {
+    "available": true,
+    "enabled": true
+  },
+  "smart_status": {
+    "passed": true
+  }
+}

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1915,6 +1915,13 @@ components:
           type: object
           additionalProperties:
             $ref: "#/components/schemas/ScsiTemperatureData"
+        endurance_used:
+          type: object
+          description: SAS SSD "Percentage used endurance indicator" from the Solid State Media log page (0x11). Only reported by solid-state SAS drives.
+          properties:
+            current_percent:
+              type: integer
+              format: int64
         seagate_farm_log:
           $ref: "#/components/schemas/SeagateFarmLog"
       additionalProperties: true

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1809,6 +1809,15 @@ components:
           type: string
         firmware_version:
           type: string
+          description: >-
+            Firmware/revision string reported by smartctl. Only populated for
+            ATA/SAT and NVMe devices; SCSI/SAS devices report this value under
+            scsi_revision instead.
+        scsi_revision:
+          type: string
+          description: >-
+            SCSI/SAS equivalent of firmware_version, reported by smartctl for
+            plain SCSI/SAS devices (e.g. "-i"/"-x" output).
         wwn:
           type: object
           properties:

--- a/webapp/backend/pkg/database/scrutiny_repository_device_self_tests.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_device_self_tests.go
@@ -65,10 +65,13 @@ func selfTestLifetimeBounds(entries []collector.AtaSmartSelfTestLogEntry, powerO
 }
 
 func (sr *scrutinyRepository) syncDeviceSelfTests(ctx context.Context, device *models.Device, collectorSmartData *collector.SmartInfo, powerOnHours int64) error {
-	if collectorSmartData.Device.Protocol != pkg.DeviceProtocolAta {
+	if collectorSmartData.Device.Protocol != pkg.DeviceProtocolAta && collectorSmartData.Device.Protocol != pkg.DeviceProtocolScsi {
 		return nil
 	}
-	entries := collectorSmartData.AtaSmartSelfTestLog.Entries()
+	// SelfTestEntries() normalizes both the ATA self-test log (a JSON array) and
+	// the SCSI/SAS self-test log (individually numbered "scsi_self_test_N" keys)
+	// into the same shape; the lifetime-bounds/dedup logic below is protocol-agnostic.
+	entries := collectorSmartData.SelfTestEntries()
 	if len(entries) == 0 {
 		return nil
 	}

--- a/webapp/backend/pkg/database/scrutiny_repository_device_self_tests.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_device_self_tests.go
@@ -64,13 +64,34 @@ func selfTestLifetimeBounds(entries []collector.AtaSmartSelfTestLogEntry, powerO
 	return minimum, maximum
 }
 
+// selfTestAbsoluteBounds treats each entry's LifetimeHours as an already-absolute hour count
+// with no rollover ambiguity. Unlike ATA's 16-bit lifetime-hours field, SCSI/SAS self-test log
+// entries report smartctl's "accumulated_power_on_hours" value, which does not wrap at 65536,
+// so entries at or above that value still have a single, exact effective age.
+func selfTestAbsoluteBounds(entries []collector.AtaSmartSelfTestLogEntry) ([]int64, []int64) {
+	minimum := make([]int64, len(entries))
+	maximum := make([]int64, len(entries))
+	for i, entry := range entries {
+		if entry.LifetimeHours < 0 {
+			minimum[i], maximum[i] = 0, -1
+			continue
+		}
+		hours := int64(entry.LifetimeHours)
+		minimum[i], maximum[i] = hours, hours
+	}
+	return minimum, maximum
+}
+
 func (sr *scrutinyRepository) syncDeviceSelfTests(ctx context.Context, device *models.Device, collectorSmartData *collector.SmartInfo, powerOnHours int64) error {
 	if collectorSmartData.Device.Protocol != pkg.DeviceProtocolAta && collectorSmartData.Device.Protocol != pkg.DeviceProtocolScsi {
 		return nil
 	}
 	// SelfTestEntries() normalizes both the ATA self-test log (a JSON array) and
 	// the SCSI/SAS self-test log (individually numbered "scsi_self_test_N" keys)
-	// into the same shape; the lifetime-bounds/dedup logic below is protocol-agnostic.
+	// into the same shape; the dedup logic below is protocol-agnostic. Resolving
+	// effective lifetime hours is not: ATA's 16-bit counter can wrap and needs
+	// epoch resolution against powerOnHours, while SCSI/SAS reports an absolute,
+	// non-wrapping accumulated power-on-hours value that needs no such resolution.
 	entries := collectorSmartData.SelfTestEntries()
 	if len(entries) == 0 {
 		return nil
@@ -80,7 +101,12 @@ func (sr *scrutinyRepository) syncDeviceSelfTests(ctx context.Context, device *m
 	if observedAt <= 0 {
 		observedAt = time.Now().Unix()
 	}
-	minimum, maximum := selfTestLifetimeBounds(entries, powerOnHours)
+	var minimum, maximum []int64
+	if collectorSmartData.Device.Protocol == pkg.DeviceProtocolScsi {
+		minimum, maximum = selfTestAbsoluteBounds(entries)
+	} else {
+		minimum, maximum = selfTestLifetimeBounds(entries, powerOnHours)
+	}
 
 	return sr.gormClient.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		var existing []models.DeviceSelfTest

--- a/webapp/backend/pkg/database/scrutiny_repository_device_self_tests_test.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_device_self_tests_test.go
@@ -125,6 +125,38 @@ func TestSaveSmartAttributesPersistsAtaSelfTests(t *testing.T) {
 	require.Equal(t, 1157, selfTests[len(selfTests)-1].LifetimeHours)
 }
 
+func TestSaveSmartAttributesPersistsScsiSelfTests(t *testing.T) {
+	repo := createDeviceSelfTestRepository(t)
+	ctx := context.Background()
+
+	device := models.Device{
+		DeviceID:       "device-1",
+		WWN:            "wwn-1",
+		DeviceProtocol: "SCSI",
+	}
+	require.NoError(t, repo.gormClient.WithContext(ctx).Create(&device).Error)
+
+	smartInfo := loadSmartInfoFixture(t, filepath.Join("..", "models", "testdata", "smart-scsi-selftest.json"))
+	require.Len(t, smartInfo.ScsiSelfTests, 3)
+
+	_, err := repo.SaveSmartAttributes(ctx, device.WWN, smartInfo)
+	require.NoError(t, err)
+
+	var selfTests []models.DeviceSelfTest
+	require.NoError(t, repo.gormClient.WithContext(ctx).
+		Order("lifetime_hours DESC, id DESC").
+		Find(&selfTests).Error)
+
+	require.Len(t, selfTests, 3)
+	require.Equal(t, device.DeviceID, selfTests[0].DeviceID)
+	require.Equal(t, device.WWN, selfTests[0].DeviceWWN)
+	require.Equal(t, 48239, selfTests[0].LifetimeHours)
+	require.Equal(t, "Background short", selfTests[0].TypeString)
+	require.Equal(t, "Completed", selfTests[0].StatusString)
+	require.True(t, selfTests[0].StatusPassed)
+	require.Equal(t, 48234, selfTests[len(selfTests)-1].LifetimeHours)
+}
+
 func TestSyncDeviceSelfTestsDedupesByDeviceIdentity(t *testing.T) {
 	repo := createDeviceSelfTestRepository(t)
 	ctx := context.Background()

--- a/webapp/backend/pkg/database/scrutiny_repository_device_self_tests_test.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_device_self_tests_test.go
@@ -157,6 +157,40 @@ func TestSaveSmartAttributesPersistsScsiSelfTests(t *testing.T) {
 	require.Equal(t, 48234, selfTests[len(selfTests)-1].LifetimeHours)
 }
 
+// TestSyncDeviceSelfTestsScsiAbsoluteHoursAboveAtaLimit reproduces a bug where SCSI self-test
+// entries were fed through ATA's 16-bit rollover-epoch resolution (selfTestLifetimeBounds),
+// which explicitly gives up (leaving EffectiveLifetimeHours nil / "Unknown (may be wrapped)")
+// whenever any entry's hours are >= 65536. SCSI/SAS self-test log entries report smartctl's
+// "accumulated_power_on_hours", an absolute, non-wrapping value, so hours >= 65536 should
+// still resolve to an exact effective age.
+func TestSyncDeviceSelfTestsScsiAbsoluteHoursAboveAtaLimit(t *testing.T) {
+	repo := createDeviceSelfTestRepository(t)
+	ctx := context.Background()
+	device := models.Device{DeviceID: "device-1", WWN: "wwn-1", DeviceProtocol: "SCSI"}
+	require.NoError(t, repo.gormClient.Create(&device).Error)
+
+	payload := collector.SmartInfo{}
+	payload.Device.Protocol = "SCSI"
+	payload.PowerOnTime.Hours = 70000
+	payload.LocalTime.TimeT = 1000
+	entry := collector.ScsiSelfTestEntry{}
+	entry.Code.Value = 1
+	entry.Code.String = "Background short"
+	entry.Result.Value = 0
+	entry.Result.String = "Completed"
+	entry.PowerOnTime.Hours = 70000 // > 65535, would be rejected as ambiguous by ATA rollover logic
+	payload.ScsiSelfTests = []collector.ScsiSelfTestEntry{entry}
+
+	require.NoError(t, repo.syncDeviceSelfTests(ctx, &device, &payload, payload.PowerOnTime.Hours))
+
+	rows, err := repo.GetDeviceSelfTests(ctx, device.DeviceID)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	require.Equal(t, 70000, rows[0].LifetimeHours)
+	require.NotNil(t, rows[0].EffectiveLifetimeHours, "SCSI self-test hours above the ATA 16-bit limit should still resolve to a known effective age")
+	require.Equal(t, int64(70000), *rows[0].EffectiveLifetimeHours)
+}
+
 func TestSyncDeviceSelfTestsDedupesByDeviceIdentity(t *testing.T) {
 	repo := createDeviceSelfTestRepository(t)
 	ctx := context.Background()

--- a/webapp/backend/pkg/database/scrutiny_repository_workload.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_workload.go
@@ -119,21 +119,27 @@ type workloadSnapshot struct {
 	// NVMe
 	DataUnitsWritten int64
 	DataUnitsRead    int64
-	PercentageUsed   int64
+	PercentageUsed   int64 // shared with SCSI (SAS SSD endurance_used.current_percent)
+
+	// SCSI
+	ScsiWriteGigabytesProcessed int64 // cumulative bytes processed by write commands
+	ScsiReadGigabytesProcessed  int64 // cumulative bytes processed by read commands
 
 	// Track which fields were present
-	hasAttr241        bool
-	hasAttr242        bool
-	hasDevstat124     bool
-	hasDevstat140     bool
-	hasDevstat78      bool
-	hasAttr177        bool
-	hasAttr231        bool
-	hasAttr232        bool
-	hasAttr233        bool
-	hasDataUnitsW     bool
-	hasDataUnitsR     bool
-	hasPercentageUsed bool
+	hasAttr241                     bool
+	hasAttr242                     bool
+	hasDevstat124                  bool
+	hasDevstat140                  bool
+	hasDevstat78                   bool
+	hasAttr177                     bool
+	hasAttr231                     bool
+	hasAttr232                     bool
+	hasAttr233                     bool
+	hasDataUnitsW                  bool
+	hasDataUnitsR                  bool
+	hasPercentageUsed              bool
+	hasScsiWriteGigabytesProcessed bool
+	hasScsiReadGigabytesProcessed  bool
 }
 
 // extractInt64 extracts an int64 value from InfluxDB result map.
@@ -188,6 +194,9 @@ func parseWorkloadSnapshot(values map[string]interface{}) *workloadSnapshot {
 		{field: "attr.data_units_written.value", dest: &snap.DataUnitsWritten, flag: &snap.hasDataUnitsW},
 		{field: "attr.data_units_read.value", dest: &snap.DataUnitsRead, flag: &snap.hasDataUnitsR},
 		{field: "attr.percentage_used.value", dest: &snap.PercentageUsed, flag: &snap.hasPercentageUsed},
+		// SCSI attributes
+		{field: "attr.write_gigabytes_processed.value", dest: &snap.ScsiWriteGigabytesProcessed, flag: &snap.hasScsiWriteGigabytesProcessed},
+		{field: "attr.read_gigabytes_processed.value", dest: &snap.ScsiReadGigabytesProcessed, flag: &snap.hasScsiReadGigabytesProcessed},
 	} {
 		*attr.dest, *attr.flag = extractInt64(values, attr.field)
 	}
@@ -259,7 +268,9 @@ func (sr *scrutinyRepository) buildWorkloadFirstLastQuery(durationKey string) st
 		`    r["_field"] == "attr.177.value" or`,
 		`    r["_field"] == "attr.231.value" or`,
 		`    r["_field"] == "attr.232.value" or`,
-		`    r["_field"] == "attr.233.value"`,
+		`    r["_field"] == "attr.233.value" or`,
+		`    r["_field"] == "attr.write_gigabytes_processed.value" or`,
+		`    r["_field"] == "attr.read_gigabytes_processed.value"`,
 		``,
 	}
 
@@ -302,7 +313,9 @@ func (sr *scrutinyRepository) buildWorkloadFirstLastQuery(durationKey string) st
 		`    (exists r["attr.devstat_1_24.value"] and r["attr.devstat_1_24.value"] > 0) or`,
 		`    (exists r["attr.devstat_1_40.value"] and r["attr.devstat_1_40.value"] > 0) or`,
 		`    (exists r["attr.data_units_written.value"] and r["attr.data_units_written.value"] > 0) or`,
-		`    (exists r["attr.data_units_read.value"] and r["attr.data_units_read.value"] > 0)`,
+		`    (exists r["attr.data_units_read.value"] and r["attr.data_units_read.value"] > 0) or`,
+		`    (exists r["attr.write_gigabytes_processed.value"] and r["attr.write_gigabytes_processed.value"] > 0) or`,
+		`    (exists r["attr.read_gigabytes_processed.value"] and r["attr.read_gigabytes_processed.value"] > 0)`,
 		`)`,
 		`|> group(columns: ["device_wwn"])`,
 		``,
@@ -364,7 +377,9 @@ func (sr *scrutinyRepository) buildWorkloadRecentQuery() string {
 		`    r["_field"] == "attr.devstat_1_24.value" or`,
 		`    r["_field"] == "attr.devstat_1_40.value" or`,
 		`    r["_field"] == "attr.data_units_written.value" or`,
-		`    r["_field"] == "attr.data_units_read.value"`,
+		`    r["_field"] == "attr.data_units_read.value" or`,
+		`    r["_field"] == "attr.write_gigabytes_processed.value" or`,
+		`    r["_field"] == "attr.read_gigabytes_processed.value"`,
 		``,
 		fmt.Sprintf("from(bucket: %q)", bucketName),
 		`|> range(start: -1w, stop: now())`,
@@ -398,8 +413,9 @@ func (sr *scrutinyRepository) computeWorkloadInsight(insight *models.WorkloadIns
 		totalWrittenBytes, totalReadBytes = sr.computeATAWorkload(first, last)
 	case pkg.DeviceProtocolNvme:
 		totalWrittenBytes, totalReadBytes = sr.computeNVMeWorkload(first, last)
+	case pkg.DeviceProtocolScsi:
+		totalWrittenBytes, totalReadBytes = sr.computeSCSIWorkload(first, last)
 	default:
-		// SCSI: no cumulative byte counters
 		insight.Intensity = "unknown"
 		sr.computeEndurance(insight, last, protocol, 0, maxTBW)
 		return
@@ -464,6 +480,20 @@ func (sr *scrutinyRepository) computeNVMeWorkload(first, last *workloadSnapshot)
 	return writtenBytes, readBytes
 }
 
+// computeSCSIWorkload derives cumulative written/read bytes for SAS/SCSI drives from the
+// delta of the "gigabytes_processed" fields in the SCSI error counter log (read/write log
+// pages). This is the SAS analog of ATA LBAs written/read and NVMe data units; the value is
+// already converted to bytes when the attribute is created (see parseGigabytesProcessed).
+func (sr *scrutinyRepository) computeSCSIWorkload(first, last *workloadSnapshot) (writtenBytes, readBytes int64) {
+	if last.hasScsiWriteGigabytesProcessed && first.hasScsiWriteGigabytesProcessed {
+		writtenBytes = last.ScsiWriteGigabytesProcessed - first.ScsiWriteGigabytesProcessed
+	}
+	if last.hasScsiReadGigabytesProcessed && first.hasScsiReadGigabytesProcessed {
+		readBytes = last.ScsiReadGigabytesProcessed - first.ScsiReadGigabytesProcessed
+	}
+	return writtenBytes, readBytes
+}
+
 func (sr *scrutinyRepository) getCumulativeWriteBytes(snap *workloadSnapshot, protocol string) int64 {
 	switch protocol {
 	case pkg.DeviceProtocolAta:
@@ -476,6 +506,10 @@ func (sr *scrutinyRepository) getCumulativeWriteBytes(snap *workloadSnapshot, pr
 	case pkg.DeviceProtocolNvme:
 		if snap.hasDataUnitsW {
 			return snap.DataUnitsWritten * 512000
+		}
+	case pkg.DeviceProtocolScsi:
+		if snap.hasScsiWriteGigabytesProcessed {
+			return snap.ScsiWriteGigabytesProcessed
 		}
 	}
 	return 0
@@ -523,7 +557,9 @@ func (sr *scrutinyRepository) computeEndurance(insight *models.WorkloadInsight, 
 // given protocol from a snapshot, returning the value and whether one was found.
 func endurancePercentageUsed(snap *workloadSnapshot, protocol string) (percentageUsed int64, hasPercentage bool) {
 	switch protocol {
-	case pkg.DeviceProtocolNvme:
+	case pkg.DeviceProtocolNvme, pkg.DeviceProtocolScsi:
+		// SCSI SAS SSDs store their endurance_used.current_percent under the shared
+		// "percentage_used" attribute ID (see processScsiSmartInfoWithOverrides).
 		if snap.hasPercentageUsed {
 			return snap.PercentageUsed, true
 		}
@@ -610,6 +646,10 @@ func (sr *scrutinyRepository) detectSpike(recentPoints []*workloadSnapshot, base
 		if newest.hasDataUnitsW && previous.hasDataUnitsW {
 			delta := newest.DataUnitsWritten - previous.DataUnitsWritten
 			recentWrittenBytes = delta * 512000
+		}
+	case pkg.DeviceProtocolScsi:
+		if newest.hasScsiWriteGigabytesProcessed && previous.hasScsiWriteGigabytesProcessed {
+			recentWrittenBytes = newest.ScsiWriteGigabytesProcessed - previous.ScsiWriteGigabytesProcessed
 		}
 	default:
 		return nil

--- a/webapp/backend/pkg/database/scrutiny_repository_workload_scsi_test.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_workload_scsi_test.go
@@ -1,0 +1,138 @@
+package database
+
+import (
+	"testing"
+	"time"
+
+	"github.com/analogj/scrutiny/webapp/backend/pkg"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/models"
+	"github.com/stretchr/testify/require"
+)
+
+// TestParseWorkloadSnapshot_ScsiGigabytesProcessed verifies that the SCSI
+// read/write_gigabytes_processed attribute fields are extracted into the workload snapshot.
+func TestParseWorkloadSnapshot_ScsiGigabytesProcessed(t *testing.T) {
+	values := map[string]interface{}{
+		"attr.write_gigabytes_processed.value": int64(243990000000),
+		"attr.read_gigabytes_processed.value":  int64(7668000000),
+		"attr.percentage_used.value":           int64(3),
+	}
+
+	snap := parseWorkloadSnapshot(values)
+
+	require.True(t, snap.hasScsiWriteGigabytesProcessed)
+	require.Equal(t, int64(243990000000), snap.ScsiWriteGigabytesProcessed)
+	require.True(t, snap.hasScsiReadGigabytesProcessed)
+	require.Equal(t, int64(7668000000), snap.ScsiReadGigabytesProcessed)
+	require.True(t, snap.hasPercentageUsed)
+	require.Equal(t, int64(3), snap.PercentageUsed)
+}
+
+// TestComputeSCSIWorkload verifies that cumulative byte deltas are computed correctly from
+// two snapshots, mirroring how ATA/NVMe compute their workload deltas.
+func TestComputeSCSIWorkload(t *testing.T) {
+	repo := &scrutinyRepository{}
+
+	first := &workloadSnapshot{
+		ScsiWriteGigabytesProcessed:    100_000_000_000,
+		hasScsiWriteGigabytesProcessed: true,
+		ScsiReadGigabytesProcessed:     10_000_000_000,
+		hasScsiReadGigabytesProcessed:  true,
+	}
+	last := &workloadSnapshot{
+		ScsiWriteGigabytesProcessed:    243_990_000_000,
+		hasScsiWriteGigabytesProcessed: true,
+		ScsiReadGigabytesProcessed:     7_668_000_000_000, // simulate large cumulative growth
+		hasScsiReadGigabytesProcessed:  true,
+	}
+
+	writtenBytes, readBytes := repo.computeSCSIWorkload(first, last)
+	require.Equal(t, int64(143_990_000_000), writtenBytes)
+	require.Equal(t, int64(7_658_000_000_000), readBytes)
+}
+
+// TestComputeSCSIWorkload_MissingCounters verifies that a missing counter on either side of the
+// delta computation results in a zero delta (e.g. drives that don't report gigabytes_processed).
+func TestComputeSCSIWorkload_MissingCounters(t *testing.T) {
+	repo := &scrutinyRepository{}
+
+	first := &workloadSnapshot{}
+	last := &workloadSnapshot{
+		ScsiWriteGigabytesProcessed:    100,
+		hasScsiWriteGigabytesProcessed: true,
+	}
+
+	writtenBytes, readBytes := repo.computeSCSIWorkload(first, last)
+	require.Equal(t, int64(0), writtenBytes)
+	require.Equal(t, int64(0), readBytes)
+}
+
+// TestEndurancePercentageUsed_Scsi verifies that SCSI SAS SSD endurance (shared
+// "percentage_used" attribute ID with NVMe) is picked up by the endurance calculation.
+func TestEndurancePercentageUsed_Scsi(t *testing.T) {
+	snap := &workloadSnapshot{
+		PercentageUsed:    3,
+		hasPercentageUsed: true,
+	}
+
+	percentageUsed, hasPercentage := endurancePercentageUsed(snap, pkg.DeviceProtocolScsi)
+	require.True(t, hasPercentage)
+	require.Equal(t, int64(3), percentageUsed)
+}
+
+// TestEndurancePercentageUsed_Scsi_NotReported verifies SCSI HDDs (no endurance_used field,
+// so no percentage_used attribute) correctly report no endurance data rather than a false 0%.
+func TestEndurancePercentageUsed_Scsi_NotReported(t *testing.T) {
+	snap := &workloadSnapshot{}
+
+	_, hasPercentage := endurancePercentageUsed(snap, pkg.DeviceProtocolScsi)
+	require.False(t, hasPercentage)
+}
+
+// TestGetCumulativeWriteBytes_Scsi verifies the SCSI branch of getCumulativeWriteBytes used for
+// TBW estimation.
+func TestGetCumulativeWriteBytes_Scsi(t *testing.T) {
+	repo := &scrutinyRepository{}
+	snap := &workloadSnapshot{
+		ScsiWriteGigabytesProcessed:    243_990_000_000,
+		hasScsiWriteGigabytesProcessed: true,
+	}
+
+	require.Equal(t, int64(243_990_000_000), repo.getCumulativeWriteBytes(snap, pkg.DeviceProtocolScsi))
+}
+
+// TestComputeWorkloadInsight_Scsi is an end-to-end check (without InfluxDB) that a SCSI SAS SSD
+// with gigabytes_processed and percentage_used populated no longer reports "unknown" intensity.
+func TestComputeWorkloadInsight_Scsi(t *testing.T) {
+	repo := &scrutinyRepository{}
+
+	baseTime := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	first := &workloadSnapshot{
+		Time:                           baseTime,
+		PowerOnHours:                   45000,
+		ScsiWriteGigabytesProcessed:    100_000_000_000,
+		hasScsiWriteGigabytesProcessed: true,
+		ScsiReadGigabytesProcessed:     5_000_000_000,
+		hasScsiReadGigabytesProcessed:  true,
+	}
+	last := &workloadSnapshot{
+		Time:                           baseTime.Add(48 * time.Hour),
+		PowerOnHours:                   45048,
+		ScsiWriteGigabytesProcessed:    243_990_000_000,
+		hasScsiWriteGigabytesProcessed: true,
+		ScsiReadGigabytesProcessed:     7_668_000_000,
+		hasScsiReadGigabytesProcessed:  true,
+		PercentageUsed:                 3,
+		hasPercentageUsed:              true,
+	}
+
+	insight := &models.WorkloadInsight{}
+	repo.computeWorkloadInsight(insight, first, last, pkg.DeviceProtocolScsi, nil)
+
+	require.NotEqual(t, "unknown", insight.Intensity)
+	require.Greater(t, insight.TotalWriteBytes, int64(0))
+	require.Greater(t, insight.TotalReadBytes, int64(0))
+	require.NotNil(t, insight.Endurance)
+	require.True(t, insight.Endurance.Available)
+	require.Equal(t, int64(3), insight.Endurance.PercentageUsed)
+}

--- a/webapp/backend/pkg/models/collector/smart.go
+++ b/webapp/backend/pkg/models/collector/smart.go
@@ -312,12 +312,12 @@ type SmartInfo struct {
 // (e.g. the "scsi_self_test_0" key in `smartctl --json -l selftest`).
 type ScsiSelfTestEntry struct {
 	Code struct {
-		Value  int    `json:"value"`
 		String string `json:"string"`
+		Value  int    `json:"value"`
 	} `json:"code"`
 	Result struct {
-		Value  int    `json:"value"`
 		String string `json:"string"`
+		Value  int    `json:"value"`
 	} `json:"result"`
 	PowerOnTime struct {
 		Hours int `json:"hours"`
@@ -328,10 +328,10 @@ type ScsiSelfTestEntry struct {
 // ("scsi_background_scan.status" in `smartctl --json -l background`).
 type ScsiBackgroundScan struct {
 	Status struct {
-		Value                      int    `json:"value"`
 		String                     string `json:"string"`
-		NumberScansPerformed       int    `json:"number_scans_performed"`
 		ScanProgress               string `json:"scan_progress"`
+		Value                      int    `json:"value"`
+		NumberScansPerformed       int    `json:"number_scans_performed"`
 		NumberMediumScansPerformed int    `json:"number_medium_scans_performed"`
 	} `json:"status"`
 }
@@ -359,8 +359,8 @@ func (s *SmartInfo) UnmarshalJSON(data []byte) error {
 	}
 
 	type indexedEntry struct {
-		index int
 		entry ScsiSelfTestEntry
+		index int
 	}
 	var indexed []indexedEntry
 	for key, value := range raw {

--- a/webapp/backend/pkg/models/collector/smart.go
+++ b/webapp/backend/pkg/models/collector/smart.go
@@ -281,6 +281,16 @@ type SmartInfo struct {
 	ScsiErrorCounterLog ScsiErrorCounterLog `json:"scsi_error_counter_log"`
 
 	ScsiEnvironmentalReports map[string]ScsiTemperatureData `json:"scsi_environmental_reports"`
+
+	// ScsiEnduranceUsed captures the SAS SSD "Percentage used endurance indicator"
+	// from the Solid State Media log page (0x11), reported by smartctl as endurance_used.
+	// It is a pointer so we can distinguish "field absent" (non-SSD SAS/SATA-behind-SAS
+	// drives that don't support this log page) from a legitimately reported 0%.
+	ScsiEnduranceUsed *ScsiEnduranceUsed `json:"endurance_used,omitempty"`
+}
+
+type ScsiEnduranceUsed struct {
+	CurrentPercent int64 `json:"current_percent"`
 }
 
 type ScsiTemperatureData struct {

--- a/webapp/backend/pkg/models/collector/smart.go
+++ b/webapp/backend/pkg/models/collector/smart.go
@@ -1,6 +1,13 @@
 package collector
 
-import "github.com/analogj/scrutiny/webapp/backend/pkg/models/common"
+import (
+	"encoding/json"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/analogj/scrutiny/webapp/backend/pkg/models/common"
+)
 
 type AtaSmartSelfTestLogEntry struct {
 	Type struct {
@@ -288,6 +295,120 @@ type SmartInfo struct {
 	// It is a pointer so we can distinguish "field absent" (non-SSD SAS/SATA-behind-SAS
 	// drives that don't support this log page) from a legitimately reported 0%.
 	ScsiEnduranceUsed *ScsiEnduranceUsed `json:"endurance_used,omitempty"`
+
+	// ScsiSelfTests captures the SCSI/SAS self-test log. Unlike ATA, smartctl does not
+	// emit this as a JSON array; it reports each entry under its own numbered top-level
+	// key ("scsi_self_test_0", "scsi_self_test_1", ...), newest first, with no count
+	// field. See SmartInfo.UnmarshalJSON, which extracts these keys manually.
+	ScsiSelfTests []ScsiSelfTestEntry `json:"-"`
+
+	// ScsiBackgroundScan captures the SAS Background Medium Scan status ("scsi_background_scan").
+	// It describes an in-progress/periodic scan rather than a discrete self-test result, so it
+	// is not folded into ScsiSelfTests/SelfTestEntries.
+	ScsiBackgroundScan *ScsiBackgroundScan `json:"scsi_background_scan,omitempty"`
+}
+
+// ScsiSelfTestEntry represents one entry of the SCSI/SAS self-test log
+// (e.g. the "scsi_self_test_0" key in `smartctl --json -l selftest`).
+type ScsiSelfTestEntry struct {
+	Code struct {
+		Value  int    `json:"value"`
+		String string `json:"string"`
+	} `json:"code"`
+	Result struct {
+		Value  int    `json:"value"`
+		String string `json:"string"`
+	} `json:"result"`
+	PowerOnTime struct {
+		Hours int `json:"hours"`
+	} `json:"power_on_time"`
+}
+
+// ScsiBackgroundScan represents the SAS Background Medium Scan status
+// ("scsi_background_scan.status" in `smartctl --json -l background`).
+type ScsiBackgroundScan struct {
+	Status struct {
+		Value                      int    `json:"value"`
+		String                     string `json:"string"`
+		NumberScansPerformed       int    `json:"number_scans_performed"`
+		ScanProgress               string `json:"scan_progress"`
+		NumberMediumScansPerformed int    `json:"number_medium_scans_performed"`
+	} `json:"status"`
+}
+
+// scsiSelfTestKeyPrefix is the prefix smartctl uses for each numbered SCSI
+// self-test log entry key (e.g. "scsi_self_test_0", "scsi_self_test_1", ...).
+const scsiSelfTestKeyPrefix = "scsi_self_test_"
+
+// UnmarshalJSON decodes the standard SmartInfo fields, then makes a second pass
+// over the raw object to collect the SCSI self-test log entries, which smartctl
+// reports as individually numbered top-level keys rather than a JSON array.
+func (s *SmartInfo) UnmarshalJSON(data []byte) error {
+	type smartInfoAlias SmartInfo
+	var alias smartInfoAlias
+	if err := json.Unmarshal(data, &alias); err != nil {
+		return err
+	}
+	*s = SmartInfo(alias)
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		// The primary decode above already succeeded, so this should not
+		// realistically fail; if it does, just skip SCSI self-test parsing.
+		return nil
+	}
+
+	type indexedEntry struct {
+		index int
+		entry ScsiSelfTestEntry
+	}
+	var indexed []indexedEntry
+	for key, value := range raw {
+		if !strings.HasPrefix(key, scsiSelfTestKeyPrefix) {
+			continue
+		}
+		indexStr := strings.TrimPrefix(key, scsiSelfTestKeyPrefix)
+		index, err := strconv.Atoi(indexStr)
+		if err != nil {
+			continue
+		}
+		var entry ScsiSelfTestEntry
+		if err := json.Unmarshal(value, &entry); err != nil {
+			continue
+		}
+		indexed = append(indexed, indexedEntry{index: index, entry: entry})
+	}
+	sort.Slice(indexed, func(i, j int) bool { return indexed[i].index < indexed[j].index })
+	for _, item := range indexed {
+		s.ScsiSelfTests = append(s.ScsiSelfTests, item.entry)
+	}
+
+	return nil
+}
+
+// SelfTestEntries normalizes the self-test log into a single shape regardless of
+// protocol: ATA entries are returned as-is (preferring the standard log, falling
+// back to extended); SCSI entries are converted from ScsiSelfTests, using the
+// result code (0 == passed) and power-on hours as the lifetime hour equivalent.
+func (s *SmartInfo) SelfTestEntries() []AtaSmartSelfTestLogEntry {
+	if entries := s.AtaSmartSelfTestLog.Entries(); len(entries) > 0 {
+		return entries
+	}
+	if len(s.ScsiSelfTests) == 0 {
+		return nil
+	}
+	entries := make([]AtaSmartSelfTestLogEntry, 0, len(s.ScsiSelfTests))
+	for _, scsiEntry := range s.ScsiSelfTests {
+		var entry AtaSmartSelfTestLogEntry
+		entry.Type.Value = scsiEntry.Code.Value
+		entry.Type.String = scsiEntry.Code.String
+		entry.Status.Value = scsiEntry.Result.Value
+		entry.Status.String = scsiEntry.Result.String
+		entry.Status.Passed = scsiEntry.Result.Value == 0
+		entry.LifetimeHours = scsiEntry.PowerOnTime.Hours
+		entries = append(entries, entry)
+	}
+	return entries
 }
 
 type ScsiEnduranceUsed struct {

--- a/webapp/backend/pkg/models/collector/smart.go
+++ b/webapp/backend/pkg/models/collector/smart.go
@@ -65,6 +65,7 @@ type SmartInfo struct {
 		ID  uint64 `json:"id"`
 	} `json:"wwn"`
 	FirmwareVersion   string       `json:"firmware_version"`
+	ScsiRevision      string       `json:"scsi_revision"`
 	UserCapacity      UserCapacity `json:"user_capacity"`
 	LogicalBlockSize  int          `json:"logical_block_size"`
 	PhysicalBlockSize int          `json:"physical_block_size"`
@@ -311,6 +312,19 @@ func (s *SmartInfo) Capacity() int64 {
 		return s.UserCapacity.Bytes
 	}
 	return 0
+}
+
+// Firmware returns the device's firmware/revision string.
+// smartctl only populates "firmware_version" for ATA/SAT and NVMe devices.
+// For plain SCSI/SAS devices, the equivalent value is reported under
+// "scsi_revision" instead (smartctl deliberately does not alias it to
+// "firmware_version" - see smartmontools scsiprint.cpp), so fall back to it
+// here when "firmware_version" is not present.
+func (s *SmartInfo) Firmware() string {
+	if s.FirmwareVersion != "" {
+		return s.FirmwareVersion
+	}
+	return s.ScsiRevision
 }
 
 type UserCapacity struct {

--- a/webapp/backend/pkg/models/collector/smart_test.go
+++ b/webapp/backend/pkg/models/collector/smart_test.go
@@ -34,6 +34,28 @@ func TestSmartInfo_Capacity(t *testing.T) {
 	})
 }
 
+func TestSmartInfo_Firmware(t *testing.T) {
+	t.Run("should report firmware_version when present (ATA/NVMe)", func(t *testing.T) {
+		smartInfo := SmartInfo{
+			FirmwareVersion: "0004",
+			ScsiRevision:    "HPD5",
+		}
+		assert.Equal(t, "0004", smartInfo.Firmware())
+	})
+
+	t.Run("should fall back to scsi_revision when firmware_version is empty (SCSI/SAS)", func(t *testing.T) {
+		smartInfo := SmartInfo{
+			ScsiRevision: "HPD5",
+		}
+		assert.Equal(t, "HPD5", smartInfo.Firmware())
+	})
+
+	t.Run("should report empty string when neither field is present", func(t *testing.T) {
+		var smartInfo SmartInfo
+		assert.Equal(t, "", smartInfo.Firmware())
+	})
+}
+
 func TestSmartInfo_LargeLBAValues(t *testing.T) {
 	// Test for GitHub issue #24 / upstream issue #800
 	// LBA values can be large unsigned 64-bit integers that overflow signed int

--- a/webapp/backend/pkg/models/collector/smart_test.go
+++ b/webapp/backend/pkg/models/collector/smart_test.go
@@ -194,3 +194,116 @@ func TestSmartInfo_AtaSmartSelfTestLogEntries(t *testing.T) {
 		assert.Equal(t, 200, smartInfo.AtaSmartSelfTestLog.Entries()[0].LifetimeHours)
 	})
 }
+
+func TestSmartInfo_ScsiSelfTestEntries(t *testing.T) {
+	t.Run("should parse numbered scsi_self_test_N keys in ascending order", func(t *testing.T) {
+		jsonData := `{
+			"device": { "protocol": "SCSI" },
+			"scsi_self_test_0": {
+				"code": { "value": 1, "string": "Background short" },
+				"result": { "value": 0, "string": "Completed" },
+				"power_on_time": { "hours": 48239 }
+			},
+			"scsi_self_test_1": {
+				"code": { "value": 2, "string": "Background long" },
+				"result": { "value": 0, "string": "Completed" },
+				"power_on_time": { "hours": 48234 }
+			},
+			"scsi_self_test_10": {
+				"code": { "value": 1, "string": "Background short" },
+				"result": { "value": 3, "string": "Aborted by host" },
+				"power_on_time": { "hours": 100 }
+			}
+		}`
+
+		var smartInfo SmartInfo
+		err := json.Unmarshal([]byte(jsonData), &smartInfo)
+		require.NoError(t, err)
+		require.Len(t, smartInfo.ScsiSelfTests, 3)
+		// numeric sort, not lexicographic ("scsi_self_test_10" must sort after "_1", not before it)
+		assert.Equal(t, 1, smartInfo.ScsiSelfTests[0].Code.Value)
+		assert.Equal(t, 48239, smartInfo.ScsiSelfTests[0].PowerOnTime.Hours)
+		assert.Equal(t, 2, smartInfo.ScsiSelfTests[1].Code.Value)
+		assert.Equal(t, 48234, smartInfo.ScsiSelfTests[1].PowerOnTime.Hours)
+		assert.Equal(t, 100, smartInfo.ScsiSelfTests[2].PowerOnTime.Hours)
+	})
+
+	t.Run("should not confuse scsi_background_scan or other keys with self-test entries", func(t *testing.T) {
+		jsonData := `{
+			"device": { "protocol": "SCSI" },
+			"scsi_background_scan": {
+				"status": { "value": 1, "string": "scan is active" }
+			}
+		}`
+
+		var smartInfo SmartInfo
+		err := json.Unmarshal([]byte(jsonData), &smartInfo)
+		require.NoError(t, err)
+		require.Empty(t, smartInfo.ScsiSelfTests)
+		require.NotNil(t, smartInfo.ScsiBackgroundScan)
+		assert.Equal(t, "scan is active", smartInfo.ScsiBackgroundScan.Status.String)
+	})
+}
+
+func TestSmartInfo_SelfTestEntries(t *testing.T) {
+	t.Run("should return ATA entries as-is when present", func(t *testing.T) {
+		jsonData := `{
+			"device": { "protocol": "ATA" },
+			"ata_smart_self_test_log": {
+				"standard": {
+					"revision": 1,
+					"table": [
+						{
+							"type": { "value": 1, "string": "Short offline" },
+							"status": { "value": 0, "string": "Completed without error", "passed": true },
+							"lifetime_hours": 100
+						}
+					]
+				}
+			}
+		}`
+		var smartInfo SmartInfo
+		require.NoError(t, json.Unmarshal([]byte(jsonData), &smartInfo))
+
+		entries := smartInfo.SelfTestEntries()
+		require.Len(t, entries, 1)
+		assert.Equal(t, 100, entries[0].LifetimeHours)
+		assert.True(t, entries[0].Status.Passed)
+	})
+
+	t.Run("should normalize scsi self-test entries", func(t *testing.T) {
+		jsonData := `{
+			"device": { "protocol": "SCSI" },
+			"scsi_self_test_0": {
+				"code": { "value": 1, "string": "Background short" },
+				"result": { "value": 0, "string": "Completed" },
+				"power_on_time": { "hours": 48239 }
+			},
+			"scsi_self_test_1": {
+				"code": { "value": 1, "string": "Background short" },
+				"result": { "value": 3, "string": "Aborted by host" },
+				"power_on_time": { "hours": 100 }
+			}
+		}`
+		var smartInfo SmartInfo
+		require.NoError(t, json.Unmarshal([]byte(jsonData), &smartInfo))
+
+		entries := smartInfo.SelfTestEntries()
+		require.Len(t, entries, 2)
+
+		assert.Equal(t, 1, entries[0].Type.Value)
+		assert.Equal(t, "Background short", entries[0].Type.String)
+		assert.Equal(t, 0, entries[0].Status.Value)
+		assert.True(t, entries[0].Status.Passed)
+		assert.Equal(t, 48239, entries[0].LifetimeHours)
+
+		assert.Equal(t, 3, entries[1].Status.Value)
+		assert.False(t, entries[1].Status.Passed)
+		assert.Equal(t, 100, entries[1].LifetimeHours)
+	})
+
+	t.Run("should return nil when no self-test data is present", func(t *testing.T) {
+		var smartInfo SmartInfo
+		assert.Nil(t, smartInfo.SelfTestEntries())
+	})
+}

--- a/webapp/backend/pkg/models/device.go
+++ b/webapp/backend/pkg/models/device.go
@@ -166,7 +166,14 @@ func (dv *Device) IsNvme() bool {
 func (dv *Device) UpdateFromCollectorSmartInfo(info collector.SmartInfo) error {
 	dv.ModelFamily = info.ModelFamily
 	dv.ModelName = info.ModelName
-	dv.Firmware = info.FirmwareVersion
+	// Only overwrite a previously known firmware/revision when this run actually
+	// reported one; smartctl omits both firmware_version and scsi_revision when
+	// the drive doesn't answer that inquiry (e.g. transient errors, permissions,
+	// or invocation args that didn't include -i/-x), and we don't want to blank
+	// out a value we already have on file.
+	if firmware := info.Firmware(); firmware != "" {
+		dv.Firmware = firmware
+	}
 	dv.DeviceProtocol = info.Device.Protocol
 	dv.SmartSupport = info.SmartSupport
 

--- a/webapp/backend/pkg/models/device_test.go
+++ b/webapp/backend/pkg/models/device_test.go
@@ -36,6 +36,52 @@ func TestUpdateFromCollectorSmartInfo_ShouldPopulateModelName(t *testing.T) {
 	require.True(t, *device.SmartSupport.Enabled)
 }
 
+func TestUpdateFromCollectorSmartInfo_ShouldPopulateFirmwareFromScsiRevisionForSas(t *testing.T) {
+	// setup
+	device := Device{
+		WWN:        "0x50000f0b005750f0",
+		DeviceName: "sdp",
+	}
+	smartInfo := collector.SmartInfo{
+		ModelName:    "HPE VO003840JWZJK",
+		ScsiRevision: "HPD5",
+	}
+	smartInfo.Device.Protocol = "SCSI"
+	smartInfo.SmartStatus.Passed = true
+
+	// test
+	err := device.UpdateFromCollectorSmartInfo(smartInfo)
+
+	// assert
+	require.NoError(t, err)
+	require.Equal(t, "HPE VO003840JWZJK", device.ModelName)
+	require.Equal(t, "HPD5", device.Firmware)
+	require.Equal(t, "SCSI", device.DeviceProtocol)
+}
+
+func TestUpdateFromCollectorSmartInfo_ShouldNotClearFirmwareWhenMissingFromPayload(t *testing.T) {
+	// setup: device already has a firmware value on file from a previous run
+	device := Device{
+		WWN:        "0x50000f0b005750f0",
+		DeviceName: "sdp",
+		Firmware:   "HPD5",
+	}
+	// this run's smartctl payload reports neither firmware_version nor scsi_revision
+	// (e.g. transient error, permissions issue, or args without -i/-x)
+	smartInfo := collector.SmartInfo{
+		ModelName: "HPE VO003840JWZJK",
+	}
+	smartInfo.Device.Protocol = "SCSI"
+	smartInfo.SmartStatus.Passed = true
+
+	// test
+	err := device.UpdateFromCollectorSmartInfo(smartInfo)
+
+	// assert: previously known firmware is preserved, not blanked out
+	require.NoError(t, err)
+	require.Equal(t, "HPD5", device.Firmware)
+}
+
 func TestUpdateFromCollectorSmartInfo_ShouldPopulateModelNameForAta(t *testing.T) {
 	// setup
 	device := Device{

--- a/webapp/backend/pkg/models/measurements/smart.go
+++ b/webapp/backend/pkg/models/measurements/smart.go
@@ -1036,7 +1036,7 @@ func (sm *Smart) processScsiSmartInfoWithOverrides(cfg config.Interface, defectG
 	// protocol-specific branching. Only populated when the drive reports it (SAS SSDs only);
 	// enduranceUsed is nil for SAS/SATA HDDs and SSDs that don't support this log page.
 	if enduranceUsed != nil {
-		sm.Attributes["percentage_used"] = (&SmartScsiAttribute{AttributeId: "percentage_used", Value: enduranceUsed.CurrentPercent, Threshold: -1}).PopulateAttributeStatus()
+		sm.Attributes["percentage_used"] = (&SmartScsiAttribute{AttributeId: "percentage_used", Value: enduranceUsed.CurrentPercent, Threshold: 100}).PopulateAttributeStatus()
 	}
 
 	// Apply overrides and find analyzed attribute status

--- a/webapp/backend/pkg/models/measurements/smart.go
+++ b/webapp/backend/pkg/models/measurements/smart.go
@@ -317,7 +317,7 @@ func (sm *Smart) FromCollectorSmartInfoWithOverrides(cfg config.Interface, wwn s
 	} else if sm.DeviceProtocol == pkg.DeviceProtocolNvme {
 		sm.processNvmeSmartInfoWithOverrides(cfg, info.NvmeSmartHealthInformationLog, mergedOverrides)
 	} else if sm.DeviceProtocol == pkg.DeviceProtocolScsi {
-		sm.processScsiSmartInfoWithOverrides(cfg, info.ScsiGrownDefectList, info.ScsiErrorCounterLog, info.ScsiEnvironmentalReports, mergedOverrides)
+		sm.processScsiSmartInfoWithOverrides(cfg, info.ScsiGrownDefectList, info.ScsiErrorCounterLog, info.ScsiEnvironmentalReports, info.ScsiEnduranceUsed, mergedOverrides)
 	}
 
 	return nil
@@ -506,6 +506,35 @@ func applyNvmeOverrides(cfg config.Interface, deviceWWN string, attrId string, n
 	return false
 }
 
+// parseGigabytesProcessed converts a smartctl SCSI error-counter-log "gigabytes_processed"
+// string (a decimal number of GB, e.g. "243.990") into a byte count. Returns false if the
+// string is empty or cannot be parsed (some drives/vendors omit this field).
+func parseGigabytesProcessed(gigabytesProcessed string) (int64, bool) {
+	trimmed := strings.TrimSpace(gigabytesProcessed)
+	if trimmed == "" {
+		return 0, false
+	}
+	gb, err := strconv.ParseFloat(trimmed, 64)
+	if err != nil {
+		return 0, false
+	}
+	return int64(gb * 1e9), true
+}
+
+// buildScsiGigabytesProcessedAttributes builds the read/write cumulative byte-processed
+// attributes (the SAS analog to ATA LBAs written/read and NVMe data units) from the SCSI
+// error counter log's "gigabytes_processed" fields, when present and parseable.
+func buildScsiGigabytesProcessedAttributes(scsiErrorCounterLog collector.ScsiErrorCounterLog) map[string]SmartAttribute {
+	attrs := map[string]SmartAttribute{}
+	if readBytes, ok := parseGigabytesProcessed(scsiErrorCounterLog.Read.GigabytesProcessed); ok {
+		attrs["read_gigabytes_processed"] = (&SmartScsiAttribute{AttributeId: "read_gigabytes_processed", Value: readBytes, Threshold: -1}).PopulateAttributeStatus()
+	}
+	if writeBytes, ok := parseGigabytesProcessed(scsiErrorCounterLog.Write.GigabytesProcessed); ok {
+		attrs["write_gigabytes_processed"] = (&SmartScsiAttribute{AttributeId: "write_gigabytes_processed", Value: writeBytes, Threshold: -1}).PopulateAttributeStatus()
+	}
+	return attrs
+}
+
 // generate SmartScsiAttribute entries from Scrutiny Collector Smart data.
 func (sm *Smart) ProcessScsiSmartInfo(cfg config.Interface, defectGrownList int64, scsiErrorCounterLog collector.ScsiErrorCounterLog, temperature map[string]collector.ScsiTemperatureData) {
 	sm.Attributes = map[string]SmartAttribute{
@@ -524,6 +553,9 @@ func (sm *Smart) ProcessScsiSmartInfo(cfg config.Interface, defectGrownList int6
 		"write_total_errors_corrected":               (&SmartScsiAttribute{AttributeId: "write_total_errors_corrected", Value: scsiErrorCounterLog.Write.TotalErrorsCorrected, Threshold: -1}).PopulateAttributeStatus(),
 		"write_correction_algorithm_invocations":     (&SmartScsiAttribute{AttributeId: "write_correction_algorithm_invocations", Value: scsiErrorCounterLog.Write.CorrectionAlgorithmInvocations, Threshold: -1}).PopulateAttributeStatus(),
 		"write_total_uncorrected_errors":             (&SmartScsiAttribute{AttributeId: "write_total_uncorrected_errors", Value: scsiErrorCounterLog.Write.TotalUncorrectedErrors, Threshold: 0}).PopulateAttributeStatus(),
+	}
+	for attrId, attr := range buildScsiGigabytesProcessedAttributes(scsiErrorCounterLog) {
+		sm.Attributes[attrId] = attr
 	}
 
 	// Apply overrides and find analyzed attribute status
@@ -978,7 +1010,7 @@ func (sm *Smart) rolloverReasonFromCrossCheck(currentPoH int64) string {
 }
 
 // processScsiSmartInfoWithOverrides generates SmartScsiAttribute entries using pre-merged overrides.
-func (sm *Smart) processScsiSmartInfoWithOverrides(cfg config.Interface, defectGrownList int64, scsiErrorCounterLog collector.ScsiErrorCounterLog, temperature map[string]collector.ScsiTemperatureData, mergedOverrides []overrides.AttributeOverride) {
+func (sm *Smart) processScsiSmartInfoWithOverrides(cfg config.Interface, defectGrownList int64, scsiErrorCounterLog collector.ScsiErrorCounterLog, temperature map[string]collector.ScsiTemperatureData, enduranceUsed *collector.ScsiEnduranceUsed, mergedOverrides []overrides.AttributeOverride) {
 	sm.Attributes = map[string]SmartAttribute{
 		"temperature": (&SmartScsiAttribute{AttributeId: "temperature", Value: sm.Temp, Threshold: -1}).PopulateAttributeStatus(),
 
@@ -995,6 +1027,16 @@ func (sm *Smart) processScsiSmartInfoWithOverrides(cfg config.Interface, defectG
 		"write_total_errors_corrected":               (&SmartScsiAttribute{AttributeId: "write_total_errors_corrected", Value: scsiErrorCounterLog.Write.TotalErrorsCorrected, Threshold: -1}).PopulateAttributeStatus(),
 		"write_correction_algorithm_invocations":     (&SmartScsiAttribute{AttributeId: "write_correction_algorithm_invocations", Value: scsiErrorCounterLog.Write.CorrectionAlgorithmInvocations, Threshold: -1}).PopulateAttributeStatus(),
 		"write_total_uncorrected_errors":             (&SmartScsiAttribute{AttributeId: "write_total_uncorrected_errors", Value: scsiErrorCounterLog.Write.TotalUncorrectedErrors, Threshold: 0}).PopulateAttributeStatus(),
+	}
+	for attrId, attr := range buildScsiGigabytesProcessedAttributes(scsiErrorCounterLog) {
+		sm.Attributes[attrId] = attr
+	}
+	// SAS SSD endurance indicator (Solid State Media log page 0x11). Reuses the "percentage_used"
+	// attribute ID shared with NVMe so downstream endurance/workload consumers require no
+	// protocol-specific branching. Only populated when the drive reports it (SAS SSDs only);
+	// enduranceUsed is nil for SAS/SATA HDDs and SSDs that don't support this log page.
+	if enduranceUsed != nil {
+		sm.Attributes["percentage_used"] = (&SmartScsiAttribute{AttributeId: "percentage_used", Value: enduranceUsed.CurrentPercent, Threshold: -1}).PopulateAttributeStatus()
 	}
 
 	// Apply overrides and find analyzed attribute status

--- a/webapp/backend/pkg/models/measurements/smart.go
+++ b/webapp/backend/pkg/models/measurements/smart.go
@@ -317,7 +317,7 @@ func (sm *Smart) FromCollectorSmartInfoWithOverrides(cfg config.Interface, wwn s
 	} else if sm.DeviceProtocol == pkg.DeviceProtocolNvme {
 		sm.processNvmeSmartInfoWithOverrides(cfg, info.NvmeSmartHealthInformationLog, mergedOverrides)
 	} else if sm.DeviceProtocol == pkg.DeviceProtocolScsi {
-		sm.processScsiSmartInfoWithOverrides(cfg, info.ScsiGrownDefectList, info.ScsiErrorCounterLog, info.ScsiEnvironmentalReports, info.ScsiEnduranceUsed, mergedOverrides)
+		sm.processScsiSmartInfoWithOverrides(cfg, info.ScsiGrownDefectList, &info.ScsiErrorCounterLog, info.ScsiEnvironmentalReports, info.ScsiEnduranceUsed, mergedOverrides)
 	}
 
 	return nil
@@ -524,7 +524,7 @@ func parseGigabytesProcessed(gigabytesProcessed string) (int64, bool) {
 // buildScsiGigabytesProcessedAttributes builds the read/write cumulative byte-processed
 // attributes (the SAS analog to ATA LBAs written/read and NVMe data units) from the SCSI
 // error counter log's "gigabytes_processed" fields, when present and parseable.
-func buildScsiGigabytesProcessedAttributes(scsiErrorCounterLog collector.ScsiErrorCounterLog) map[string]SmartAttribute {
+func buildScsiGigabytesProcessedAttributes(scsiErrorCounterLog *collector.ScsiErrorCounterLog) map[string]SmartAttribute {
 	attrs := map[string]SmartAttribute{}
 	if readBytes, ok := parseGigabytesProcessed(scsiErrorCounterLog.Read.GigabytesProcessed); ok {
 		attrs["read_gigabytes_processed"] = (&SmartScsiAttribute{AttributeId: "read_gigabytes_processed", Value: readBytes, Threshold: -1}).PopulateAttributeStatus()
@@ -554,7 +554,7 @@ func (sm *Smart) ProcessScsiSmartInfo(cfg config.Interface, defectGrownList int6
 		"write_correction_algorithm_invocations":     (&SmartScsiAttribute{AttributeId: "write_correction_algorithm_invocations", Value: scsiErrorCounterLog.Write.CorrectionAlgorithmInvocations, Threshold: -1}).PopulateAttributeStatus(),
 		"write_total_uncorrected_errors":             (&SmartScsiAttribute{AttributeId: "write_total_uncorrected_errors", Value: scsiErrorCounterLog.Write.TotalUncorrectedErrors, Threshold: 0}).PopulateAttributeStatus(),
 	}
-	for attrId, attr := range buildScsiGigabytesProcessedAttributes(scsiErrorCounterLog) {
+	for attrId, attr := range buildScsiGigabytesProcessedAttributes(&scsiErrorCounterLog) {
 		sm.Attributes[attrId] = attr
 	}
 
@@ -1010,7 +1010,7 @@ func (sm *Smart) rolloverReasonFromCrossCheck(currentPoH int64) string {
 }
 
 // processScsiSmartInfoWithOverrides generates SmartScsiAttribute entries using pre-merged overrides.
-func (sm *Smart) processScsiSmartInfoWithOverrides(cfg config.Interface, defectGrownList int64, scsiErrorCounterLog collector.ScsiErrorCounterLog, temperature map[string]collector.ScsiTemperatureData, enduranceUsed *collector.ScsiEnduranceUsed, mergedOverrides []overrides.AttributeOverride) {
+func (sm *Smart) processScsiSmartInfoWithOverrides(cfg config.Interface, defectGrownList int64, scsiErrorCounterLog *collector.ScsiErrorCounterLog, temperature map[string]collector.ScsiTemperatureData, enduranceUsed *collector.ScsiEnduranceUsed, mergedOverrides []overrides.AttributeOverride) {
 	sm.Attributes = map[string]SmartAttribute{
 		"temperature": (&SmartScsiAttribute{AttributeId: "temperature", Value: sm.Temp, Threshold: -1}).PopulateAttributeStatus(),
 

--- a/webapp/backend/pkg/models/measurements/smart_test.go
+++ b/webapp/backend/pkg/models/measurements/smart_test.go
@@ -783,6 +783,50 @@ func TestFromCollectorSmartInfo_Scsi_SAS_SSD_Endurance(t *testing.T) {
 	require.Equal(t, int64(243990000000), smartMdl.Attributes["write_gigabytes_processed"].(*measurements.SmartScsiAttribute).Value)
 }
 
+// TestFromCollectorSmartInfo_Scsi_SAS_SSD_Endurance_ExceedsThreshold tests that a SAS SSD
+// reporting a "percentage_used" endurance value above 100 is flagged as failed, matching
+// NVMe's percentage_used threshold behavior. Previously the SCSI attribute was created with
+// Threshold: -1 (disabled), so a device already past its rated endurance limit stayed
+// "Passed" despite the critical metadata for this attribute.
+func TestFromCollectorSmartInfo_Scsi_SAS_SSD_Endurance_ExceedsThreshold(t *testing.T) {
+	//setup
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	fakeConfig := mock_config.NewMockInterface(mockCtrl)
+	expectConsumerDriveProfilesEnabledDefault(fakeConfig)
+	fakeConfig.EXPECT().GetIntSlice("failures.transient.ata").Return([]int{195}).AnyTimes()
+	fakeConfig.EXPECT().Get("smart.attribute_overrides").Return(nil).AnyTimes()
+
+	smartDataFile, err := os.Open("../testdata/smart-scsi-sas-ssd.json")
+	require.NoError(t, err)
+	defer smartDataFile.Close()
+
+	var smartJson collector.SmartInfo
+
+	smartDataBytes, err := ioutil.ReadAll(smartDataFile)
+	require.NoError(t, err)
+	err = json.Unmarshal(smartDataBytes, &smartJson)
+	require.NoError(t, err)
+
+	// Push the reported endurance usage past the manufacturer's rated limit.
+	smartJson.ScsiEnduranceUsed.CurrentPercent = 105
+
+	//test
+	smartMdl := measurements.Smart{}
+	err = smartMdl.FromCollectorSmartInfo(fakeConfig, "WWN-test", smartJson)
+
+	//assert
+	require.NoError(t, err)
+	require.Equal(t, pkg.DeviceStatusFailedScrutiny, smartMdl.Status)
+
+	require.Contains(t, smartMdl.Attributes, "percentage_used")
+	percentageUsedAttr, ok := smartMdl.Attributes["percentage_used"].(*measurements.SmartScsiAttribute)
+	require.True(t, ok, "SCSI percentage_used attribute should be *SmartScsiAttribute, got %T", smartMdl.Attributes["percentage_used"])
+	require.Equal(t, int64(105), percentageUsedAttr.Value)
+	require.True(t, pkg.AttributeStatusHas(percentageUsedAttr.Status, pkg.AttributeStatusFailedScrutiny),
+		"percentage_used should fail once current_percent (%d) exceeds threshold (%d)", percentageUsedAttr.Value, percentageUsedAttr.Threshold)
+}
+
 // TestFromCollectorSmartInfo_Scsi_SAS_EnvironmentalReports tests that for SAS drives
 // where the standard temperature field is 0, the temperature is correctly parsed
 // from scsi_environmental_reports.temperature_1.current (fixes GitHub issue #26)

--- a/webapp/backend/pkg/models/measurements/smart_test.go
+++ b/webapp/backend/pkg/models/measurements/smart_test.go
@@ -151,10 +151,10 @@ func TestSmart_Flatten_SCSI(t *testing.T) {
 		"attr.read_errors_corrected_by_eccfast.thresh":            int64(0),
 		"attr.read_errors_corrected_by_eccfast.transformed_value": int64(0),
 		"attr.read_errors_corrected_by_eccfast.value":             int64(300357663),
-		"logical_block_size": int64(512),
-		"power_cycle_count":  int64(10),
-		"power_on_hours":     int64(10),
-		"temp":               int64(50)},
+		"logical_block_size":                                      int64(512),
+		"power_cycle_count":                                       int64(10),
+		"power_on_hours":                                          int64(10),
+		"temp":                                                    int64(50)},
 		fields)
 }
 
@@ -669,10 +669,22 @@ func TestFromCollectorSmartInfo_Scsi(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "WWN-test", smartMdl.DeviceWWN)
 	require.Equal(t, pkg.DeviceStatusPassed, smartMdl.Status)
-	require.Equal(t, 14, len(smartMdl.Attributes))
+	require.Equal(t, 16, len(smartMdl.Attributes))
 
 	require.Equal(t, int64(0), smartMdl.Attributes["scsi_grown_defect_list"].(*measurements.SmartScsiAttribute).Value)
 	require.Equal(t, int64(300357663), smartMdl.Attributes["read_errors_corrected_by_eccfast"].(*measurements.SmartScsiAttribute).Value) //total_errors_corrected
+
+	// read/write_gigabytes_processed should be parsed from the SCSI error counter log's
+	// decimal-GB "gigabytes_processed" string into bytes (GB * 1e9).
+	require.Contains(t, smartMdl.Attributes, "read_gigabytes_processed")
+	require.Contains(t, smartMdl.Attributes, "write_gigabytes_processed")
+	// smart-scsi.json / smart-scsi-failed.json both use read=176987.332 write=86472.611
+	require.Equal(t, int64(176987332000000), smartMdl.Attributes["read_gigabytes_processed"].(*measurements.SmartScsiAttribute).Value)
+	require.Equal(t, int64(86472611000000), smartMdl.Attributes["write_gigabytes_processed"].(*measurements.SmartScsiAttribute).Value)
+
+	// This fixture has no endurance_used field (HDD, not SSD), so percentage_used should
+	// not be created.
+	require.NotContains(t, smartMdl.Attributes, "percentage_used")
 }
 
 func TestFromCollectorSmartInfo_Scsi_Fail_Scrutiny(t *testing.T) {
@@ -720,7 +732,55 @@ func TestFromCollectorSmartInfo_Scsi_Fail_Scrutiny(t *testing.T) {
 		smartMdl.Attributes["read_total_uncorrected_errors"].(*measurements.SmartScsiAttribute).StatusReason,
 	)
 
-	require.Equal(t, 14, len(smartMdl.Attributes))
+	require.Equal(t, 16, len(smartMdl.Attributes))
+}
+
+// TestFromCollectorSmartInfo_Scsi_SAS_SSD_Endurance tests that SAS SSDs (which report the
+// Solid State Media log page as "endurance_used") get a "percentage_used" attribute, and that
+// the read/write "gigabytes_processed" counters are converted to bytes. Fixes the SAS SSD
+// workload/endurance "unknown" reporting gap.
+func TestFromCollectorSmartInfo_Scsi_SAS_SSD_Endurance(t *testing.T) {
+	//setup
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	fakeConfig := mock_config.NewMockInterface(mockCtrl)
+	expectConsumerDriveProfilesEnabledDefault(fakeConfig)
+	fakeConfig.EXPECT().GetIntSlice("failures.transient.ata").Return([]int{195}).AnyTimes()
+	fakeConfig.EXPECT().Get("smart.attribute_overrides").Return(nil).AnyTimes()
+
+	smartDataFile, err := os.Open("../testdata/smart-scsi-sas-ssd.json")
+	require.NoError(t, err)
+	defer smartDataFile.Close()
+
+	var smartJson collector.SmartInfo
+
+	smartDataBytes, err := ioutil.ReadAll(smartDataFile)
+	require.NoError(t, err)
+	err = json.Unmarshal(smartDataBytes, &smartJson)
+	require.NoError(t, err)
+
+	//test
+	smartMdl := measurements.Smart{}
+	err = smartMdl.FromCollectorSmartInfo(fakeConfig, "WWN-test", smartJson)
+
+	//assert
+	require.NoError(t, err)
+	require.Equal(t, "WWN-test", smartMdl.DeviceWWN)
+	require.Equal(t, pkg.DeviceStatusPassed, smartMdl.Status)
+
+	// percentage_used should be populated from endurance_used.current_percent
+	require.Contains(t, smartMdl.Attributes, "percentage_used")
+	percentageUsedAttr, ok := smartMdl.Attributes["percentage_used"].(*measurements.SmartScsiAttribute)
+	require.True(t, ok, "SCSI percentage_used attribute should be *SmartScsiAttribute, got %T", smartMdl.Attributes["percentage_used"])
+	require.Equal(t, int64(3), percentageUsedAttr.Value)
+
+	// read_gigabytes_processed: 7.668 GB -> 7668000000 bytes
+	require.Contains(t, smartMdl.Attributes, "read_gigabytes_processed")
+	require.Equal(t, int64(7668000000), smartMdl.Attributes["read_gigabytes_processed"].(*measurements.SmartScsiAttribute).Value)
+
+	// write_gigabytes_processed: 243.990 GB -> 243990000000 bytes
+	require.Contains(t, smartMdl.Attributes, "write_gigabytes_processed")
+	require.Equal(t, int64(243990000000), smartMdl.Attributes["write_gigabytes_processed"].(*measurements.SmartScsiAttribute).Value)
 }
 
 // TestFromCollectorSmartInfo_Scsi_SAS_EnvironmentalReports tests that for SAS drives

--- a/webapp/backend/pkg/models/testdata/smart-scsi-sas-ssd.json
+++ b/webapp/backend/pkg/models/testdata/smart-scsi-sas-ssd.json
@@ -1,0 +1,71 @@
+{
+  "device": {
+    "name": "/dev/sdp",
+    "info_name": "/dev/sdp",
+    "type": "scsi",
+    "protocol": "SCSI"
+  },
+  "scsi_vendor": "HPE",
+  "scsi_product": "VO003840JWZJK",
+  "model_name": "HPE VO003840JWZJK",
+  "scsi_revision": "HPD5",
+  "scsi_version": "SPC-5",
+  "user_capacity": {
+    "blocks": 7501476528,
+    "bytes": 3840755982336
+  },
+  "logical_block_size": 512,
+  "rotation_rate": 0,
+  "form_factor": {
+    "scsi_value": 3,
+    "name": "2.5 inches"
+  },
+  "serial_number": "ABCDEFGHIJKLMNOP",
+  "device_type": {
+    "scsi_value": 0,
+    "name": "disk"
+  },
+  "smart_status": {
+    "passed": true
+  },
+  "temperature": {
+    "current": 22
+  },
+  "endurance_used": {
+    "current_percent": 3
+  },
+  "scsi_environmental_reports": {
+    "temperature_1": {
+      "parameter_code": 0,
+      "current": 22,
+      "lifetime_maximum": 28,
+      "lifetime_minimum": 9,
+      "maximum_since_power_on": 24,
+      "minimum_since_power_on": 21
+    }
+  },
+  "power_on_time": {
+    "hours": 45364,
+    "minutes": 44
+  },
+  "scsi_error_counter_log": {
+    "read": {
+      "errors_corrected_by_eccfast": 0,
+      "errors_corrected_by_eccdelayed": 0,
+      "errors_corrected_by_rereads_rewrites": 0,
+      "total_errors_corrected": 0,
+      "correction_algorithm_invocations": 0,
+      "gigabytes_processed": "7.668",
+      "total_uncorrected_errors": 0
+    },
+    "write": {
+      "errors_corrected_by_eccfast": 0,
+      "errors_corrected_by_eccdelayed": 0,
+      "errors_corrected_by_rereads_rewrites": 0,
+      "total_errors_corrected": 0,
+      "correction_algorithm_invocations": 0,
+      "gigabytes_processed": "243.990",
+      "total_uncorrected_errors": 0
+    }
+  }
+}

--- a/webapp/backend/pkg/models/testdata/smart-scsi-selftest.json
+++ b/webapp/backend/pkg/models/testdata/smart-scsi-selftest.json
@@ -1,0 +1,69 @@
+{
+  "device": {
+    "name": "/dev/sdl",
+    "info_name": "/dev/sdl",
+    "type": "scsi",
+    "protocol": "SCSI"
+  },
+  "scsi_vendor": "HPE",
+  "scsi_product": "VO003840JWZJK",
+  "model_name": "HPE VO003840JWZJK",
+  "serial_number": "ABCDEFGHIJKLMNOP",
+  "smart_status": {
+    "passed": true
+  },
+  "power_on_time": {
+    "hours": 48257
+  },
+  "scsi_self_test_0": {
+    "code": {
+      "value": 1,
+      "string": "Background short"
+    },
+    "result": {
+      "value": 0,
+      "string": "Completed"
+    },
+    "power_on_time": {
+      "hours": 48239,
+      "aka": "accumulated_power_on_hours"
+    }
+  },
+  "scsi_self_test_1": {
+    "code": {
+      "value": 2,
+      "string": "Background long"
+    },
+    "result": {
+      "value": 0,
+      "string": "Completed"
+    },
+    "power_on_time": {
+      "hours": 48234,
+      "aka": "accumulated_power_on_hours"
+    }
+  },
+  "scsi_self_test_2": {
+    "code": {
+      "value": 1,
+      "string": "Background short"
+    },
+    "result": {
+      "value": 0,
+      "string": "Completed"
+    },
+    "power_on_time": {
+      "hours": 48234,
+      "aka": "accumulated_power_on_hours"
+    }
+  },
+  "scsi_background_scan": {
+    "status": {
+      "value": 1,
+      "string": "scan is active",
+      "number_scans_performed": 71,
+      "scan_progress": "3.05%",
+      "number_medium_scans_performed": 71
+    }
+  }
+}

--- a/webapp/backend/pkg/thresholds/scsi_attribute_metadata.go
+++ b/webapp/backend/pkg/thresholds/scsi_attribute_metadata.go
@@ -125,4 +125,28 @@ var ScsiMetadata = map[string]ScsiAttributeMetadata{
 		Critical:    false,
 		Description: "Current drive temperature in Celsius.",
 	},
+	"read_gigabytes_processed": {
+		ID:          "read_gigabytes_processed",
+		DisplayName: "Data Read",
+		DisplayType: "",
+		Ideal:       "",
+		Critical:    false,
+		Description: "Cumulative amount of data processed by read commands, taken from the SCSI Read Error Counter log page's \"gigabytes processed\" field. This is the SAS/SCSI equivalent of ATA LBAs Read or NVMe Data Units Read, and is the basis for workload read-rate estimates on SAS drives. Note this counts all data processed (including retries), not just unique host data, and is reported at ~1 GB granularity.",
+	},
+	"write_gigabytes_processed": {
+		ID:          "write_gigabytes_processed",
+		DisplayName: "Data Written",
+		DisplayType: "",
+		Ideal:       "",
+		Critical:    false,
+		Description: "Cumulative amount of data processed by write commands, taken from the SCSI Write Error Counter log page's \"gigabytes processed\" field. This is the SAS/SCSI equivalent of ATA LBAs Written or NVMe Data Units Written, and is the basis for workload write-rate and endurance (TBW) estimates on SAS drives. Note this counts all data processed (including retries), not just unique host data, and is reported at ~1 GB granularity.",
+	},
+	"percentage_used": {
+		ID:          "percentage_used",
+		DisplayName: "Percentage Used",
+		DisplayType: "",
+		Ideal:       "low",
+		Critical:    true,
+		Description: "SAS SSD wear indicator from the Solid State Media log page's \"Percentage used endurance indicator\". Reaches 100% at the manufacturer's rated endurance limit, but the drive may continue to operate beyond that point. Only reported by solid-state SAS drives.",
+	},
 }

--- a/webapp/frontend/src/app/modules/detail/detail.component.html
+++ b/webapp/frontend/src/app/modules/detail/detail.component.html
@@ -325,13 +325,13 @@
         }
 
         <!-- SMART Self-Tests -->
-        @if (isAta()) {
+        @if (hasSelfTestSupport()) {
         <div class="flex flex-auto w-full p-4">
             <treo-card class="flex flex-auto p-4 flex-col">
                 <div class="flex items-center justify-between mb-4">
                     <div>
                         <div class="font-bold text-md text-secondary uppercase tracking-wider">SMART Self-Tests</div>
-                        <div class="text-sm text-secondary">ATA self-test history from recorded smartctl uploads</div>
+                        <div class="text-sm text-secondary">Self-test history from recorded smartctl uploads</div>
                     </div>
                     @if (!selfTestsLoading && selfTests.length > 0) {
                     <div class="text-sm text-secondary">{{ selfTests.length }} entries</div>

--- a/webapp/frontend/src/app/modules/detail/detail.component.spec.ts
+++ b/webapp/frontend/src/app/modules/detail/detail.component.spec.ts
@@ -128,6 +128,36 @@ describe('DetailComponent', () => {
         expect(mockDetailService.getSelfTestData).toHaveBeenCalledWith('device-1');
     });
 
+    it('should load self-tests when SCSI device details arrive', () => {
+        component.ngOnInit();
+
+        dataSubject.next({
+            data: {
+                device: { device_id: 'device-2', device_protocol: 'SCSI', smart_display_mode: 'scrutiny' },
+                smart_results: [],
+            },
+            metadata: {},
+        });
+
+        expect(mockDetailService.getSelfTestData).toHaveBeenCalledWith('device-2');
+    });
+
+    it('should not load self-tests for NVMe devices', () => {
+        component.ngOnInit();
+
+        dataSubject.next({
+            data: {
+                device: { device_id: 'device-3', device_protocol: 'NVMe', smart_display_mode: 'scrutiny' },
+                smart_results: [],
+            },
+            metadata: {},
+        });
+
+        expect(mockDetailService.getSelfTestData).not.toHaveBeenCalled();
+        expect(component.selfTests).toEqual([]);
+        expect(component.selfTestsLoaded).toBeTrue();
+    });
+
     describe('self-test power-on age', () => {
         const row: DeviceSelfTestModel = {
             id: 1,

--- a/webapp/frontend/src/app/modules/detail/detail.component.ts
+++ b/webapp/frontend/src/app/modules/detail/detail.component.ts
@@ -250,7 +250,7 @@ export class DetailComponent implements OnInit, AfterViewInit, OnDestroy {
             // Load replacement risk (lazy, non-blocking)
             this._loadReplacementRisk(this.device.device_id);
 
-            if (this.isAta()) {
+            if (this.hasSelfTestSupport()) {
                 this._loadSelfTests(this.device.device_id);
             } else {
                 this.selfTests = [];
@@ -511,6 +511,15 @@ export class DetailComponent implements OnInit, AfterViewInit, OnDestroy {
 
     isScsi(): boolean {
         return this.device?.device_protocol === 'SCSI';
+    }
+
+    /**
+     * SMART self-test history is recorded for both ATA and SCSI/SAS devices
+     * (smartctl's numbered scsi_self_test_N log entries are normalized into
+     * the same self-test rows as the ATA self-test log).
+     */
+    hasSelfTestSupport(): boolean {
+        return this.isAta() || this.isScsi();
     }
 
     isNvme(): boolean {

--- a/webapp/frontend/src/app/modules/detail/detail.component.ts
+++ b/webapp/frontend/src/app/modules/detail/detail.component.ts
@@ -475,7 +475,7 @@ export class DetailComponent implements OnInit, AfterViewInit, OnDestroy {
             return null;
         }
 
-        // Check for percentage_used (NVMe) or devstat_7_8 (ATA)
+        // Check for percentage_used (NVMe, and SAS SSD endurance_used) or devstat_7_8 (ATA)
         const percentageUsedAttr = attrs['percentage_used'] || attrs['devstat_7_8'];
         if (percentageUsedAttr) {
             // For percentage_used, use value; for devstat_7_8, use raw_value if available, otherwise value
@@ -1050,6 +1050,12 @@ export class DetailComponent implements OnInit, AfterViewInit, OnDestroy {
             return (nvmeAttr.value * 512 * 1000) / (1024 * 1024 * 1024 * 1024);
         }
 
+        // SCSI/SAS: write_gigabytes_processed is already stored in bytes
+        const scsiAttr = attrs['write_gigabytes_processed'];
+        if (scsiAttr?.value != null) {
+            return scsiAttr.value / TB;
+        }
+
         return null;
     }
 
@@ -1097,6 +1103,12 @@ export class DetailComponent implements OnInit, AfterViewInit, OnDestroy {
         const nvmeAttr = attrs['data_units_read'];
         if (nvmeAttr?.value != null) {
             return (nvmeAttr.value * 512 * 1000) / (1024 * 1024 * 1024 * 1024);
+        }
+
+        // SCSI/SAS: read_gigabytes_processed is already stored in bytes
+        const scsiAttr = attrs['read_gigabytes_processed'];
+        if (scsiAttr?.value != null) {
+            return scsiAttr.value / TB;
         }
 
         return null;


### PR DESCRIPTION
## Summary

Adding additional support for SCSI drives to read gigabytes processed (read/written) from information log sections. Fix a missing scsi_revision handler. Added selftest support for the top level sibling SCSI selftests keyed as scsi_self_test_N where N is the test number.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Changes Made

- Added support for reading gigabytes processed in read and write error information sections
- Added section to workload intensity to process gigabytes processed
- Fixed issue with scsi_revision not handled
- Added scsi selftest support (unmarshal sibling objects keyed as scsi_self_test_N)

## Testing

Used the workflow to build docker images to test web changes, unit tests added for associated changes

- [x] I have tested this locally
- [x] I have added/updated tests that prove my fix/feature works
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary (particularly complex areas)
- [x] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [x] No console.log, debug statements, or commented-out code

## Screenshots (if applicable)

<img width="2438" height="130" alt="shot_1" src="https://github.com/user-attachments/assets/1518366d-27eb-4261-918e-6f5e82e2d834" />
<img width="172" height="176" alt="shot_2" src="https://github.com/user-attachments/assets/7c7a0a31-7627-4b11-abf3-4d13c16ef16e" />
<img width="2624" height="1348" alt="shot_3" src="https://github.com/user-attachments/assets/e6ca096f-759d-4b47-89a7-d354e7eb0100" />



## Additional Notes

2 HP SAS SSD's (Samsung PM1643a OEM's) spurred on this change to get SAS/SCSI support updated within the app. This PR might be opinionated against those, as I have no additional SAS devices to work with (everything else on the expander/hba is SATA). Put together by Opus 4.8 & Sonnet 5 with some in the loop guidance, if it feels too vibe-slop'ed I can close and refine.
